### PR TITLE
fix(daily-recommend): raise slice cap from 12 to 100

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mineradio",
   "productName": "Mineradio",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "沉浸式音乐播放器，融合天气电台、歌词舞台、粒子视觉和 3D 歌单架。",
   "author": "Mineradio",
   "main": "desktop/main.js",

--- a/server.js
+++ b/server.js
@@ -1718,7 +1718,7 @@ async function handleDiscoverHome() {
     dailySongs = (Array.isArray(raw) ? raw : [])
       .map(mapSongRecord)
       .filter(song => song.id && song.name)
-      .slice(0, 12);
+      .slice(0, 100);
   }
 
   return {


### PR DESCRIPTION
## 问题 / Problem

在已登录网易云状态下点击首页「每日推荐」卡片，进入播放队列只能看到 12 首歌，与网易云官方 web / 客户端显示的 30-34 首不一致。

After logging into Netease Cloud Music and clicking the daily-recommendation card on the homepage, the play queue only shows 12 tracks — far fewer than the 30-34 tracks shown on Netase's official web/PC client.

## 根因 / Root Cause

`server.js` 的 `handleDiscoverHome()` 在处理网易云 `/recommend/songs` 接口返回时做了硬截断：

```js
// server.js:1721 (v1.1.1)
dailySongs = (Array.isArray(raw) ? raw : [])
  .map(mapSongRecord)
  .filter(song => song.id && song.name)
  .slice(0, 12);   // ← 截断到这里
```

而网易云 `/api/v3/discovery/recommend/songs` 接口本身**不传 `limit`/`offset` 参数**，固定返回 30-34 首 `dailySongs`（参考 NeteaseCloudMusicApi v4 模块 `module/recommend_songs.js`）。前 12 首之后的 18+ 首今日推荐被直接丢弃，未进入前端 `homeDiscoverState.songs`，因此点击「每日推荐」卡片时 `playQueue = homeDiscoverState.songs.map(cloneSong)` 只能塞入 12 首。

The Netease `/api/v3/discovery/recommend/songs` endpoint does not accept `limit`/`offset` and returns a fixed 30-34 tracks. The hard `.slice(0, 12)` in `handleDiscoverHome()` discards everything beyond the first 12, so they never reach `homeDiscoverState.songs` and never enter the play queue.

## 复现步骤 / Steps to Reproduce

1. 安装 v1.1.1，启动 Mineradio
2. 网易云扫码登录
3. 首页 → 点击「每日推荐」卡片
4. 播放队列长度 = 12；网易云 web 端同期长度 = 30-34

## 修复 / Fix

把 `slice(0, 12)` 改为 `slice(0, 100)`：

```diff
-      .slice(0, 12);
+      .slice(0, 100);
```

100 是预留上限，应对网易云将来可能的返回量增加。实际使用中仍由网易云接口决定，不会到 100。

`package.json` 版本号同步从 1.1.1 升到 1.1.2。

## 验证 / Verification

- 已重新构建 v1.1.2 NSIS 安装包，本机实测：登录后 `/api/discover/home` 返回的 `dailySongs` 长度从 12 提升到与网易云实际返回一致（约 30-34）
- 首页「每日推荐」卡片点击后播放队列长度同步增加
- 未观察到 30-34 首量级的明显性能影响

## 影响范围 / Impact

- `server.js` 单点改动，1 行
- `package.json` 版本号改动，1 行
- 仅影响网易云已登录用户首页聚合数据的 `dailySongs` 字段
- 其他首页入口（私人推荐歌单、热门播客）保持原行为未动