### PR TITLE
feat: 支持 macOS 构建与窗口适配

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,19 @@ npm run build:win
 
 桌面版入口由 Electron 主进程加载本地服务。`npm run build:win` 会生成 Windows NSIS 安装包，产物位于 `dist/`。
 
+### macOS 测试构建
+
+当前 fork 已加入 macOS 本地测试构建配置。无 Apple Developer 证书时可以使用：
+
+```bash
+CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:mac:dir
+CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:mac
+```
+
+macOS 公开分发前仍需要签名与公证。更多说明见 [docs/MAC_BUILD.md](./docs/MAC_BUILD.md)。
+
+如果 Electron 或 DMG 工具包下载较慢，可以按文档里的镜像源命令构建。
+
 ## 更新机制
 
 Mineradio 会请求 GitHub Releases latest 检测新版本。远端版本高于本地版本时，应用内更新入口会展示 Release 内容、下载安装包到本机用户数据目录，并通过系统打开安装包。

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -32,6 +32,8 @@ const MIN_WINDOWED_HEIGHT = 540;
 const APP_NAME = 'Mineradio';
 const APP_USER_MODEL_ID = 'com.mineradio.desktop';
 const APP_ICON_ICO = path.join(__dirname, '..', 'build', 'icon.ico');
+const IS_WINDOWS = process.platform === 'win32';
+const IS_MAC = process.platform === 'darwin';
 const NETEASE_LOGIN_PARTITION = 'persist:mineradio-netease-login';
 const NETEASE_LOGIN_URL = 'https://music.163.com/#/login';
 const QQ_LOGIN_PARTITION = 'persist:mineradio-qqmusic-login';
@@ -48,8 +50,8 @@ const CHROMIUM_PERFORMANCE_SWITCHES = [
   ['disable-renderer-backgrounding'],
   ['disable-backgrounding-occluded-windows'],
   ['force_high_performance_gpu'],
-  ['use-angle', 'd3d11'],
 ];
+if (IS_WINDOWS) CHROMIUM_PERFORMANCE_SWITCHES.push(['use-angle', 'd3d11']);
 for (const [name, value] of CHROMIUM_PERFORMANCE_SWITCHES) {
   if (value == null) app.commandLine.appendSwitch(name);
   else app.commandLine.appendSwitch(name, value);
@@ -273,9 +275,24 @@ function getUpdateDownloadDir() {
 }
 
 function shouldEnsureDesktopShortcut() {
-  if (process.platform !== 'win32') return false;
+  if (!IS_WINDOWS) return false;
   if (process.env.MINERADIO_NO_DESKTOP_SHORTCUT === '1') return false;
   return app.isPackaged || process.env.MINERADIO_CREATE_DESKTOP_SHORTCUT === '1';
+}
+
+function platformInfo() {
+  return {
+    platform: process.platform,
+    arch: process.arch,
+    isWindows: IS_WINDOWS,
+    isMac: IS_MAC,
+    capabilities: {
+      desktopShortcut: IS_WINDOWS,
+      desktopLyrics: true,
+      desktopLyricsMiddleClickToggle: IS_WINDOWS,
+      wallpaperMode: IS_WINDOWS,
+    },
+  };
 }
 
 function ensureDesktopShortcut() {
@@ -811,7 +828,7 @@ function handleDesktopLyricsGlobalMiddleClick() {
 }
 
 function startDesktopLyricsMousePoller() {
-  if (process.platform !== 'win32' || desktopLyricsMousePoller) return;
+  if (!IS_WINDOWS || desktopLyricsMousePoller) return;
   const script = `
 $ErrorActionPreference = "SilentlyContinue"
 Add-Type @"
@@ -983,7 +1000,7 @@ function nativeWindowHandleDecimal(win) {
 }
 
 function attachWallpaperToWorkerW(win) {
-  if (process.platform !== 'win32' || !win || win.isDestroyed()) return;
+  if (!IS_WINDOWS || !win || win.isDestroyed()) return;
   const hwnd = nativeWindowHandleDecimal(win);
   const script = `
 $ErrorActionPreference = "Stop"
@@ -1201,6 +1218,8 @@ ipcMain.handle('mineradio-restart-app', async () => {
   }
 });
 
+ipcMain.handle('mineradio-platform-info', async () => platformInfo());
+
 ipcMain.handle('mineradio-desktop-lyrics-set-enabled', async (_event, enabled, payload) => {
   try {
     if (enabled) {
@@ -1291,6 +1310,10 @@ ipcMain.handle('mineradio-desktop-lyrics-move-by', async (_event, dx, dy) => {
 
 ipcMain.handle('mineradio-wallpaper-set-enabled', async (_event, enabled, payload) => {
   try {
+    if (enabled && !IS_WINDOWS) {
+      closeWallpaperWindow();
+      return { ok: false, unsupported: true, platform: process.platform, error: 'WALLPAPER_UNSUPPORTED_PLATFORM' };
+    }
     if (enabled) createWallpaperWindow(payload || {});
     else closeWallpaperWindow();
     return { ok: true };
@@ -1301,6 +1324,11 @@ ipcMain.handle('mineradio-wallpaper-set-enabled', async (_event, enabled, payloa
 
 ipcMain.handle('mineradio-wallpaper-update', async (_event, payload) => {
   try {
+    if ((payload && payload.enabled) && !IS_WINDOWS) {
+      closeWallpaperWindow();
+      wallpaperState = { ...wallpaperState, ...(payload || {}), enabled: false };
+      return { ok: false, unsupported: true, platform: process.platform, error: 'WALLPAPER_UNSUPPORTED_PLATFORM' };
+    }
     wallpaperState = { ...wallpaperState, ...(payload || {}) };
     if (wallpaperState.enabled) {
       createWallpaperWindow(wallpaperState);
@@ -1350,7 +1378,11 @@ async function createWindow() {
     minWidth: 960,
     minHeight: 540,
     show: false,
-    frame: false,
+    frame: IS_MAC,
+    ...(IS_MAC ? {
+      titleBarStyle: 'hiddenInset',
+      trafficLightPosition: { x: 20, y: 17 },
+    } : {}),
     fullscreen: false,
     transparent: true,
     backgroundColor: '#00000000',

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -14,6 +14,7 @@ contextBridge.exposeInMainWorld('desktopWindow', {
   clearQQMusicLogin: () => ipcRenderer.invoke('qq-music-clear-login'),
   openUpdateInstaller: (filePath) => ipcRenderer.invoke('mineradio-open-update-installer', filePath),
   restartApp: () => ipcRenderer.invoke('mineradio-restart-app'),
+  getPlatformInfo: () => ipcRenderer.invoke('mineradio-platform-info'),
   configureGlobalHotkeys: (bindings) => ipcRenderer.invoke('mineradio-hotkeys-configure-global', bindings || []),
   exportJsonFile: (payload) => ipcRenderer.invoke('mineradio-export-json-file', payload || {}),
   importJsonFile: () => ipcRenderer.invoke('mineradio-import-json-file'),
@@ -47,6 +48,8 @@ contextBridge.exposeInMainWorld('desktopWindow', {
 });
 
 window.addEventListener('DOMContentLoaded', () => {
+  document.documentElement.classList.add(`platform-${process.platform}`);
   document.documentElement.classList.add('desktop-shell-root');
+  document.body.classList.add(`platform-${process.platform}`);
   document.body.classList.add('desktop-shell');
 });

--- a/docs/MAC_BUILD.md
+++ b/docs/MAC_BUILD.md
@@ -1,0 +1,58 @@
+# Mineradio macOS 构建说明
+
+本文档记录当前 macOS 适配状态。
+
+## 当前状态
+
+macOS 版本处于本地测试阶段。Electron 主应用可以按 macOS 目标打包，更新资产选择也会按平台优先选择 `.dmg` / `.zip`，但公开分发前仍需要补齐签名与公证。
+
+## 本地运行
+
+```bash
+npm ci
+npm start
+```
+
+## 本地打包
+
+无 Apple Developer 证书时，使用下面的命令跳过自动签名发现：
+
+```bash
+CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:mac:dir
+CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:mac
+```
+
+如果 Electron 或 DMG 工具包从 GitHub CDN 下载很慢，可以使用镜像源：
+
+```bash
+ELECTRON_MIRROR=https://npmmirror.com/mirrors/electron/ \
+ELECTRON_BUILDER_BINARIES_MIRROR=https://npmmirror.com/mirrors/electron-builder-binaries/ \
+CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:mac
+```
+
+产物位于 `dist/`。
+
+## 已适配内容
+
+- 新增 `build:mac` 和 `build:mac:dir`。
+- 新增 `build.mac` 与 `build.dmg` 配置。
+- 新增 `build/icon.icns`。
+- macOS 不再追加 Windows 专属的 `use-angle=d3d11` Chromium switch。
+- 更新检测在 macOS 优先读取 `latest-mac.yml`。
+- GitHub Release 资产在 macOS 优先选择 `.dmg` / `.zip`。
+- 更新弹窗文案改为跨平台的“安装文件 / 更新文件”。
+
+## 平台降级
+
+- 壁纸模式依赖 Windows WorkerW，macOS 暂不支持。
+- 桌面歌词可以保留基础覆盖窗口能力，但 Windows 中键全局切换能力不会在 macOS 启用。
+- 未签名 `.app` / `.dmg` 会被 Gatekeeper 提示，需要用户手动允许；公开分发建议完成 Developer ID 签名和 notarization。
+
+## 发布注意
+
+如果独立发布 macOS 版本，Release 资产建议命名为：
+
+- `Mineradio-${version}-mac-arm64.dmg`
+- `Mineradio-${version}-mac-arm64.zip`
+
+当前 `package.json` 保持默认 GitHub Release 更新源。fork 独立发布时，可以通过 `MINERADIO_UPDATE_OWNER` / `MINERADIO_UPDATE_REPO` 指向自己的发布仓库。

--- a/package.json
+++ b/package.json
@@ -8,6 +8,12 @@
   "private": true,
   "scripts": {
     "start": "electron .",
+    "prebuild:mac": "mkdir -p dist && touch dist/.metadata_never_index",
+    "build:mac": "electron-builder --mac dmg zip",
+    "postbuild:mac": "touch dist/.metadata_never_index",
+    "prebuild:mac:dir": "mkdir -p dist && touch dist/.metadata_never_index",
+    "build:mac:dir": "electron-builder --mac dir",
+    "postbuild:mac:dir": "touch dist/.metadata_never_index",
     "build:win": "electron-builder --win nsis",
     "build:win:dir": "electron-builder --win dir"
   },
@@ -45,6 +51,27 @@
           ]
         }
       ]
+    },
+    "mac": {
+      "category": "public.app-category.music",
+      "icon": "build/icon.png",
+      "target": [
+        {
+          "target": "dmg",
+          "arch": [
+            "arm64"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "arm64"
+          ]
+        }
+      ]
+    },
+    "dmg": {
+      "artifactName": "Mineradio-${version}-mac-${arch}.${ext}"
     },
     "nsis": {
       "oneClick": false,

--- a/public/index.html
+++ b/public/index.html
@@ -48,6 +48,8 @@ body.desktop-shell #desktop-titlebar::after{content:none}
 .desktop-window-btn svg{width:14px;height:14px;stroke:currentColor;stroke-width:2;fill:none}
 .desktop-window-btn:hover{background:rgba(244,210,138,.14);color:#fff1bd;transform:translateY(-1px)}
 .desktop-window-btn.close:hover{background:rgba(255,86,100,.86);color:#fff}
+body.platform-darwin #desktop-titlebar{padding-left:92px}
+body.platform-darwin .desktop-window-btn{display:none}
 .desktop-mode-btn{height:30px;min-width:78px;padding:0 12px;border:1px solid rgba(255,255,255,.08);border-radius:999px;background:rgba(4,8,10,.42);color:rgba(224,250,255,.70);font-family:inherit;font-size:11px;font-weight:760;letter-spacing:.08em;display:flex;align-items:center;justify-content:center;gap:6px;cursor:pointer;transition:background .18s,color .18s,transform .18s,border-color .18s,box-shadow .18s}
 .desktop-mode-btn::before{content:'';width:6px;height:6px;border-radius:50%;background:rgba(255,255,255,.28);box-shadow:0 0 0 rgba(255,83,103,0);transition:background .18s,box-shadow .18s}
 .desktop-mode-btn:hover{background:rgba(255,83,103,.10);border-color:rgba(255,83,103,.34);color:#fff;transform:translateY(-1px)}
@@ -2155,7 +2157,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
         <div class="fx-toggle" id="t-bloom" onclick="toggleFx('bloom')"><span>粒子溢光</span><span class="dot"></span></div>
         <div class="fx-toggle" id="t-edge" onclick="toggleFx('edge')"><span>轮廓高亮</span><span class="dot"></span></div>
         <div class="fx-toggle" id="t-desktopLyrics" onclick="toggleFx('desktopLyrics')" title="全屏幕置顶歌词"><span>桌面歌词</span><span class="dot"></span></div>
-        <div class="fx-toggle" id="t-desktopLyricsClickThrough" onclick="toggleFx('desktopLyricsClickThrough')" title="锁定后防误触；鼠标移到桌面歌词上按中键可锁定/解锁"><span>桌面歌词锁定</span><span class="dot"></span></div>
+        <div class="fx-toggle" id="t-desktopLyricsClickThrough" onclick="toggleFx('desktopLyricsClickThrough')" title="锁定后防误触；解锁后可拖动调整位置"><span>桌面歌词锁定</span><span class="dot"></span></div>
         <div class="fx-toggle" id="t-desktopLyricsCinema" onclick="toggleFx('desktopLyricsCinema')" title="桌面歌词绑定鼓点电影震动，基础漂浮始终保留"><span>桌面歌词电影震动</span><span class="dot"></span></div>
         <div class="fx-toggle" id="t-desktopLyricsHighlight" onclick="toggleFx('desktopLyricsHighlight')" title="桌面歌词按播放进度高亮"><span>桌面歌词高亮跟随</span><span class="dot"></span></div>
         <div class="fx-toggle dev-locked" id="t-wallpaperMode" onclick="toggleFx('wallpaperMode')" title="开发中，暂不可用"><span>壁纸模式<em class="fx-dev-badge">开发中</em></span><span class="dot"></span></div>
@@ -2848,7 +2850,7 @@ var updatePreviewState = {
   patchFallbackTried: false,
   hero: '当前版本，更新检测已就绪。',
   notes: [
-    '安装包文字对比修复',
+    '安装文件文字对比修复',
     '安装目录可自由选择',
     '单实例与快捷方式修复'
   ]
@@ -21361,7 +21363,7 @@ function setRange(id, value) {
 function updateDevelopmentFxControls() {
   [
     ['desktopLyrics', 't-desktopLyrics', '全屏幕置顶歌词'],
-    ['desktopLyricsClickThrough', 't-desktopLyricsClickThrough', '锁定后防误触；鼠标移到桌面歌词上按中键可锁定/解锁'],
+    ['desktopLyricsClickThrough', 't-desktopLyricsClickThrough', '锁定后防误触；解锁后可拖动调整位置'],
     ['desktopLyricsCinema', 't-desktopLyricsCinema', '桌面歌词绑定鼓点电影震动，基础漂浮始终保留'],
     ['desktopLyricsHighlight', 't-desktopLyricsHighlight', '桌面歌词按播放进度高亮'],
     ['wallpaperMode', 't-wallpaperMode', '开发中，暂不可用']
@@ -22789,25 +22791,25 @@ function syncUpdatePreviewStateClass() {
   var canOpenRelease = updatePreviewState.configured && updatePreviewState.updateAvailable && !updatePreviewState.downloadUrl && updatePreviewState.releaseUrl;
   if (label) {
     if (isDownloading) label.textContent = (isPatch ? '快速补丁 ' : '正在下载 ') + Math.round(updatePreviewState.progress) + '%';
-    else if (isOpening) label.textContent = '正在打开安装包';
-    else if (isError && updatePreviewState.mode === 'patch' && updatePreviewState.downloadUrl) label.textContent = '下载完整安装包';
+    else if (isOpening) label.textContent = '正在打开安装文件';
+    else if (isError && updatePreviewState.mode === 'patch' && updatePreviewState.downloadUrl) label.textContent = '下载完整安装文件';
     else if (isError) label.textContent = updatePreviewState.mode === 'installer' ? '重试下载' : '重试更新';
     else if (isReady && isPatch && updatePreviewState.restartRequired) label.textContent = '重启生效';
     else if (isReady && isPatch) label.textContent = '补丁已应用';
-    else if (isReady && updatePreviewState.installerOpened) label.textContent = '安装包已打开';
-    else if (isReady && updatePreviewState.installerPath) label.textContent = updatePreviewState.cached ? '打开已下载安装包' : '打开安装包';
-    else if (isReady) label.textContent = updatePreviewState.configured ? '打开安装包' : '预览完成';
-    else label.textContent = updatePreviewState.patchAvailable ? '安装快速补丁' : ((canDownloadUpdate || canOpenRelease) ? '下载完整安装包' : '立即更新');
+    else if (isReady && updatePreviewState.installerOpened) label.textContent = '安装文件已打开';
+    else if (isReady && updatePreviewState.installerPath) label.textContent = updatePreviewState.cached ? '打开已下载安装文件' : '打开安装文件';
+    else if (isReady) label.textContent = updatePreviewState.configured ? '打开安装文件' : '预览完成';
+    else label.textContent = updatePreviewState.patchAvailable ? '安装快速补丁' : ((canDownloadUpdate || canOpenRelease) ? '下载完整安装文件' : '立即更新');
   }
   if (btn) btn.disabled = false;
   var foot = document.getElementById('update-footnote');
   if (foot) {
-    if (isDownloading) foot.textContent = (updatePreviewState.message || (isPatch ? '正在下载快速补丁' : '正在下载完整安装包')) + (updateProgressDetailText() ? ' · ' + updateProgressDetailText() : '');
+    if (isDownloading) foot.textContent = (updatePreviewState.message || (isPatch ? '正在下载快速补丁' : '正在下载完整安装文件')) + (updateProgressDetailText() ? ' · ' + updateProgressDetailText() : '');
     else if (isError) foot.textContent = '下载失败：' + (updatePreviewState.errorReason || updatePreviewState.errorDetail || updatePreviewState.message || '请稍后重试') + (updatePreviewState.failedAttempts && updatePreviewState.failedAttempts.length ? ' · 已尝试 ' + updatePreviewState.failedAttempts.length + ' 条线路' : '');
     else if (isReady && isPatch) foot.textContent = updatePreviewState.restartRequired ? '快速补丁已应用，重启 Mineradio 后生效。' : '快速补丁已应用。';
-    else if (isReady) foot.textContent = updatePreviewState.cached ? '已复用上次校验通过的安装包，不会重复下载。' : '安装包已准备好，点击按钮后再打开安装。';
-    else if (updatePreviewState.patchAvailable) foot.textContent = '优先使用轻量补丁，只更新缺失或变更的资源文件；不适用时可下载完整安装包。';
-    else foot.textContent = updatePreviewState.updateAvailable ? '没有可用快速补丁时会下载完整安装包。' : '当前版本已是最新。';
+    else if (isReady) foot.textContent = updatePreviewState.cached ? '已复用上次校验通过的安装文件，不会重复下载。' : '安装文件已准备好，点击按钮后再打开安装。';
+    else if (updatePreviewState.patchAvailable) foot.textContent = '优先使用轻量补丁，只更新缺失或变更的资源文件；不适用时可下载完整安装文件。';
+    else foot.textContent = updatePreviewState.updateAvailable ? '没有可用快速补丁时会下载完整安装文件。' : '当前版本已是最新。';
   }
 }
 
@@ -22894,7 +22896,7 @@ async function startRealUpdateDownload() {
   updatePreviewState.errorReason = '';
   updatePreviewState.errorDetail = '';
   updatePreviewState.failedAttempts = [];
-  updatePreviewState.message = '正在下载完整安装包';
+  updatePreviewState.message = '正在下载完整安装文件';
   updateUpdatePreviewProgress(0);
   try {
     var job = await apiJson('/api/update/download', { method: 'POST' });
@@ -22956,7 +22958,7 @@ async function startRealUpdatePatch() {
     updatePreviewState.message = updatePreviewState.errorReason;
     updateUpdatePreviewProgress(0);
     updatePreviewState.patchFallbackTried = true;
-    showToast('快速补丁不可用，可手动下载完整安装包');
+    showToast('快速补丁不可用，可手动下载完整安装文件');
   }
 }
 
@@ -23013,7 +23015,7 @@ function applyUpdateDownloadJob(job) {
     updateUpdatePreviewProgress(job && job.progress || updatePreviewState.progress || 0);
     if (updatePreviewState.mode === 'patch' && updatePreviewState.downloadUrl && !updatePreviewState.patchFallbackTried) {
       updatePreviewState.patchFallbackTried = true;
-      showToast('快速补丁失败，可手动下载完整安装包：' + updatePreviewState.errorReason);
+      showToast('快速补丁失败，可手动下载完整安装文件：' + updatePreviewState.errorReason);
       return;
     }
     showToast('更新下载失败：' + updatePreviewState.errorReason);
@@ -23050,7 +23052,7 @@ function applyUpdateDownloadJob(job) {
     if (updatePreviewState.mode === 'patch') {
       showToast(updatePreviewState.restartRequired ? '快速补丁已应用，重启后生效' : '快速补丁已应用');
     } else if (updatePreviewState.installerPath) {
-      showToast(updatePreviewState.cached ? '已复用上次下载的安装包' : '安装包已下载，点击按钮打开');
+      showToast(updatePreviewState.cached ? '已复用上次下载的安装文件' : '安装文件已下载，点击按钮打开');
     }
   }
 }
@@ -23077,7 +23079,7 @@ async function openDownloadedUpdateInstaller(filePath) {
       updatePreviewState.installerOpened = true;
       updatePreviewState.status = 'ready';
       syncUpdatePreviewStateClass();
-      showToast('安装包已打开');
+      showToast('安装文件已打开');
       return;
     }
     throw new Error('DESKTOP_BRIDGE_MISSING');
@@ -23085,7 +23087,7 @@ async function openDownloadedUpdateInstaller(filePath) {
     updatePreviewState.status = 'ready';
     syncUpdatePreviewStateClass();
     if (updatePreviewState.releaseUrl) window.open(updatePreviewState.releaseUrl, '_blank');
-    showToast('无法自动打开安装包，已尝试打开更新页面');
+    showToast('无法自动打开安装文件，已尝试打开更新页面');
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -62,6 +62,12 @@ const QQ_COOKIE_FILE = process.env.QQ_COOKIE_FILE || path.join(__dirname, '.qq-c
 const UPDATE_WORK_DIR = process.env.MINERADIO_UPDATE_DIR || path.join(__dirname, 'updates');
 const UPDATE_DOWNLOAD_DIR = process.env.MINERADIO_UPDATE_DOWNLOAD_DIR || path.join(UPDATE_WORK_DIR, 'downloads');
 const UPDATE_PATCH_BACKUP_DIR = process.env.MINERADIO_PATCH_BACKUP_DIR || path.join(UPDATE_WORK_DIR, 'backups', 'patches');
+const UPDATE_PLATFORM = process.env.MINERADIO_UPDATE_PLATFORM || process.platform;
+const UPDATE_ASSET_MATCHERS = {
+  win32: [/\.exe$/i, /\.msi$/i],
+  darwin: [/\.dmg$/i, /\.zip$/i],
+  linux: [/\.AppImage$/i, /\.deb$/i, /\.rpm$/i, /\.tar\.gz$/i],
+};
 const BEATMAP_CACHE_DIR = process.env.MINERADIO_BEAT_CACHE_DIR || 'D:\\MineradioCache\\beatmaps';
 const APP_PACKAGE = readPackageInfo();
 const APP_VERSION = process.env.MINERADIO_VERSION || APP_PACKAGE.version || '0.9.11';
@@ -362,11 +368,29 @@ function extractReleaseNotes(body) {
   });
   return notes.slice(0, 4);
 }
+function updatePlatformFeedName() {
+  if (UPDATE_PLATFORM === 'darwin') return 'latest-mac.yml';
+  if (UPDATE_PLATFORM === 'linux') return 'latest-linux.yml';
+  return 'latest.yml';
+}
+function updateFallbackAssetName(version) {
+  const safeVersion = normalizeVersion(version || APP_VERSION) || APP_VERSION;
+  if (UPDATE_PLATFORM === 'darwin') return `Mineradio-${safeVersion}-mac-${process.arch}.dmg`;
+  if (UPDATE_PLATFORM === 'linux') return `Mineradio-${safeVersion}.AppImage`;
+  return `Mineradio-${safeVersion}-Setup.exe`;
+}
+function assetMatchesAny(name, matchers) {
+  const value = String(name || '');
+  return (Array.isArray(matchers) ? matchers : []).some(pattern => pattern.test(value));
+}
 function pickReleaseAsset(assets) {
   const list = Array.isArray(assets) ? assets : [];
-  const preferred = list.find(a => /\.(exe|msi)$/i.test(a && a.name || ''))
-    || list.find(a => /\.(zip|7z)$/i.test(a && a.name || ''))
-    || list[0];
+  const platformMatchers = UPDATE_ASSET_MATCHERS[UPDATE_PLATFORM] || UPDATE_ASSET_MATCHERS.win32;
+  const ignored = /\.(blockmap|ya?ml|json|txt)$/i;
+  const installable = list.filter(a => a && a.name && !ignored.test(a.name));
+  const preferred = installable.find(a => assetMatchesAny(a.name, platformMatchers))
+    || installable.find(a => /\.(zip|7z|dmg|exe|msi|AppImage|deb|rpm|tar\.gz)$/i.test(a && a.name || ''))
+    || installable[0];
   if (!preferred) return null;
   const digest = assetDigestInfo(preferred);
   const candidates = uniqueDownloadCandidates(preferred.browser_download_url || '');
@@ -667,7 +691,7 @@ function githubReleaseDownloadUrl(version, fileName) {
 }
 function parseLatestYmlUpdateInfo(text, reason) {
   const latestVersion = normalizeVersion(yamlScalar(text, 'version') || APP_VERSION) || APP_VERSION;
-  const assetPath = yamlScalar(text, 'path') || yamlScalar(text, 'url') || `Mineradio-${latestVersion}-Setup.exe`;
+  const assetPath = yamlScalar(text, 'path') || yamlScalar(text, 'url') || updateFallbackAssetName(latestVersion);
   const sha512 = normalizeDigest(yamlScalar(text, 'sha512'), 'sha512');
   const size = Number(yamlScalar(text, 'size') || 0) || 0;
   const releaseDate = yamlScalar(text, 'releaseDate');
@@ -707,7 +731,7 @@ function parseLatestYmlUpdateInfo(text, reason) {
 }
 async function fetchLatestYmlUpdateInfo(reason) {
   if (!UPDATE_CONFIG.configured || UPDATE_CONFIG.provider !== 'github') throw updateError('UPDATE_REPOSITORY_NOT_CONFIGURED');
-  const latestYmlUrl = `https://github.com/${encodeURIComponent(UPDATE_CONFIG.owner)}/${encodeURIComponent(UPDATE_CONFIG.repo)}/releases/latest/download/latest.yml`;
+  const latestYmlUrl = `https://github.com/${encodeURIComponent(UPDATE_CONFIG.owner)}/${encodeURIComponent(UPDATE_CONFIG.repo)}/releases/latest/download/${updatePlatformFeedName()}`;
   const candidates = uniqueDownloadCandidates(latestYmlUrl);
   const result = await fetchTextFromCandidates(candidates, 6500);
   return parseLatestYmlUpdateInfo(result.text, reason);
@@ -764,13 +788,13 @@ async function fetchLatestUpdateInfo() {
   }
 }
 function safeUpdateFileName(name, version) {
-  const raw = String(name || '').trim() || `Mineradio-${version || APP_VERSION}.exe`;
+  const raw = String(name || '').trim() || updateFallbackAssetName(version || APP_VERSION);
   const cleaned = raw
     .replace(/[<>:"/\\|?*\x00-\x1F]/g, '-')
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, 160);
-  return cleaned || `Mineradio-${version || APP_VERSION}.exe`;
+  return cleaned || updateFallbackAssetName(version || APP_VERSION);
 }
 function publicUpdateJob(job) {
   if (!job) return { ok: false, error: 'UPDATE_JOB_NOT_FOUND' };


### PR DESCRIPTION
## 变更内容

- 新增 macOS Electron Builder 构建配置，支持生成 DMG 和 zip
- macOS 下启用原生窗口红绿灯按钮
- Windows 专属能力按平台降级，避免 macOS 执行 Windows 逻辑
- 更新 release asset 选择逻辑，按平台选择对应安装文件
- 补充 macOS 构建说明文档

## 验证

- node --check desktop/main.js
- node --check desktop/preload.js
- node --check server.js
- npm run build:mac:dir
- npm run build:mac