### PR TITLE
修复 QQ 音乐最高音质 Hi-Res 歌曲返回 404 无法播放 (Fixes #113)

### DIFF
--- a/server.js
+++ b/server.js
@@ -2649,6 +2649,24 @@ async function handleQQSearch(keywords, limit) {
   });
 }
 
+// QQ 对 Hi-Res/无损经常返回带 purl 却实际 404 的地址；用一个轻量 Range 探测确认能否真正拉到流
+function qqProbePlayable(targetUrl) {
+  return new Promise((resolve) => {
+    let mod;
+    try { mod = new URL(targetUrl).protocol === 'https:' ? https : http; }
+    catch (e) { return resolve(false); }
+    let settled = false;
+    const done = (ok) => { if (!settled) { settled = true; resolve(ok); } };
+    const req = mod.get(targetUrl, { headers: { ...QQ_HEADERS, Range: 'bytes=0-1' }, timeout: 4500 }, (r) => {
+      const ok = r.statusCode === 200 || r.statusCode === 206;
+      r.destroy();
+      done(ok);
+    });
+    req.on('timeout', () => { req.destroy(); done(false); });
+    req.on('error', () => done(false));
+  });
+}
+
 async function handleQQSongUrl(mid, mediaMid, qualityPreference) {
   const songmid = String(mid || '').trim();
   if (!songmid) return { provider: 'qq', url: '', error: 'MISSING_MID', message: 'Missing QQ song mid' };
@@ -2688,10 +2706,16 @@ async function handleQQSongUrl(mid, mediaMid, qualityPreference) {
   }, { cookie: true });
   const data = json && json.req_0 && json.req_0.data;
   const infos = (data && Array.isArray(data.midurlinfo)) ? data.midurlinfo : [];
-  const info = infos.find(item => item && item.purl) || infos[0];
+  const sip = (data && data.sip && data.sip[0]) || 'https://ws.stream.qqmusic.qq.com/';
+  // 按音质顺序在有 purl 的候选里挑「真正能拉到流(206)」的那个；Hi-Res 经常给 purl 却 404，需自动回退到可用音质
+  const purlCandidates = infos.filter(item => item && item.purl);
+  let info = null;
+  for (let ci = 0; ci < purlCandidates.length && ci < 4; ci++) {
+    if (await qqProbePlayable(sip + purlCandidates[ci].purl)) { info = purlCandidates[ci]; break; }
+  }
+  if (!info) info = purlCandidates[0] || infos[0];
   const purl = info && info.purl;
   if (purl) {
-    const sip = (data.sip && data.sip[0]) || 'https://ws.stream.qqmusic.qq.com/';
     const fileMeta = fileCandidates.find(item => item.filename === info.filename) || {};
     return {
       provider: 'qq',


### PR DESCRIPTION
## 问题
登录 QQ VIP（豪华绿钻）后设「最高」音质，部分 VIP 歌返回 404 放不了；降到 320 / 标准音质则正常。详见 #113。

## 根因
QQ 的 `vkey.GetVkeyServer` 对 Hi-Res 候选会返回带 `purl` 却实际 404 的地址，`handleQQSongUrl` 取了第一个有 `purl` 的就直接返回、未验证地址是否真能拉流。

## 改动
- 新增 `qqProbePlayable(url)`：轻量 Range 探测（`bytes=0-1`，4.5s 超时）判断地址能否真正拉到流。
- `handleQQSongUrl` 改为按音质从高到低探测有 `purl` 的候选，选第一个返回 200/206 的；最多探测 4 个，全部失败才退回原行为。

## 代价
每次取播放地址会多 1~2 次快速探测（通常几百毫秒）。可后续优化为「只对无损探测」或缓存结果。

## 测试
- 周杰伦《晴天》最高音质：HTTP 404 → 206 可播无损 ✅
- 320 / 标准音质行为不变（仍 206）
- `node --check server.js` 通过

Fixes #113
