### PR TITLE
fix(playback): 修复切歌栈溢出崩溃 / fix song-switch stack-overflow crash (#17)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -15374,12 +15374,12 @@ function beginListenSession(song, context) {
     maxProgress: 0,
   };
 }
-function updateListenStatsTick(force) {
+function updateListenStatsTick(force, noRestart) {
   if (!audio || !audio.duration || audio.paused) return;
   var song = currentCoverSong();
   if (!song) return;
   var key = queueItemKey(song);
-  if (!listenSession || listenSession.key !== key) beginListenSession(song, activeRadioContext);
+  if (!noRestart && (!listenSession || listenSession.key !== key)) beginListenSession(song, activeRadioContext);
   if (!listenSession) return;
   var now = Date.now();
   var audioTime = isFinite(audio.currentTime) ? audio.currentTime : 0;
@@ -15394,7 +15394,7 @@ function updateListenStatsTick(force) {
 }
 function finalizeListenSession(completed) {
   if (!listenSession) return;
-  updateListenStatsTick(true);
+  updateListenStatsTick(true, true);
   var session = listenSession;
   listenSession = null;
   var effective = completed || session.listenMs >= 45000 || session.maxProgress >= 0.5 || (!audio || !audio.duration ? session.listenMs >= 30000 : false);


### PR DESCRIPTION
## 问题 / Problem

切歌时 CPU 持续飙升、内存暴涨,前端渲染线程最终卡死崩溃,控制台刷出大量 `RangeError: Maximum call stack size exceeded`;崩溃之后听歌统计定时器每约 200ms 又触发一次,CPU 一直降不下来。

Switching songs makes CPU climb and memory balloon until the renderer freezes and crashes, with the console flooded by `RangeError: Maximum call stack size exceeded`. After the crash the ~200ms listen-stats timer keeps re-triggering it, so CPU never settles back down.

## 根因 / Root Cause

`public/index.html` 里 `beginListenSession` / `updateListenStatsTick` / `finalizeListenSession` 三个函数互相调用形成了环,而且没有重入保护。问题出在 `finalizeListenSession` 在把 `listenSession` 置空之前就先调了一次 tick:

```js
function finalizeListenSession(completed) {
  if (!listenSession) return;
  updateListenStatsTick(true);        // 此时 listenSession 还是旧 session
  var session = listenSession;
  listenSession = null;
  ...
}
function updateListenStatsTick(force) {
  ...
  if (!listenSession || listenSession.key !== key) beginListenSession(song, activeRadioContext); // key 不同就重开 session
  ...
}
function beginListenSession(song, context) {
  ...
  if (listenSession && listenSession.key !== snap.key) finalizeListenSession(false); // 旧 session 还在,又去 finalize
  ...
}
```

`nextTrack` / `prevTrack` 会先更新 `currentIdx`,在旧音频暂停之前就调用 `finalizeListenSession`。这时当前歌已经是新歌,而 `listenSession` 仍指向旧歌,于是形成 `finalize → tick → begin → finalize` 无限递归,直到栈溢出。

The three functions call each other in a cycle with no re-entrancy guard. `finalizeListenSession` runs the tick before clearing `listenSession`, and since `nextTrack`/`prevTrack` advance `currentIdx` and call `finalizeListenSession` before the old audio is paused, the current song is already the new one while `listenSession` still points at the old one. The tick then restarts a session through `beginListenSession`, which re-enters `finalizeListenSession`, looping until the stack overflows.

## 复现步骤 / Steps to Reproduce

1. 播放任意一首歌 / Play any song
2. 快速连续点下一首 / 上一首 / Rapidly click next / previous
3. CPU、内存飙升,控制台出现 `RangeError: Maximum call stack size exceeded`,界面崩溃 / CPU and memory spike, the console shows `RangeError: Maximum call stack size exceeded`, and the UI crashes

## 修复 / Fix

给 `updateListenStatsTick` 加一个 `noRestart` 参数,`finalizeListenSession` 调用它时传 `true`。这样结算时只把当前 session 的时长刷新一次,不再顺手重开 session,递归链就断了。另外两个调用点(暂停、周期 tick)仍然只传一个参数,行为不变;统计也照旧记在旧 session 上。

Add a `noRestart` parameter to `updateListenStatsTick`, which `finalizeListenSession` passes as `true`. The final flush then only updates the current session's listen time instead of restarting a session, which breaks the cycle. The other two call sites (pause, periodic tick) still pass a single argument and behave exactly as before, and stats are still recorded against the old session.

```diff
-function updateListenStatsTick(force) {
+function updateListenStatsTick(force, noRestart) {
   ...
-  if (!listenSession || listenSession.key !== key) beginListenSession(song, activeRadioContext);
+  if (!noRestart && (!listenSession || listenSession.key !== key)) beginListenSession(song, activeRadioContext);
   ...
 function finalizeListenSession(completed) {
   if (!listenSession) return;
-  updateListenStatsTick(true);
+  updateListenStatsTick(true, true);
```

## 验证 / Validation

- 写了一个 Node 脚本复刻这三个函数的真实调用流程:旧逻辑稳定复现 `RangeError: Maximum call stack size exceeded`,改完之后不再溢出,时长也正确累计在旧 session 上。
- `public/index.html` 的内联脚本用 `new Function(...)` 解析过,没有语法错误。
- 另外两个调用点只传一个参数(`noRestart` 为 `undefined`),逻辑没变。
- 在 Windows 上实测:播放后快速连续切下一首/上一首多次,界面不再崩溃,控制台没有 `RangeError`,CPU/内存正常,听歌统计也正常累计。

- A Node script reproduces the real call flow of the three functions: the old logic reliably triggers `RangeError: Maximum call stack size exceeded`, and after the change it no longer overflows while listen time is still accrued on the old session.
- The inline scripts in `public/index.html` parse with `new Function(...)` without syntax errors.
- The other two call sites pass a single argument (`noRestart` is `undefined`), so their logic is unchanged.
- Tested on Windows: after playback, rapidly switching next/previous many times no longer crashes the UI, the console stays free of `RangeError`, CPU/memory stay normal, and listen stats accumulate correctly.

Closes #17
