### PR TITLE
feat(macOS): 添加窗口控件、快捷键适配、触控板灵敏度及主页空白点击等 Mac 体验优化

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -48,8 +48,8 @@ const CHROMIUM_PERFORMANCE_SWITCHES = [
   ['disable-renderer-backgrounding'],
   ['disable-backgrounding-occluded-windows'],
   ['force_high_performance_gpu'],
-  ['use-angle', 'd3d11'],
-];
+  process.platform === 'win32' ? ['use-angle', 'd3d11'] : null,
+].filter(Boolean);
 for (const [name, value] of CHROMIUM_PERFORMANCE_SWITCHES) {
   if (value == null) app.commandLine.appendSwitch(name);
   else app.commandLine.appendSwitch(name, value);
@@ -1351,9 +1351,15 @@ async function createWindow() {
     minHeight: 540,
     show: false,
     frame: false,
+    titleBarStyle: process.platform === 'darwin' ? 'hidden' : undefined,
+    trafficLightPosition: process.platform === 'darwin' ? { x: 18, y: 14 } : undefined,
     fullscreen: false,
-    transparent: true,
-    backgroundColor: '#00000000',
+    transparent: process.platform !== 'darwin',
+    backgroundColor: process.platform === 'darwin' ? '#010304' : '#00000000',
+    resizable: true,
+    maximizable: true,
+    minimizable: true,
+    fullscreenable: true,
     hasShadow: true,
     autoHideMenuBar: true,
     title: APP_NAME,
@@ -1384,6 +1390,9 @@ async function createWindow() {
   });
 
   mainWindow.once('ready-to-show', () => {
+    if (process.platform === 'darwin') {
+      mainWindow.setFullScreenable(true);
+    }
     mainWindow.show();
     sendWindowState(mainWindow);
   });

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -49,4 +49,7 @@ contextBridge.exposeInMainWorld('desktopWindow', {
 window.addEventListener('DOMContentLoaded', () => {
   document.documentElement.classList.add('desktop-shell-root');
   document.body.classList.add('desktop-shell');
+  if (process.platform === 'darwin') {
+    document.body.classList.add('mac-os');
+  }
 });

--- a/public/index.html
+++ b/public/index.html
@@ -45,6 +45,7 @@ body.desktop-shell #desktop-titlebar::after{content:none}
 .desktop-app-title{display:none}
 .desktop-window-controls{display:flex;align-items:center;gap:6px;padding:0;border-radius:0;background:transparent;box-shadow:none;-webkit-app-region:no-drag;pointer-events:auto}
 .desktop-window-btn{width:38px;height:30px;border:0;border-radius:10px;background:rgba(4,8,10,.42);color:rgba(224,250,255,.72);display:flex;align-items:center;justify-content:center;cursor:pointer;transition:background .18s,color .18s,transform .18s}
+body.mac-os .desktop-window-btn{display:none!important}
 .desktop-window-btn svg{width:14px;height:14px;stroke:currentColor;stroke-width:2;fill:none}
 .desktop-window-btn:hover{background:rgba(244,210,138,.14);color:#fff1bd;transform:translateY(-1px)}
 .desktop-window-btn.close:hover{background:rgba(255,86,100,.86);color:#fff}
@@ -101,6 +102,8 @@ body.custom-background-override #album-bg{opacity:0!important}
 body.render-deep-sleep #canvas-container,body.render-deep-sleep #idle-guide-canvas,body.render-deep-sleep #splash-canvas,body.render-deep-sleep #hand-canvas{opacity:0!important;visibility:hidden!important}
 body.splash-active:not(.splash-revealing) #canvas-container{opacity:.16;transform:scale(1)}
 body.splash-active.splash-revealing #canvas-container{opacity:1;transform:scale(1)}
+body.empty-home-active #canvas-container{pointer-events:none!important;cursor:default!important}
+body.empty-home-active #canvas-container canvas{pointer-events:none!important;cursor:default!important}
 #idle-guide-canvas{position:fixed;inset:0;z-index:2;width:100%;height:100%;pointer-events:none;opacity:0;transition:opacity .7s cubic-bezier(.22,1,.36,1)}
 body.idle-guide-on #idle-guide-canvas{opacity:1!important}
 body.home-wallpaper-preview #idle-guide-canvas{opacity:0!important;visibility:hidden!important}
@@ -5514,6 +5517,7 @@ var UI_HIT_SELECTOR = '#search-area,#top-right,#fullscreen-diy-zone,#fx-panel,#f
 
 function isPointerOverUi(e) {
   if (!e) return false;
+  if (document.body.classList.contains('empty-home-active')) return true;
   var el = document.elementFromPoint(e.clientX, e.clientY);
   return !!(el && el.closest && el.closest(UI_HIT_SELECTOR));
 }
@@ -14964,6 +14968,10 @@ renderer.domElement.addEventListener('contextmenu', function(e){
 //   side 模式: 常驻不再用半屏预览区接管滚轮
 //   stage 模式: 鼠标 y > 60% 屏幕高
 //   shift + wheel: 强制滚卡片
+var shelfWheelAccumulator = 0;
+var shelfWheelTimer = null;
+var clWheelAccumulator = 0;
+var clWheelTimer = null;
 var wheelOverShelf = false;
 renderer.domElement.addEventListener('wheel', function(e){
   if (isPointerOverUi(e)) return;
@@ -14979,7 +14987,13 @@ renderer.domElement.addEventListener('wheel', function(e){
       var panelScreenHit = !rowHit && !panelHit && cl.screenContainsPanel ? cl.screenContainsPanel(e.clientX, e.clientY) : false;
       if (!rowHit && !panelHit && !panelScreenHit) return;
       e.preventDefault(); e.stopImmediatePropagation();
-      cl.scrollBy(e.deltaY > 0 ? 1 : -1);
+      if (clWheelTimer) clearTimeout(clWheelTimer);
+      clWheelTimer = setTimeout(function() { clWheelAccumulator = 0; }, 150);
+      clWheelAccumulator += e.deltaY;
+      if (Math.abs(clWheelAccumulator) >= 60) {
+        cl.scrollBy(clWheelAccumulator > 0 ? 1 : -1);
+        clWheelAccumulator = 0;
+      }
       return;
     }
   }
@@ -14998,7 +15012,13 @@ renderer.domElement.addEventListener('wheel', function(e){
   if (inShelfArea) {
     e.preventDefault();
     e.stopImmediatePropagation();
-    shelfManager.scrollBy(e.deltaY > 0 ? 1 : -1);
+    if (shelfWheelTimer) clearTimeout(shelfWheelTimer);
+    shelfWheelTimer = setTimeout(function() { shelfWheelAccumulator = 0; }, 150);
+    shelfWheelAccumulator += e.deltaY;
+    if (Math.abs(shelfWheelAccumulator) >= 60) {
+      shelfManager.scrollBy(shelfWheelAccumulator > 0 ? 1 : -1);
+      shelfWheelAccumulator = 0;
+    }
   }
 }, { passive: false, capture: true });
 
@@ -16229,7 +16249,7 @@ function isHomeBlankDismissClick(e) {
   var home = document.getElementById('empty-home');
   if (!home) return false;
   var homeRect = home.getBoundingClientRect();
-  if (!isPointInsideRectWithPad(x, y, homeRect, 0)) return false;
+  if (!isPointInsideRectWithPad(x, y, homeRect, 0)) return true;
   if (isPointNearHomeContent(x, y)) return false;
   return true;
 }
@@ -21848,10 +21868,11 @@ function normalizeHotkeyEvent(e) {
   return mods.concat([code]).join('+');
 }
 function hotkeyDisplayPart(part) {
+  var isMac = document.body.classList.contains('mac-os');
   if (part === 'Ctrl') return 'Ctrl';
-  if (part === 'Alt') return 'Alt';
+  if (part === 'Alt') return isMac ? 'Opt' : 'Alt';
   if (part === 'Shift') return 'Shift';
-  if (part === 'Meta') return 'Win';
+  if (part === 'Meta') return isMac ? 'Cmd' : 'Win';
   if (part === 'Space') return 'Space';
   if (part === 'ArrowLeft') return 'Left';
   if (part === 'ArrowRight') return 'Right';
@@ -21870,11 +21891,12 @@ function formatHotkey(hotkey) {
 function hotkeyToAccelerator(hotkey) {
   var parts = String(hotkey || '').split('+').filter(Boolean);
   if (!parts.length) return '';
+  var isMac = document.body.classList.contains('mac-os');
   return parts.map(function(part){
     if (part === 'Ctrl') return 'Control';
     if (part === 'Alt') return 'Alt';
     if (part === 'Shift') return 'Shift';
-    if (part === 'Meta') return 'Super';
+    if (part === 'Meta') return isMac ? 'Cmd' : 'Super';
     if (part === 'Space') return 'Space';
     if (part === 'ArrowLeft') return 'Left';
     if (part === 'ArrowRight') return 'Right';


### PR DESCRIPTION
这个 Pull Request 为 Mineradio 引入了多项 macOS 体验优化与交互细节改进，同时也完美保证了 Windows 端的向前兼容性：

1. **macOS 原生窗口控制键（红绿灯）适配**：
   - 在 macOS 上启用原生红绿灯控制键，支持自定义定位 `titleBarStyle: 'hidden'`。
   - 修复了 Electron 中「设置窗口透明会导致 macOS 绿灯全屏功能被系统锁定禁用」的限制：在 macOS 上关闭窗口透明，改用深黑色（`#010304`）作为窗口底色，成功点亮了原生的绿灯全屏和空间切换功能。
   - 自动隐藏 macOS 上多余的 Windows 风格控制键，防止出现双重标题栏控制键。

2. **触控板滚动灵敏度降敏**：
   - 为 3D 歌单架旋转切卡和歌曲详情列表滚动引入了「滚动量累加器」，只有当滚动量累计达到 `60px` 阈值时才触发一次翻页，重置时间为 `150ms`。
   - 解决了 Mac 触控板滑动时切歌单和列表过于灵敏、容易滑飞的问题，同时普通鼠标滚轮一格仍可正常切页。

3. **macOS 热键适配**：
   - 识别并重置了热键界面上的键位显示，在 macOS 上会将 `Meta` 显示为 **`Cmd`**，`Alt` 显示为 **`Opt`**。
   - 优化了底层向 Electron 注册全局热键的规则，Mac 端包含 Command 的组合键会自动转为 `Cmd` 注册（Windows 保持 `Super` 键注册），确保全局热键在 Mac 上能够被正确注册与触发。

4. **主页面空白区域点击回退与 3D 交互隔离**：
   - 当主页面激活时，禁用背景 WebGL 画布的鼠标穿透事件，防止光标出现抓取手势（`grab`）并屏蔽了 3D 对象的 hover 高亮效果。
   - 允许点击主面板外部的背景空白处（或内部卡片间隙）直接触发 `dismissHomePage()`，快速收起主页面并平滑切回正在播放的 3D 粒子和镜头页面。

所有修改均已在 macOS 和 Windows 端测试，兼容性完好！