### PR TITLE
[codex] add macOS M4 compatibility

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1,8 +1,9 @@
-const { app, BrowserWindow, ipcMain, shell, screen, session, globalShortcut, dialog } = require('electron');
+const { app, BrowserWindow, ipcMain, shell, screen, session, globalShortcut, dialog, powerMonitor } = require('electron');
 const net = require('net');
 const path = require('path');
 const fs = require('fs');
-const { execFile, spawn } = require('child_process');
+const os = require('os');
+const { execFile, execFileSync, spawn } = require('child_process');
 
 let mainWindow = null;
 let localServer = null;
@@ -31,7 +32,10 @@ const MIN_WINDOWED_WIDTH = 960;
 const MIN_WINDOWED_HEIGHT = 540;
 const APP_NAME = 'Mineradio';
 const APP_USER_MODEL_ID = 'com.mineradio.desktop';
+const IS_WINDOWS = process.platform === 'win32';
+const IS_MAC = process.platform === 'darwin';
 const APP_ICON_ICO = path.join(__dirname, '..', 'build', 'icon.ico');
+const APP_ICON_PNG = path.join(__dirname, '..', 'build', 'icon.png');
 const NETEASE_LOGIN_PARTITION = 'persist:mineradio-netease-login';
 const NETEASE_LOGIN_URL = 'https://music.163.com/#/login';
 const QQ_LOGIN_PARTITION = 'persist:mineradio-qqmusic-login';
@@ -39,17 +43,27 @@ const QQ_LOGIN_URL = 'https://y.qq.com/n/ryqq/profile';
 
 const CHROMIUM_PERFORMANCE_SWITCHES = [
   ['autoplay-policy', 'no-user-gesture-required'],
-  ['ignore-gpu-blocklist'],
-  ['enable-gpu-rasterization'],
-  ['enable-oop-rasterization'],
-  ['enable-zero-copy'],
-  ['enable-accelerated-2d-canvas'],
   ['disable-background-timer-throttling'],
   ['disable-renderer-backgrounding'],
   ['disable-backgrounding-occluded-windows'],
-  ['force_high_performance_gpu'],
-  ['use-angle', 'd3d11'],
 ];
+
+// ANGLE backends are platform-specific. Forcing D3D11 on macOS makes the GPU
+// process exit repeatedly and can leave the transparent Electron window visible
+// but unable to repaint or respond to pointer input.
+if (IS_WINDOWS) {
+  CHROMIUM_PERFORMANCE_SWITCHES.push(
+    ['ignore-gpu-blocklist'],
+    ['enable-gpu-rasterization'],
+    ['enable-oop-rasterization'],
+    ['enable-zero-copy'],
+    ['enable-accelerated-2d-canvas'],
+    ['force_high_performance_gpu'],
+    ['use-angle', 'd3d11'],
+  );
+} else if (IS_MAC) {
+  CHROMIUM_PERFORMANCE_SWITCHES.push(['use-angle', 'metal']);
+}
 for (const [name, value] of CHROMIUM_PERFORMANCE_SWITCHES) {
   if (value == null) app.commandLine.appendSwitch(name);
   else app.commandLine.appendSwitch(name, value);
@@ -242,12 +256,14 @@ function getWindowState(win) {
     hasDisplayOnRight: false,
     displayBounds: null,
   };
+  const isNativeFullScreen = win.isFullScreen()
+    || (IS_MAC && typeof win.isSimpleFullScreen === 'function' && win.isSimpleFullScreen());
   return {
     isMaximized: win.isMaximized(),
-    isNativeFullScreen: win.isFullScreen(),
+    isNativeFullScreen,
     isHtmlFullScreen: htmlFullscreenActive,
     isWindowFullScreen: windowFullscreenActive,
-    isFullScreen: win.isFullScreen() || htmlFullscreenActive || windowFullscreenActive,
+    isFullScreen: isNativeFullScreen || htmlFullscreenActive || windowFullscreenActive,
     isMinimized: win.isMinimized(),
     isVisible: win.isVisible(),
     isFocused: win.isFocused(),
@@ -257,6 +273,47 @@ function getWindowState(win) {
 
 function getSenderWindow(event) {
   return BrowserWindow.fromWebContents(event.sender);
+}
+
+function getPerformanceProfile() {
+  const cpus = os.cpus() || [];
+  const cpuModel = cpus[0] && cpus[0].model ? String(cpus[0].model) : '';
+  let hardwareModel = '';
+  if (IS_MAC) {
+    try {
+      hardwareModel = execFileSync('/usr/sbin/sysctl', ['-n', 'hw.model'], {
+        encoding: 'utf8',
+        timeout: 1000,
+      }).trim();
+    } catch (_) {}
+  }
+  let display = null;
+  try { display = screen.getPrimaryDisplay(); } catch (_) {}
+  let thermalState = 'unknown';
+  let onBattery = false;
+  try { thermalState = powerMonitor.getCurrentThermalState(); } catch (_) {}
+  try { onBattery = powerMonitor.isOnBatteryPower(); } catch (_) {}
+  return {
+    platform: process.platform,
+    arch: process.arch,
+    hardwareModel,
+    cpuModel,
+    logicalCores: cpus.length,
+    memoryGB: Math.round(os.totalmem() / 1073741824),
+    onBattery,
+    thermalState,
+    display: display ? {
+      width: display.bounds.width,
+      height: display.bounds.height,
+      scaleFactor: display.scaleFactor || 1,
+      frequency: display.displayFrequency || 0,
+    } : null,
+  };
+}
+
+function broadcastPerformanceProfile() {
+  if (!mainWindow || mainWindow.isDestroyed()) return;
+  mainWindow.webContents.send('mineradio-performance-profile', getPerformanceProfile());
 }
 
 function focusMainWindow() {
@@ -667,36 +724,57 @@ function applyWindowedBounds(win) {
   sendWindowState(win);
 }
 
+function isPlatformFullScreen(win) {
+  if (!win || win.isDestroyed()) return false;
+  if (IS_MAC && typeof win.isSimpleFullScreen === 'function') {
+    return win.isSimpleFullScreen();
+  }
+  return win.isFullScreen();
+}
+
+function setPlatformFullScreen(win, enabled) {
+  if (!win || win.isDestroyed()) return;
+  if (IS_MAC && typeof win.setSimpleFullScreen === 'function') {
+    win.setSimpleFullScreen(!!enabled);
+    return;
+  }
+  win.setFullScreen(!!enabled);
+}
+
 function exitFullscreenToWindow(win) {
   if (!win || win.isDestroyed()) return;
   windowFullscreenActive = false;
 
-  if (!win.isFullScreen()) {
+  if (!isPlatformFullScreen(win)) {
     applyWindowedBounds(win);
     return;
   }
 
   let applied = false;
   const applyOnce = () => {
-    if (applied || !win || win.isDestroyed() || win.isFullScreen()) return;
+    if (applied || !win || win.isDestroyed() || isPlatformFullScreen(win)) return;
     applied = true;
     applyWindowedBounds(win);
   };
 
-  win.once('leave-full-screen', () => setTimeout(applyOnce, 50));
-  win.setFullScreen(false);
-  setTimeout(applyOnce, 500);
+  if (!IS_MAC) win.once('leave-full-screen', () => setTimeout(applyOnce, 50));
+  setPlatformFullScreen(win, false);
+  setTimeout(applyOnce, IS_MAC ? 80 : 500);
+  setTimeout(() => sendWindowState(win), IS_MAC ? 100 : 520);
 }
 
 function toggleFullscreen(win) {
   if (!win || win.isDestroyed()) return;
-  if (win.isFullScreen() || windowFullscreenActive) {
+  if (isPlatformFullScreen(win) || windowFullscreenActive) {
     exitFullscreenToWindow(win);
     return;
   }
   windowFullscreenActive = true;
-  win.setFullScreen(true);
+  setPlatformFullScreen(win, true);
+  // Native fullscreen transitions are asynchronous. Send an optimistic state
+  // immediately, then reconcile it after macOS/Windows has applied the change.
   sendWindowState(win);
+  setTimeout(() => sendWindowState(win), IS_MAC ? 100 : 500);
 }
 
 function overlayUrl(page) {
@@ -1117,6 +1195,8 @@ ipcMain.handle('desktop-window-get-state', (event) => {
   return getWindowState(getSenderWindow(event));
 });
 
+ipcMain.handle('mineradio-performance-profile', () => getPerformanceProfile());
+
 ipcMain.handle('desktop-window-close', (event) => {
   getSenderWindow(event)?.close();
 });
@@ -1352,12 +1432,15 @@ async function createWindow() {
     show: false,
     frame: false,
     fullscreen: false,
-    transparent: true,
-    backgroundColor: '#00000000',
+    fullscreenable: true,
+    // Opaque windows are substantially more reliable for pointer hit-testing
+    // and WebGL composition on macOS. Windows keeps the original glass shell.
+    transparent: !IS_MAC,
+    backgroundColor: IS_MAC ? '#050608' : '#00000000',
     hasShadow: true,
     autoHideMenuBar: true,
     title: APP_NAME,
-    icon: APP_ICON_ICO,
+    icon: IS_MAC ? APP_ICON_PNG : APP_ICON_ICO,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,
@@ -1446,6 +1529,10 @@ if (!gotSingleInstanceLock) {
     });
     screen.on('display-added', () => scheduleWindowStateSend(mainWindow));
     screen.on('display-removed', () => scheduleWindowStateSend(mainWindow));
+    powerMonitor.on('on-ac', broadcastPerformanceProfile);
+    powerMonitor.on('on-battery', broadcastPerformanceProfile);
+    powerMonitor.on('thermal-state-change', broadcastPerformanceProfile);
+    powerMonitor.on('speed-limit-change', broadcastPerformanceProfile);
     await createWindow();
   });
 

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -2,11 +2,13 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('desktopWindow', {
   isDesktop: true,
+  platform: process.platform,
   minimize: () => ipcRenderer.invoke('desktop-window-minimize'),
   toggleMaximize: () => ipcRenderer.invoke('desktop-window-toggle-maximize'),
   toggleFullscreen: () => ipcRenderer.invoke('desktop-window-toggle-fullscreen'),
   exitFullscreenWindowed: () => ipcRenderer.invoke('desktop-window-exit-fullscreen-windowed'),
   getState: () => ipcRenderer.invoke('desktop-window-get-state'),
+  getPerformanceProfile: () => ipcRenderer.invoke('mineradio-performance-profile'),
   close: () => ipcRenderer.invoke('desktop-window-close'),
   openNeteaseMusicLogin: () => ipcRenderer.invoke('netease-music-open-login'),
   clearNeteaseMusicLogin: () => ipcRenderer.invoke('netease-music-clear-login'),
@@ -43,6 +45,12 @@ contextBridge.exposeInMainWorld('desktopWindow', {
     const listener = (_event, state) => callback(state);
     ipcRenderer.on('desktop-window-state', listener);
     return () => ipcRenderer.removeListener('desktop-window-state', listener);
+  },
+  onPerformanceProfile: (callback) => {
+    if (typeof callback !== 'function') return () => {};
+    const listener = (_event, profile) => callback(profile || {});
+    ipcRenderer.on('mineradio-performance-profile', listener);
+    return () => ipcRenderer.removeListener('mineradio-performance-profile', listener);
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "scripts": {
     "start": "electron .",
+    "build:mac": "electron-builder --mac dir",
     "build:win": "electron-builder --win nsis",
     "build:win:dir": "electron-builder --win dir"
   },
@@ -44,6 +45,13 @@
             "x64"
           ]
         }
+      ]
+    },
+    "mac": {
+      "category": "public.app-category.music",
+      "icon": "build/icon.png",
+      "target": [
+        "dir"
       ]
     },
     "nsis": {

--- a/public/index.html
+++ b/public/index.html
@@ -3430,6 +3430,10 @@ var desktopRuntimeState = {
   focused: true,
   fullscreen: false
 };
+var nativePerformanceProfile = {
+  platform: '', arch: '', hardwareModel: '', cpuModel: '', logicalCores: 0, memoryGB: 0,
+  onBattery: false, thermalState: 'unknown', display: null
+};
 var renderPowerState = { mode: '', width: 0, height: 0, pixelRatio: 0 };
 var backgroundCacheTrimTimer = 0;
 var runtimePerfState = {
@@ -3687,6 +3691,20 @@ function updateDesktopRuntimeState(state) {
   if (wasDeep && !isDeepBackgroundMode()) recoverVisualsAfterBackground('desktop-runtime-state');
   if (desktopRuntimeState.fullscreen !== wasFullscreen) scheduleMainRendererViewportRefresh('desktop-runtime-state');
 }
+function isM4MacBookProProfile() {
+  return nativePerformanceProfile.platform === 'darwin'
+    && nativePerformanceProfile.arch === 'arm64'
+    && nativePerformanceProfile.hardwareModel === 'Mac16,1'
+    && /Apple M4(?:$|\s)/i.test(nativePerformanceProfile.cpuModel || '')
+    && nativePerformanceProfile.logicalCores >= 10
+    && nativePerformanceProfile.memoryGB >= 16;
+}
+function updateNativePerformanceProfile(profile) {
+  nativePerformanceProfile = Object.assign({}, nativePerformanceProfile, profile || {});
+  document.documentElement.classList.toggle('macbook-pro-14-m4', isM4MacBookProProfile());
+  if (typeof renderer !== 'undefined' && renderer) applyRendererPowerMode();
+  if (typeof renderPerfState !== 'undefined' && renderPerfState) renderPerfState.lastRenderAt = 0;
+}
 function installRenderPowerHooks() {
   updateRenderPowerClasses();
   document.addEventListener('visibilitychange', function(){
@@ -3710,6 +3728,12 @@ function installRenderPowerHooks() {
     if (typeof window.desktopWindow.getState === 'function') {
       window.desktopWindow.getState().then(updateDesktopRuntimeState).catch(function(){});
     }
+  }
+  if (window.desktopWindow && typeof window.desktopWindow.onPerformanceProfile === 'function') {
+    window.desktopWindow.onPerformanceProfile(updateNativePerformanceProfile);
+  }
+  if (window.desktopWindow && typeof window.desktopWindow.getPerformanceProfile === 'function') {
+    window.desktopWindow.getPerformanceProfile().then(updateNativePerformanceProfile).catch(function(){});
   }
 }
 
@@ -3735,10 +3759,31 @@ var renderInteractionBoostUntil = 0;
 var renderInteractionReason = '';
 function renderQualityProfile() {
   var quality = normalizePerformanceQuality(fx && fx.performanceQuality);
-  if (quality === 'eco') return { cap: 0.95, min: 0.56, budget: 2400000 };
-  if (quality === 'balanced') return { cap: 1.12, min: 0.66, budget: 3800000 };
-  if (quality === 'ultra') return { cap: 1.75, min: 0.85, budget: 7800000 };
-  return { cap: RENDER_DPR_CAP, min: RENDER_MIN_DPR, budget: RENDER_PIXEL_BUDGET };
+  var profile;
+  if (quality === 'eco') profile = { cap: 0.95, min: 0.56, budget: 2400000 };
+  else if (quality === 'balanced') profile = { cap: 1.12, min: 0.66, budget: 3800000 };
+  else if (quality === 'ultra') profile = { cap: 1.75, min: 0.85, budget: 7800000 };
+  else profile = { cap: RENDER_DPR_CAP, min: RENDER_MIN_DPR, budget: RENDER_PIXEL_BUDGET };
+
+  // The 14-inch M4 panel is Retina/ProMotion. Give the 10-core GPU a little
+  // more resolution headroom on AC, without ever rendering at the raw 2x DPR.
+  if (isM4MacBookProProfile()) {
+    if (quality === 'high') profile = { cap: 1.45, min: 0.78, budget: 6200000 };
+    if (quality === 'ultra') profile = { cap: 1.75, min: 0.90, budget: 8200000 };
+  }
+
+  var thermal = String(nativePerformanceProfile.thermalState || '').toLowerCase();
+  var scale = nativePerformanceProfile.onBattery ? 0.84 : 1;
+  if (thermal === 'serious') scale = Math.min(scale, 0.72);
+  if (thermal === 'critical') scale = Math.min(scale, 0.56);
+  if (scale < 1) {
+    profile = {
+      cap: Math.max(profile.min, profile.cap * Math.sqrt(scale)),
+      min: Math.max(0.50, profile.min * Math.sqrt(scale)),
+      budget: Math.round(profile.budget * scale)
+    };
+  }
+  return profile;
 }
 function getRenderPixelRatio() {
   var device = window.devicePixelRatio || 1;
@@ -26378,6 +26423,23 @@ var desktopWindowState = {};
 
 function toggleFullscreen() {
   var api = window.desktopWindow;
+  // On macOS, Electron's native/simple fullscreen is unreliable for this
+  // frameless WebGL window. The HTML Fullscreen API uses Electron's supported
+  // renderer transition and correctly resizes both the window and canvas.
+  if (api && api.isDesktop && api.platform === 'darwin') {
+    if (document.fullscreenElement) {
+      document.exitFullscreen().catch(function(){
+        if (typeof api.exitFullscreenWindowed === 'function') api.exitFullscreenWindowed();
+      });
+    } else {
+      document.documentElement.requestFullscreen().catch(function(){
+        if (typeof api.toggleFullscreen === 'function') api.toggleFullscreen();
+        else showToast('全屏被系统拒绝');
+      });
+    }
+    scheduleMainRendererViewportRefresh('mac-document-fullscreen-toggle');
+    return;
+  }
   if (api && api.isDesktop && typeof api.toggleFullscreen === 'function') {
     if (document.fullscreenElement && document.exitFullscreen) {
       document.exitFullscreen().catch(function(){});
@@ -26581,6 +26643,10 @@ function isMainSceneCoveredBySplash() {
 }
 function getAdaptiveRenderFps() {
   if (isDeepBackgroundMode()) return 1;
+  var thermal = String(nativePerformanceProfile.thermalState || '').toLowerCase();
+  if (thermal === 'critical') return 30;
+  if (thermal === 'serious') return 45;
+  if (nativePerformanceProfile.onBattery) return 60;
   if (RENDER_VISIBLE_VSYNC) return 0;
   var tier = (typeof getRenderLoadTier === 'function') ? getRenderLoadTier() : 0;
   if (typeof isRenderInteractionActive === 'function' && isRenderInteractionActive()) {


### PR DESCRIPTION
@XxHuberrr 你好，这个 PR 补充了 Mineradio 在 macOS Apple Silicon，特别是 14 英寸 MacBook Pro M4（Mac16,1）上的运行、全屏和性能适配，供你审阅。

## 改动内容

- 按平台选择 ANGLE 后端：Windows 保持 D3D11，macOS 改用 Metal。
- macOS 主窗口改用稳定的不透明合成，避免透明 WebGL 窗口出现显示正常但点击无响应的问题。
- macOS 全屏按钮改用已验证可用的 HTML Fullscreen API，并保留主进程全屏作为兜底；进入和退出时同步窗口及画布状态。
- 新增 macOS arm64 的 `build:mac` 和 electron-builder 配置。
- 新增运行时硬件、电源、热状态和显示器信息通道。
- 针对 `Mac16,1` + Apple M4 + 16GB + Retina/120Hz 调整渲染像素预算：插电时保留 ProMotion 高刷新，电池模式限制为 60 FPS，严重/临界热状态自动进一步降帧与降像素预算。
- 后台和最小化时继续沿用原有深度休眠策略。

## 根因

原启动参数在所有平台强制 `use-angle=d3d11`。macOS 上 GPU 进程因此初始化失败；结合透明无边框 WebGL 窗口，会出现交互和重绘异常。原全屏路径在该窗口模式下也无法可靠进入全屏。

## 实测环境

- MacBook Pro 14-inch，型号 `Mac16,1`
- Apple M4：10 核 CPU / 10 核 GPU
- 16GB 内存
- 3024×1964 Liquid Retina XDR，逻辑分辨率 1512×982，120Hz
- macOS 26.3.1，arm64

## 验证

- `node --check desktop/main.js`
- `node --check desktop/preload.js`
- `git diff --check`
- `CSC_IDENTITY_AUTO_DISCOVERY=false npm run build:mac`：成功生成 `dist/mac-arm64/Mineradio.app`
- 应用按钮进入全屏：状态同步成功，画布 1512×949；再次触发可恢复至 1134×638
- 超高画质全屏实测：DPR 1.75，约 439 万渲染像素，约 116–120 FPS
- 电池策略模拟：目标 60 FPS，像素预算按策略下降

这是草稿 PR，方便你按项目整体规划调整命名、阈值或平台支持范围。
