### PR TITLE
fix(server): 节奏图缓存目录跨平台化，修复非 Windows 下 D:\ 硬编码

### DIFF
--- a/server.js
+++ b/server.js
@@ -48,6 +48,7 @@ const http = require('http');
 const https = require('https');
 const fs   = require('fs');
 const path = require('path');
+const os = require('os');
 const crypto = require('crypto');
 const tls = require('tls');
 const { once } = require('events');
@@ -62,7 +63,13 @@ const QQ_COOKIE_FILE = process.env.QQ_COOKIE_FILE || path.join(__dirname, '.qq-c
 const UPDATE_WORK_DIR = process.env.MINERADIO_UPDATE_DIR || path.join(__dirname, 'updates');
 const UPDATE_DOWNLOAD_DIR = process.env.MINERADIO_UPDATE_DOWNLOAD_DIR || path.join(UPDATE_WORK_DIR, 'downloads');
 const UPDATE_PATCH_BACKUP_DIR = process.env.MINERADIO_PATCH_BACKUP_DIR || path.join(UPDATE_WORK_DIR, 'backups', 'patches');
-const BEATMAP_CACHE_DIR = process.env.MINERADIO_BEAT_CACHE_DIR || 'D:\\MineradioCache\\beatmaps';
+function defaultBeatmapCacheDir() {
+  if (process.platform === 'win32') return 'D:\\MineradioCache\\beatmaps';
+  if (process.platform === 'darwin') return path.join(os.homedir(), 'Library', 'Caches', 'Mineradio', 'beatmaps');
+  const base = process.env.XDG_CACHE_HOME || path.join(os.homedir(), '.cache');
+  return path.join(base, 'Mineradio', 'beatmaps');
+}
+const BEATMAP_CACHE_DIR = process.env.MINERADIO_BEAT_CACHE_DIR || defaultBeatmapCacheDir();
 const APP_PACKAGE = readPackageInfo();
 const APP_VERSION = process.env.MINERADIO_VERSION || APP_PACKAGE.version || '0.9.11';
 const UPDATE_CONFIG = readUpdateConfig(APP_PACKAGE);
@@ -508,6 +515,10 @@ function beatCacheRootInfo() {
   const dir = path.resolve(BEATMAP_CACHE_DIR);
   const root = path.parse(dir).root;
   const drive = root ? root.replace(/[\\\/]+$/, '').toUpperCase() : '';
+  if (process.platform !== 'win32') {
+    // No drive-letter concept on macOS/Linux: any writable root is fine.
+    return { dir, root, drive, allowed: !!root, available: !!root };
+  }
   const allowed = !!root && !/^C:$/i.test(drive);
   const available = allowed && fs.existsSync(root);
   return { dir, root, drive, allowed, available };


### PR DESCRIPTION
## 背景

`server.js` 里 `BEATMAP_CACHE_DIR` 默认值硬编码为 `D:\MineradioCache\beatmaps`。在 macOS / Linux 上：

- `path.parse('D:\\MineradioCache\\beatmaps').root` 取不到盘符根（POSIX 下返回空）；
- `beatCacheRootInfo()` 因此判定 `allowed=false` / `available=false`；
- 结果 `/api/beatmap/cache/status` 返回 `mode: memory-only`，**节奏图磁盘缓存被静默禁用**——每次重启丢缓存，长播客 DJ 节奏分析要重复跑。

这个问题和平台打包无关，任何在非 Windows 上运行 `server.js` 的场景都会触发。

## 改动

- 新增 `defaultBeatmapCacheDir()`：
  - Windows 保持 `D:\MineradioCache\beatmaps`，**行为完全不变**；
  - macOS 用 `~/Library/Caches/Mineradio/beatmaps`；
  - Linux 用 `$XDG_CACHE_HOME`（缺省 `~/.cache`）下的 `Mineradio/beatmaps`。
- `beatCacheRootInfo()`：非 `win32` 平台不再套用「禁 C 盘 + 盘符根须存在」这套 Windows 习惯逻辑，任意可写根目录即视为可用。
- `MINERADIO_BEAT_CACHE_DIR` 环境变量覆盖行为保持不变。

仅改 `server.js`，`+12 / -1`。

## 测试（macOS, Apple Silicon）

- `node --check server.js` 通过。
- 实际启动后 `GET /api/beatmap/cache/status`：由 `{"mode":"memory-only","reason":"C_DRIVE_DISABLED"}` 变为 `{"mode":"disk","dir":"/Users/<user>/Library/Caches/Mineradio/beatmaps"}`。
- `POST /api/beatmap/cache` 写入 + `GET` 读回 + 落盘文件均正常。
- Windows 路径分支未改动，行为不变。

> 备注：与 #87（macOS 构建与窗口适配）互补但相互独立，可单独合并。