### PR TITLE
feat: add experimental macOS build path

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,28 @@ Windows 用户可以在 GitHub Releases 中下载安装包。
 
 已经安装过旧版本的用户，建议卸载旧版本、隔离旧安装包后，再使用 `v1.1.1` 安装包纯净安装。
 
+## macOS 尝鲜构建
+
+macOS 目前不是官方签名发布平台，但开发者和尝鲜用户可以从源码构建本地 `.app`：
+
+```bash
+npm install
+npm run build:mac:dir
+open dist/mac*/Mineradio.app
+```
+
+开发模式可使用 `npm start`。`http://localhost:3000` 是 Electron 本地服务地址，只在应用运行时可访问，并不是线上网页。更多说明见 [macOS 尝鲜构建说明](./docs/MACOS_EXPERIMENTAL_BUILD.md)。
+
 ## 开发运行
 
 ```bash
 npm install
 npm start
 npm run build:win
+npm run build:mac:dir
 ```
 
-桌面版入口由 Electron 主进程加载本地服务。`npm run build:win` 会生成 Windows NSIS 安装包，产物位于 `dist/`。
+桌面版入口由 Electron 主进程加载本地服务。`npm run build:win` 会生成 Windows NSIS 安装包，`npm run build:mac:dir` 会生成本地 macOS `.app` 目录，产物位于 `dist/`。
 
 ## 更新机制
 

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -29,6 +29,7 @@ const WINDOWED_SCALE = 3 / 4;
 const WINDOWED_MARGIN = 32;
 const MIN_WINDOWED_WIDTH = 960;
 const MIN_WINDOWED_HEIGHT = 540;
+const USE_NATIVE_TRAFFIC_LIGHTS = process.platform === 'darwin';
 const APP_NAME = 'Mineradio';
 const APP_USER_MODEL_ID = 'com.mineradio.desktop';
 const APP_ICON_ICO = path.join(__dirname, '..', 'build', 'icon.ico');
@@ -36,6 +37,9 @@ const NETEASE_LOGIN_PARTITION = 'persist:mineradio-netease-login';
 const NETEASE_LOGIN_URL = 'https://music.163.com/#/login';
 const QQ_LOGIN_PARTITION = 'persist:mineradio-qqmusic-login';
 const QQ_LOGIN_URL = 'https://y.qq.com/n/ryqq/profile';
+const ANGLE_BACKEND = process.platform === 'win32'
+  ? 'd3d11'
+  : (process.platform === 'darwin' ? 'metal' : 'opengl');
 
 const CHROMIUM_PERFORMANCE_SWITCHES = [
   ['autoplay-policy', 'no-user-gesture-required'],
@@ -48,7 +52,7 @@ const CHROMIUM_PERFORMANCE_SWITCHES = [
   ['disable-renderer-backgrounding'],
   ['disable-backgrounding-occluded-windows'],
   ['force_high_performance_gpu'],
-  ['use-angle', 'd3d11'],
+  ['use-angle', ANGLE_BACKEND],
 ];
 for (const [name, value] of CHROMIUM_PERFORMANCE_SWITCHES) {
   if (value == null) app.commandLine.appendSwitch(name);
@@ -697,6 +701,17 @@ function toggleFullscreen(win) {
   windowFullscreenActive = true;
   win.setFullScreen(true);
   sendWindowState(win);
+}
+
+function enterNativeFullscreenFromZoom(win) {
+  if (process.platform !== 'darwin' || !win || win.isDestroyed()) return false;
+  if (win.isFullScreen() || windowFullscreenActive) return false;
+  windowFullscreenActive = true;
+  setTimeout(() => {
+    if (!win || win.isDestroyed() || win.isFullScreen()) return;
+    try { win.setFullScreen(true); } catch (e) {}
+  }, 0);
+  return true;
 }
 
 function overlayUrl(page) {
@@ -1350,7 +1365,12 @@ async function createWindow() {
     minWidth: 960,
     minHeight: 540,
     show: false,
-    frame: false,
+    frame: USE_NATIVE_TRAFFIC_LIGHTS,
+    titleBarStyle: USE_NATIVE_TRAFFIC_LIGHTS ? 'hiddenInset' : undefined,
+    trafficLightPosition: USE_NATIVE_TRAFFIC_LIGHTS ? { x: 18, y: 18 } : undefined,
+    fullscreenable: true,
+    maximizable: true,
+    resizable: true,
     fullscreen: false,
     transparent: true,
     backgroundColor: '#00000000',
@@ -1388,7 +1408,10 @@ async function createWindow() {
     sendWindowState(mainWindow);
   });
 
-  mainWindow.on('maximize', () => sendWindowState(mainWindow));
+  mainWindow.on('maximize', () => {
+    if (enterNativeFullscreenFromZoom(mainWindow)) return;
+    sendWindowState(mainWindow);
+  });
   mainWindow.on('unmaximize', () => sendWindowState(mainWindow));
   mainWindow.on('minimize', () => sendWindowState(mainWindow));
   mainWindow.on('restore', () => sendWindowState(mainWindow));

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -2,6 +2,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('desktopWindow', {
   isDesktop: true,
+  platform: process.platform,
   minimize: () => ipcRenderer.invoke('desktop-window-minimize'),
   toggleMaximize: () => ipcRenderer.invoke('desktop-window-toggle-maximize'),
   toggleFullscreen: () => ipcRenderer.invoke('desktop-window-toggle-fullscreen'),

--- a/docs/MACOS_EXPERIMENTAL_BUILD.md
+++ b/docs/MACOS_EXPERIMENTAL_BUILD.md
@@ -1,0 +1,32 @@
+# macOS 尝鲜构建说明
+
+Mineradio 当前正式下载入口仍以 Windows 安装包为主。macOS 支持处于开发者/尝鲜阶段，适合愿意从源码运行或本地构建 `.app` 的用户。
+
+## 开发模式
+
+```bash
+npm install
+npm start
+```
+
+`npm start` 会启动 Electron 窗口和本地 Node 服务。浏览器中的 `http://localhost:3000` 只在这个服务运行时可访问，并不是线上网页。
+
+## 构建本地 App
+
+```bash
+npm install
+npm run build:mac:dir
+open dist/mac*/Mineradio.app
+```
+
+生成的 `.app` 是本机未签名构建，不等同于官方发布包。macOS 构建会使用系统左上角红黄绿窗口按钮；首次打开时，如果 macOS 安全设置拦截，可以在系统设置的隐私与安全性页面中允许本机生成的应用继续打开。
+
+## 关闭和重新打开
+
+- 开发模式：在运行 `npm start` 的终端按 `Ctrl+C`。
+- 本地 `.app`：像普通 macOS 应用一样退出 Mineradio。
+- 如果 `localhost:3000` 打不开，通常说明本地服务没有运行。
+
+## 后续发布路径
+
+后续可以在维护者认可后补充 `.dmg`/`.zip` Release 资产、SHA256 校验、未签名提示，并在具备证书时接入签名和 notarization。

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "start": "electron .",
     "build:win": "electron-builder --win nsis",
-    "build:win:dir": "electron-builder --win dir"
+    "build:win:dir": "electron-builder --win dir",
+    "build:mac": "electron-builder --mac dmg zip",
+    "build:mac:dir": "electron-builder --mac dir"
   },
   "build": {
     "appId": "com.mineradio.desktop",
@@ -46,6 +48,27 @@
         }
       ]
     },
+    "mac": {
+      "category": "public.app-category.music",
+      "icon": "build/icon.png",
+      "identity": null,
+      "target": [
+        {
+          "target": "dmg",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
+      ]
+    },
     "nsis": {
       "oneClick": false,
       "perMachine": false,
@@ -60,6 +83,9 @@
       "installerHeader": "build/installerHeader.bmp",
       "include": "build/installer.nsh",
       "artifactName": "Mineradio-${version}-Setup.${ext}"
+    },
+    "dmg": {
+      "artifactName": "Mineradio-${version}-mac-${arch}.${ext}"
     },
     "publish": [
       {

--- a/public/index.html
+++ b/public/index.html
@@ -62,6 +62,8 @@ body.desktop-shell #desktop-titlebar #update-entry::before,
 body.desktop-shell #desktop-titlebar #update-entry::after{display:none}
 body.desktop-shell #desktop-titlebar #visual-guide-btn:hover,
 body.desktop-shell #desktop-titlebar #update-entry:hover{background:rgba(255,83,103,.10);border-color:rgba(255,83,103,.32);color:#fff;transform:translateY(-1px)}
+body.desktop-shell.desktop-platform-darwin #desktop-titlebar{padding-left:92px}
+body.desktop-shell.desktop-platform-darwin .desktop-window-btn{display:none}
 body.desktop-shell #search-area{top:-92px}
 body.desktop-shell #search-area.peek{top:34px}
 body.desktop-shell #search-area.stage-mode.peek{top:32px}
@@ -26410,6 +26412,7 @@ function toggleFullscreen() {
 
   document.documentElement.classList.add('desktop-shell-root');
   document.body.classList.add('desktop-shell');
+  document.body.classList.add('desktop-platform-' + (api.platform || 'unknown'));
   document.body.classList.remove('desktop-fullscreen');
   desktopFullscreenActive = false;
   syncCursorAutoHideMode();

--- a/server.js
+++ b/server.js
@@ -48,6 +48,7 @@ const http = require('http');
 const https = require('https');
 const fs   = require('fs');
 const path = require('path');
+const os = require('os');
 const crypto = require('crypto');
 const tls = require('tls');
 const { once } = require('events');
@@ -62,7 +63,12 @@ const QQ_COOKIE_FILE = process.env.QQ_COOKIE_FILE || path.join(__dirname, '.qq-c
 const UPDATE_WORK_DIR = process.env.MINERADIO_UPDATE_DIR || path.join(__dirname, 'updates');
 const UPDATE_DOWNLOAD_DIR = process.env.MINERADIO_UPDATE_DOWNLOAD_DIR || path.join(UPDATE_WORK_DIR, 'downloads');
 const UPDATE_PATCH_BACKUP_DIR = process.env.MINERADIO_PATCH_BACKUP_DIR || path.join(UPDATE_WORK_DIR, 'backups', 'patches');
-const BEATMAP_CACHE_DIR = process.env.MINERADIO_BEAT_CACHE_DIR || 'D:\\MineradioCache\\beatmaps';
+function defaultBeatmapCacheDir() {
+  if (process.platform === 'win32') return 'D:\\MineradioCache\\beatmaps';
+  return path.join(os.tmpdir(), 'MineradioCache', 'beatmaps');
+}
+
+const BEATMAP_CACHE_DIR = process.env.MINERADIO_BEAT_CACHE_DIR || defaultBeatmapCacheDir();
 const APP_PACKAGE = readPackageInfo();
 const APP_VERSION = process.env.MINERADIO_VERSION || APP_PACKAGE.version || '0.9.11';
 const UPDATE_CONFIG = readUpdateConfig(APP_PACKAGE);


### PR DESCRIPTION
## 背景

Mineradio 当前正式下载和安装说明主要面向 Windows 用户。macOS 用户虽然可以从源码运行，但容易遇到几个体验断点：不知道 `localhost:3000` 只是本地服务、没有可构建的 `.app` 路径、窗口行为不像 macOS App、以及非 Windows 环境会生成 `D:\MineradioCache\beatmaps` 这类 Windows 风格目录。

这个 PR 先做一版低风险的 macOS 尝鲜构建支持，目标是让开发者和早期体验用户可以更顺畅地在 macOS 上构建、打开和理解 Mineradio，同时不改变现有 Windows 安装包流程。

## 修改内容

- 新增 `build:mac` / `build:mac:dir` 脚本，支持本地生成 macOS `.app`，并预留 `.dmg` / `.zip` 目标。
- 新增 macOS electron-builder 配置，默认使用未签名本地构建，避免开发者机器上的签名证书状态影响尝鲜构建。
- macOS 主窗口使用原生红黄绿窗口按钮，并将绿色按钮的 zoom/maximize 行为桥接到 native fullscreen，让体验更接近普通 macOS App。
- Chromium ANGLE 后端按平台选择：Windows 保持 `d3d11`，macOS 使用 `metal`，其他平台使用 `opengl`。
- 非 Windows 系统下默认 beatmap 缓存改到系统临时目录，避免在项目根目录生成 Windows 路径形式的缓存目录。
- README 增加 macOS 尝鲜构建说明，并新增 `docs/MACOS_EXPERIMENTAL_BUILD.md` 解释开发模式、本地 `.app`、`localhost:3000` 和后续 `.dmg` 发布路径。

## 影响范围

- Windows 现有 `build:win` / NSIS 安装包配置保持不变。
- macOS 目前仍定位为开发者/尝鲜构建，不等同于官方签名发布包。
- 本地已验证可以额外生成 `Mineradio-1.1.1-mac-arm64.dmg`，但本 PR 不提交二进制产物；如果维护者认可，后续可以补充 Release 资产、SHA256 校验、签名和 notarization 流程。

## 验证

- `git diff --check`
- `node --check desktop/main.js`
- `node --check desktop/preload.js`
- `node --check server.js`
- `npm run build:mac:dir`
- 打开 `dist/mac-arm64/Mineradio.app`
- `curl -I http://localhost:3000` 返回 `HTTP/1.1 200 OK`
- 本地额外验证 `npx electron-builder --mac dmg --arm64` 可生成 macOS `.dmg`

## 后续方向

如果这个方向合适，我也愿意继续协助补齐 macOS 发布体验，例如 Release 命名、校验文件、未签名提示、GitHub Actions 自动构建，以及在具备证书时接入签名和 notarization。
