### PR TITLE
feat(local-import): 解析本地音乐内嵌封面与歌词 / parse embedded cover & lyrics for local files (#35, #18)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -19986,6 +19986,91 @@ setInterval(function(){
 //  文件拖放
 // ============================================================
 document.getElementById('file-input').addEventListener('change', function(e){ handleFiles(e.target.files); e.target.value = ''; });
+// 本地音乐内嵌标签解析（ID3v2.2/2.3/2.4）：封面 APIC、歌词 USLT、标题/歌手（#18 #35）。
+// 纯函数 + 防御式：任何异常都返回已解析到的部分，绝不抛出，避免影响播放主流程。
+var localTagReader = (function(){
+  function synchsafe(b, o){ return ((b[o]&0x7f)<<21)|((b[o+1]&0x7f)<<14)|((b[o+2]&0x7f)<<7)|(b[o+3]&0x7f); }
+  function readUint32(b, o){ return ((b[o]<<24)|(b[o+1]<<16)|(b[o+2]<<8)|b[o+3])>>>0; }
+  function latin1(b, o, len){ var s=''; for (var i=0;i<len;i++) s+=String.fromCharCode(b[o+i]); return s; }
+  function decodeText(bytes, enc){
+    try {
+      if (enc===1) return new TextDecoder('utf-16').decode(bytes);
+      if (enc===2) return new TextDecoder('utf-16be').decode(bytes);
+      if (enc===3) return new TextDecoder('utf-8').decode(bytes);
+      return new TextDecoder('latin1').decode(bytes);
+    } catch (e) { var s=''; for (var i=0;i<bytes.length;i++) s+=String.fromCharCode(bytes[i]); return s; }
+  }
+  function readNullTerminated(frame, start, enc){
+    var i=start;
+    if (enc===1 || enc===2) { for (; i+1<frame.length; i+=2) { if (frame[i]===0 && frame[i+1]===0) break; } return { text:decodeText(frame.subarray(start,i),enc), next:i+2 }; }
+    for (; i<frame.length; i++) { if (frame[i]===0) break; }
+    return { text:decodeText(frame.subarray(start,i),enc), next:i+1 };
+  }
+  function stripNulls(s){ return String(s||'').replace(/ +$/g,''); }
+  function readTextFrame(frame){ if (!frame.length) return ''; return stripNulls(decodeText(frame.subarray(1), frame[0])).trim(); }
+  function readLyricsFrame(frame){ if (frame.length<4) return ''; var enc=frame[0]; var desc=readNullTerminated(frame,4,enc); return stripNulls(decodeText(frame.subarray(desc.next),enc)); }
+  function imageFormatToMime(fmt){ fmt=(fmt||'').toUpperCase(); if (fmt.indexOf('PNG')>=0) return 'image/png'; return 'image/jpeg'; }
+  function readPictureFrame(frame, isV22){
+    if (frame.length<4) return null;
+    var enc=frame[0], mime, pos;
+    if (isV22) { mime=imageFormatToMime(latin1(frame,1,3)); pos=4; }
+    else { var m=readNullTerminated(frame,1,0); mime=m.text||'image/jpeg'; pos=m.next; }
+    pos+=1; // picture type
+    var desc=readNullTerminated(frame,pos,enc);
+    var data=frame.subarray(desc.next);
+    if (!data.length) return null;
+    return { mime:mime, data:data.slice ? data.slice() : new Uint8Array(data) };
+  }
+  function parseId3v2(buffer){
+    var out={ title:'', artist:'', lyrics:'', picture:null };
+    try {
+      var bytes=buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
+      if (bytes.length<10 || bytes[0]!==0x49 || bytes[1]!==0x44 || bytes[2]!==0x33) return out;
+      var major=bytes[3]; if (major<2 || major>4) return out;
+      var flags=bytes[5], tagSize=synchsafe(bytes,6), pos=10, end=Math.min(bytes.length, 10+tagSize);
+      if (flags&0x40) { if (major===4) pos+=synchsafe(bytes,pos); else pos+=4+readUint32(bytes,pos); }
+      var idLen=major===2?3:4, sizeLen=major===2?3:4;
+      while (pos+idLen+sizeLen<=end) {
+        var id=latin1(bytes,pos,idLen);
+        if (!/^[A-Z0-9]+$/.test(id)) break;
+        var size;
+        if (major===2) size=(bytes[pos+3]<<16)|(bytes[pos+4]<<8)|bytes[pos+5];
+        else if (major===4) size=synchsafe(bytes,pos+4);
+        else size=readUint32(bytes,pos+4);
+        var dataStart=pos+idLen+sizeLen+(major===2?0:2), dataEnd=dataStart+size;
+        if (size<=0 || dataEnd>end) break;
+        var frame=bytes.subarray(dataStart,dataEnd);
+        if (id==='TIT2'||id==='TT2') { if (!out.title) out.title=readTextFrame(frame); }
+        else if (id==='TPE1'||id==='TP1') { if (!out.artist) out.artist=readTextFrame(frame); }
+        else if (id==='USLT'||id==='ULT') { if (!out.lyrics) out.lyrics=readLyricsFrame(frame); }
+        else if (id==='APIC'||id==='PIC') { if (!out.picture) out.picture=readPictureFrame(frame, id==='PIC'); }
+        pos=dataEnd;
+      }
+    } catch (e) {}
+    return out;
+  }
+  // 只读取标签实际长度（ID3v2 标签固定在文件头部），避免把整首歌读进内存。
+  function readLocalAudioTags(file, cb){
+    try {
+      if (!file || !file.slice) { cb(null); return; }
+      var head=new FileReader();
+      head.onerror=function(){ cb(null); };
+      head.onload=function(e){
+        try {
+          var h=new Uint8Array(e.target.result);
+          if (h.length<10 || h[0]!==0x49 || h[1]!==0x44 || h[2]!==0x33) { cb(null); return; }
+          var size=((h[6]&0x7f)<<21)|((h[7]&0x7f)<<14)|((h[8]&0x7f)<<7)|(h[9]&0x7f);
+          var full=new FileReader();
+          full.onerror=function(){ cb(null); };
+          full.onload=function(ev){ try { cb(parseId3v2(ev.target.result)); } catch (err) { cb(null); } };
+          full.readAsArrayBuffer(file.slice(0, 10+size));
+        } catch (err) { cb(null); }
+      };
+      head.readAsArrayBuffer(file.slice(0, 10));
+    } catch (e) { cb(null); }
+  }
+  return { read: readLocalAudioTags };
+})();
 function handleFiles(files) {
   var audioFile = null, imgFile = null;
   for (var i = 0; i < files.length; i++) {
@@ -20060,6 +20145,38 @@ function handleFiles(files) {
     var localCoverOpts = { trackToken: token, deferHeavy: firstVisualPlay, delay: firstVisualPlay ? 60 : 0, timeout: firstVisualPlay ? 300 : 180 };
     if (localCover) applyCoverDataUrl(localCover, localCoverOpts);
     else if (!imgFile) loadCoverFromUrl('', localCoverOpts);
+    // 读取内嵌标签，异步补全标题/歌手/封面/歌词（#18 #35）。token 与 localUrl 双重校验，避免快速切歌后覆盖新歌。
+    localTagReader.read(audioFile, function(tags){
+      if (!tags || token !== trackSwitchToken || !currentLocalSong || currentLocalSong.localUrl !== url) return;
+      if (tags.title) {
+        currentLocalSong.name = tags.title;
+        document.getElementById('thumb-title').textContent = tags.title;
+      }
+      if (tags.artist) {
+        currentLocalSong.artist = tags.artist;
+        document.getElementById('thumb-artist').textContent = tags.artist;
+      }
+      if (tags.title || tags.artist) updateControlTrackInfo({ name: currentLocalSong.name, artist: currentLocalSong.artist });
+      if (tags.picture && tags.picture.data && !imgFile && !getCustomCoverForSong(currentLocalSong)) {
+        try {
+          var picReader = new FileReader();
+          picReader.onload = function(ev){
+            if (token !== trackSwitchToken || !currentLocalSong || currentLocalSong.localUrl !== url) return;
+            currentLocalSong.cover = ev.target.result;
+            applyCoverDataUrl(ev.target.result, { trackToken: token });
+          };
+          picReader.readAsDataURL(new Blob([tags.picture.data], { type: tags.picture.mime || 'image/jpeg' }));
+        } catch (err) {}
+      }
+      if (tags.lyrics) {
+        var lrcLines = parseLyricText(tags.lyrics);
+        if (lrcLines.length) {
+          var lyr = withLyricFallback(lrcLines);
+          setOriginalLyricsState(lyr, false, (lyr.length && lyr[0].fallback) ? 'fallback' : 'lrc-line');
+          applyPreferredLyricsForCurrent(true);
+        }
+      }
+    });
   }
   if (imgFile) {
     var uploadCoverOpts = audioFile


### PR DESCRIPTION
## 背景 / Background

拖入本地音频后只能播放,内嵌的封面和歌词都识别不出来,也希望能用上文件里内嵌的歌词。

Dropping in a local audio file only plays it — the embedded cover art and lyrics aren't picked up, and I also want the lyrics embedded in the file to be used.

## 根因 / Root Cause

`handleFiles`(`public/index.html`)创建本地歌曲时,标题用的是文件名,歌手写死成"本地文件",封面只认单独拖进来的图片,歌词给的是空 fallback,自始至终没读过音频文件自己的标签。

When `handleFiles` (`public/index.html`) builds a local song, the title comes from the filename, the artist is hard-coded to "本地文件", the cover only uses a separately dropped image, and lyrics are an empty fallback — it never reads the file's own tags.

## 实现 / What it does

新增了一个 ID3v2 标签解析器(`localTagReader`,支持 v2.2 / v2.3 / v2.4),在拖入本地音频时异步读取并补全:

- 封面 `APIC`:只在没有单独拖图片、也没有自定义封面时才用;
- 歌词 `USLT`:只在能解析出带时间轴的 LRC 时才用,走的是和在线歌曲一样的 `parseLyricText → setOriginalLyricsState` 流程;
- 标题 / 歌手 `TIT2` / `TPE1`:覆盖掉文件名和默认的"本地文件"。

读取时只取标签那一段字节(先读头部 10 字节拿到标签长度,再精确读 `10+size`),不会把整首歌读进内存;整个过程是异步的,不挡播放;用 `trackSwitchToken` 和 `localUrl` 双重校验,快速切歌时不会拿旧歌的标签盖到新歌上;解析包在 try/catch 里,出错就返回已解析到的部分,不会抛异常。

Adds an ID3v2 tag parser (`localTagReader`, v2.2 / v2.3 / v2.4) that, on drop, asynchronously reads and fills in:

- cover `APIC`: only when no image was dropped separately and no custom cover exists;
- lyrics `USLT`: only when it parses into timed LRC, through the same `parseLyricText → setOriginalLyricsState` path as online songs;
- title / artist `TIT2` / `TPE1`: overriding the filename and the default "本地文件".

It reads only the tag bytes (first 10 bytes for the tag length, then exactly `10+size`), so it never loads the whole track into memory; the work is async and doesn't block playback; `trackSwitchToken` and `localUrl` are both checked so a fast switch can't apply an old file's tags to the new song; and parsing is wrapped in try/catch, returning whatever it parsed instead of throwing.

## 说明 / Notes

- 目前只解析 MP3 / ID3v2。FLAC、M4A 等还没做,这类文件会直接跳过(用文件名当标题,没有内嵌封面/歌词),不影响现有行为。
- 歌词只在 `USLT` 带时间轴(LRC)时才显示;有些 MP3 的 `USLT` 是没有时间轴的纯文本,这种维持原来的 fallback。封面的命中率会高一些。
- 暂时没处理 ID3 的 unsynchronisation 标志(比较少见);带这个标志的文件会读不出标签,但不会报错。

- Only MP3 / ID3v2 is parsed for now. FLAC, M4A, etc. aren't handled yet and are simply skipped (filename title, no embedded cover/lyrics), without affecting existing behavior.
- Lyrics only show when `USLT` carries timestamps (LRC); some MP3s store plain-text `USLT` with no timing, which keeps the existing fallback. Cover art has a higher hit rate.
- The ID3 unsynchronisation flag isn't handled yet (uncommon); files using it won't yield tags, but won't error either.

## 验证 / Validation

- 给解析器写了单元测试,覆盖 v2.3 / v2.4、四种文本编码(latin1 / UTF-16+BOM / UTF-16BE / UTF-8,含中文)、带和不带时间轴的 `USLT`、以及 PNG/JPEG 的 `APIC`;截断、垃圾数据、空输入都不会抛异常。
- 读取路径单独验证过:只读标签字节、不读整首歌;非 MP3 文件(没有 `ID3` 头)返回 `null`,直接跳过。
- `public/index.html` 内联脚本用 `new Function(...)` 解析,没有语法错误。
- 在 Windows 上拖入实测:内嵌标题、歌手、封面、带时间轴歌词都能正确渲染(测试文件的歌词 `Mineradio 内嵌歌词测试` 正常显示在歌词台上);无标签文件正常回退,不报错。截图见下。

- Unit tests cover v2.3 / v2.4, all four text encodings (latin1 / UTF-16+BOM / UTF-16BE / UTF-8, incl. CJK), `USLT` with and without timestamps, and PNG/JPEG `APIC`; truncated, garbage, and empty inputs never throw.
- The read path is verified separately: only the tag bytes are read, not the whole track; non-MP3 files (no `ID3` header) return `null` and are skipped.
- The inline scripts in `public/index.html` parse with `new Function(...)` without syntax errors.
- Tested by dropping tagged MP3s into the app on Windows: embedded title, artist, cover, and timed lyrics all render correctly (the test file's lyric line `Mineradio 内嵌歌词测试` shows up on the lyric stage); untagged files fall back correctly without errors. Screenshot below.

## 实测截图 / Screenshot

拖入带内嵌标签的本地 MP3 后,标题、歌手、封面、歌词都会自动补全 / After dropping a locally tagged MP3, the title, artist, cover, and lyrics are filled in automatically:

![local file embedded title artist cover lyrics rendered](https://raw.githubusercontent.com/averatec0773/Mineradio/assets/pr-screenshots/screenshots/local-embedded-tags.png)

Closes #35, closes #18
