### PR TITLE
fix(playlist): 加载全部歌曲，修复 500 首截断 / load full playlist, fix 500-track cap (#40)

### DIFF
--- a/server.js
+++ b/server.js
@@ -4106,8 +4106,19 @@ const server = http.createServer(async (req, res) => {
       // 新版本 NeteaseCloudMusicApi 通常提供 playlist_track_all；旧版本退回 playlist_detail。
       if (typeof playlist_track_all === 'function') {
         try {
-          const all = await playlist_track_all({ id, limit: 500, offset: 0, cookie: userCookie, timestamp: Date.now() });
-          rawTracks = (all.body && (all.body.songs || all.body.tracks)) || [];
+          // playlist_track_all 内部按 trackIds.slice(offset, offset+limit) 取歌，
+          // 单次 limit 会截断大歌单（#40：1000+ 首只加载 500 首），这里按 offset 翻页取全。
+          const pageSize = 1000;
+          let offset = 0;
+          for (;;) {
+            const page = await playlist_track_all({ id, limit: pageSize, offset, cookie: userCookie, timestamp: Date.now() });
+            const songs = (page.body && (page.body.songs || page.body.tracks)) || [];
+            if (!songs.length) break;
+            rawTracks = rawTracks.concat(songs);
+            if (songs.length < pageSize) break;
+            offset += pageSize;
+            if (offset >= 50000) break; // 安全上限，避免异常情况下无限翻页
+          }
         } catch (err) {
           console.warn('[PlaylistTracks] playlist_track_all failed, fallback to detail:', err.message);
         }


### PR DESCRIPTION
## 问题 / Problem

用网易云账号登录后,右侧歌单显示的曲目数是对的(比如 1000+ 首),但点开实际只加载到 500 首。

After logging in with a Netease Cloud Music account, the right-side playlist shows the correct count (e.g. 1000+), but opening it only loads up to 500 tracks.

## 根因 / Root Cause

`server.js` 的 `/api/playlist/tracks` 路由把 `playlist_track_all` 的 `limit` 写死成了 500:

```js
// server.js (v1.1.1)
const all = await playlist_track_all({ id, limit: 500, offset: 0, cookie: userCookie, timestamp: Date.now() });
rawTracks = (all.body && (all.body.songs || all.body.tracks)) || [];
```

而 `NeteaseCloudMusicApi` 的 `playlist_track_all` 是先拿到歌单完整的 `trackIds`,再按 `trackIds.slice(offset, offset + limit)` 切片去查详情:

```js
// node_modules/NeteaseCloudMusicApi/module/playlist_track_all.js
let limit = parseInt(query.limit) || 1000
let offset = parseInt(query.offset) || 0
...
trackIds.slice(offset, offset + limit)   // 单次 limit 决定能取多少首
```

所以 `limit:500` 会把任何超过 500 首的歌单截断到 500 首。

The `/api/playlist/tracks` route hard-codes `limit: 500`. Inside `NeteaseCloudMusicApi`, `playlist_track_all` first fetches the full `trackIds` list and then does `trackIds.slice(offset, offset + limit)` before hydrating details, so a single `limit:500` truncates any playlist longer than 500 tracks.

## 复现步骤 / Steps to Reproduce

1. 网易云账号登录 / Log in with a Netease Cloud Music account
2. 打开一个超过 500 首的歌单(如 1000+ 首)/ Open a playlist with more than 500 tracks (e.g. 1000+)
3. 实际加载 = 500 首;歌单标称数量 = 1000+ / Only 500 load, while the playlist count shows 1000+

## 修复 / Fix

改成按 `offset` 翻页循环把所有曲目取全。页大小用 1000(`NeteaseCloudMusicApi` 的默认值,也是它内部 `/song/detail` 文档里写的安全上限),再加一个 `offset >= 50000` 的兜底,防止异常情况下无限翻页;原来的 `playlist_detail` 回退保留。

Replace the single capped call with an offset-paginated loop that fetches every page. Page size is 1000 (the library default, and the documented safe ceiling for its internal `/song/detail` batch), plus an `offset >= 50000` guard against runaway looping; the existing `playlist_detail` fallback is kept.

```diff
-          const all = await playlist_track_all({ id, limit: 500, offset: 0, cookie: userCookie, timestamp: Date.now() });
-          rawTracks = (all.body && (all.body.songs || all.body.tracks)) || [];
+          const pageSize = 1000;
+          let offset = 0;
+          for (;;) {
+            const page = await playlist_track_all({ id, limit: pageSize, offset, cookie: userCookie, timestamp: Date.now() });
+            const songs = (page.body && (page.body.songs || page.body.tracks)) || [];
+            if (!songs.length) break;
+            rawTracks = rawTracks.concat(songs);
+            if (songs.length < pageSize) break;
+            offset += pageSize;
+            if (offset >= 50000) break; // 安全上限 / safety cap
+          }
```

## 验证 / Validation

- 用真实安装的 `NeteaseCloudMusicApi` 模块配 mock 的 HTTP 层做了集成测试:2300 首的歌单,旧逻辑返回 500、新逻辑返回全部 2300(去重后仍是 2300);整除、非整除、0 首等边界都覆盖了,无重复、必定终止。
- `node --check server.js` 通过。
- 在 Windows 上用真实网易云登录态实测:`HIPHOP` 歌单(标称 948 首)修复前只加载到 500 首,修复后加载到 947 首(`947/947`)。少的那 1 首是网易云已下架的无效曲目,被 `rawTracks.map(mapSongRecord).filter(t => t.id)` 正常过滤掉,符合预期。截图见下。

- Integration test against the real installed `NeteaseCloudMusicApi` module with a mocked HTTP layer: for a 2300-track playlist the old logic returns 500 and the new one returns all 2300 (2300 unique); boundary cases (exact multiples, non-multiples, 0 tracks) pass with no duplicates and guaranteed termination.
- `node --check server.js` passes.
- Tested on Windows with a real Netease login: the `HIPHOP` playlist (948 listed) loaded only 500 before the fix and 947 after (`947/947`). The one missing track is a delisted/invalid song that `rawTracks.map(mapSongRecord).filter(t => t.id)` correctly drops, which is expected. Screenshots below.

## 实测截图 / Screenshots

修复前 / Before — 加载卡在 500 上限:

![playlist before fix capped at 500](https://raw.githubusercontent.com/averatec0773/Mineradio/assets/pr-screenshots/screenshots/playlist-before-500.png)

修复后 / After — 加载到全部曲目(`947/947`):

![playlist after fix loads all tracks](https://raw.githubusercontent.com/averatec0773/Mineradio/assets/pr-screenshots/screenshots/playlist-after-947.png)

Closes #40
