### PR TITLE
[codex]添加YT music播放源

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -36,6 +36,8 @@ const NETEASE_LOGIN_PARTITION = 'persist:mineradio-netease-login';
 const NETEASE_LOGIN_URL = 'https://music.163.com/#/login';
 const QQ_LOGIN_PARTITION = 'persist:mineradio-qqmusic-login';
 const QQ_LOGIN_URL = 'https://y.qq.com/n/ryqq/profile';
+const YOUTUBE_LOGIN_PARTITION = 'persist:mineradio-youtube-login';
+const YOUTUBE_LOGIN_URL = 'https://music.youtube.com/';
 
 const CHROMIUM_PERFORMANCE_SWITCHES = [
   ['autoplay-policy', 'no-user-gesture-required'],
@@ -88,6 +90,23 @@ const NETEASE_LOGIN_COOKIE_PRIORITY = [
   'WEVNSM',
   'WNMCID',
   'JSESSIONID-WYYY',
+];
+const YOUTUBE_LOGIN_COOKIE_PRIORITY = [
+  '__Secure-3PSID',
+  '__Secure-1PSID',
+  'SID',
+  'HSID',
+  'SSID',
+  'APISID',
+  'SAPISID',
+  '__Secure-3PAPISID',
+  '__Secure-1PAPISID',
+  '__Secure-3PSIDTS',
+  '__Secure-1PSIDTS',
+  'LOGIN_INFO',
+  'PREF',
+  'VISITOR_INFO1_LIVE',
+  'YSC',
 ];
 
 function findOpenPort(startPort) {
@@ -349,6 +368,14 @@ function neteaseCookieHasLogin(cookieText) {
   return !!obj.MUSIC_U;
 }
 
+function youtubeCookieHasLogin(cookieText) {
+  const obj = parseCookieHeader(cookieText);
+  const accountId = obj.SID || obj['__Secure-1PSID'] || obj['__Secure-3PSID'] || obj.LOGIN_INFO || '';
+  const authToken = obj.SAPISID || obj.APISID || obj.SSID || obj.HSID ||
+    obj['__Secure-1PAPISID'] || obj['__Secure-3PAPISID'] || obj.LOGIN_INFO || '';
+  return !!(accountId && authToken);
+}
+
 function isQQCookieDomain(domain) {
   const normalized = String(domain || '').replace(/^\./, '').toLowerCase();
   return normalized === 'qq.com' || normalized.endsWith('.qq.com') || normalized.endsWith('qqmusic.qq.com');
@@ -359,6 +386,13 @@ function isNeteaseCookieDomain(domain) {
   return normalized === '163.com' || normalized.endsWith('.163.com') ||
     normalized === 'music.163.com' || normalized.endsWith('.music.163.com') ||
     normalized === 'netease.com' || normalized.endsWith('.netease.com');
+}
+
+function isYoutubeCookieDomain(domain) {
+  const normalized = String(domain || '').replace(/^\./, '').toLowerCase();
+  return normalized === 'youtube.com' || normalized.endsWith('.youtube.com') ||
+    normalized === 'google.com' || normalized.endsWith('.google.com') ||
+    normalized === 'accounts.google.com' || normalized.endsWith('.accounts.google.com');
 }
 
 function buildCookieHeaderFor(cookies, isAllowedDomain, priority) {
@@ -395,6 +429,11 @@ async function readQQLoginCookieHeader(cookieSession) {
 async function readNeteaseLoginCookieHeader(cookieSession) {
   const cookies = await cookieSession.cookies.get({});
   return buildCookieHeaderFor(cookies, isNeteaseCookieDomain, NETEASE_LOGIN_COOKIE_PRIORITY);
+}
+
+async function readYoutubeLoginCookieHeader(cookieSession) {
+  const cookies = await cookieSession.cookies.get({});
+  return buildCookieHeaderFor(cookies, isYoutubeCookieDomain, YOUTUBE_LOGIN_COOKIE_PRIORITY);
 }
 
 async function openNeteaseMusicLoginWindow(owner) {
@@ -600,6 +639,144 @@ async function openQQMusicLoginWindow(owner) {
   });
 }
 
+async function openYoutubeMusicLoginWindow(owner) {
+  const cookieSession = session.fromPartition(YOUTUBE_LOGIN_PARTITION);
+  const initialCookie = await readYoutubeLoginCookieHeader(cookieSession);
+  if (youtubeCookieHasLogin(initialCookie)) return { ok: true, cookie: initialCookie, reused: true };
+
+  return new Promise((resolve) => {
+    let settled = false;
+    let pollTimer = null;
+    let signInClickAttempted = false;
+    let lastNavigationUrl = YOUTUBE_LOGIN_URL;
+
+    const loginWindow = new BrowserWindow({
+      width: 980,
+      height: 760,
+      minWidth: 780,
+      minHeight: 580,
+      parent: owner && !owner.isDestroyed() ? owner : undefined,
+      modal: false,
+      show: false,
+      autoHideMenuBar: true,
+      title: 'YouTube Music Login',
+      backgroundColor: '#111111',
+      icon: APP_ICON_ICO,
+      webPreferences: {
+        partition: YOUTUBE_LOGIN_PARTITION,
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+      },
+    });
+
+    const finish = async (result) => {
+      if (settled) return;
+      settled = true;
+      if (pollTimer) clearInterval(pollTimer);
+      if (loginWindow && !loginWindow.isDestroyed()) {
+        loginWindow.close();
+      }
+      resolve(result);
+    };
+
+    const currentLoginUrl = () => {
+      try {
+        const current = loginWindow && !loginWindow.isDestroyed() ? loginWindow.webContents.getURL() : '';
+        return current || lastNavigationUrl || YOUTUBE_LOGIN_URL;
+      } catch (e) {
+        return lastNavigationUrl || YOUTUBE_LOGIN_URL;
+      }
+    };
+
+    const isYoutubeReturnUrl = (rawUrl) => {
+      try {
+        const current = new URL(rawUrl || currentLoginUrl());
+        const host = current.hostname.replace(/^www\./, '').toLowerCase();
+        return host === 'music.youtube.com' || host === 'youtube.com' || host.endsWith('.youtube.com');
+      } catch (e) {
+        return false;
+      }
+    };
+
+    const shouldAutoClickSignIn = () => {
+      if (signInClickAttempted) return false;
+      try {
+        const current = new URL(loginWindow.webContents.getURL() || YOUTUBE_LOGIN_URL);
+        const host = current.hostname.replace(/^www\./, '').toLowerCase();
+        return host === 'music.youtube.com' || host === 'youtube.com' || host.endsWith('.youtube.com');
+      } catch (e) {
+        return false;
+      }
+    };
+
+    const checkCookies = async () => {
+      try {
+        const cookie = await readYoutubeLoginCookieHeader(cookieSession);
+        lastNavigationUrl = currentLoginUrl();
+        if (youtubeCookieHasLogin(cookie) && isYoutubeReturnUrl(lastNavigationUrl)) {
+          finish({ ok: true, cookie });
+        }
+      } catch (e) {
+        console.warn('YouTube login cookie check failed:', e.message);
+      }
+    };
+
+    loginWindow.webContents.setWindowOpenHandler(({ url }) => {
+      if (/^https?:\/\/([^/]+\.)?youtube\.com/i.test(url) || /^https?:\/\/accounts\.google\.com/i.test(url)) {
+        loginWindow.loadURL(url).catch((e) => console.warn('YouTube login popup navigation failed:', e.message));
+      } else if (/^https?:\/\//i.test(url)) {
+        shell.openExternal(url).catch(() => {});
+      }
+      return { action: 'deny' };
+    });
+
+    loginWindow.webContents.on('did-finish-load', () => {
+      lastNavigationUrl = currentLoginUrl();
+      checkCookies();
+      if (!shouldAutoClickSignIn()) return;
+      signInClickAttempted = true;
+      loginWindow.webContents.executeJavaScript(`
+        setTimeout(() => {
+          const nodes = Array.from(document.querySelectorAll('a, button, tp-yt-paper-button, ytmusic-button-renderer'));
+          const loginNode = nodes.find((node) => {
+            const text = (node.textContent || '').trim();
+            if (!/sign\\s*in|log\\s*in|login|登录|登入/i.test(text)) return false;
+            const rect = node.getBoundingClientRect();
+            return rect.width > 0 && rect.height > 0;
+          });
+          if (loginNode) loginNode.click();
+        }, 900);
+      `, true).catch(() => {});
+    });
+
+    loginWindow.webContents.on('did-navigate', (_event, navigationUrl) => {
+      lastNavigationUrl = navigationUrl || currentLoginUrl();
+      checkCookies();
+    });
+    loginWindow.webContents.on('did-navigate-in-page', (_event, navigationUrl) => {
+      lastNavigationUrl = navigationUrl || currentLoginUrl();
+      checkCookies();
+    });
+    loginWindow.on('ready-to-show', () => loginWindow.show());
+    loginWindow.on('closed', async () => {
+      if (settled) return;
+      if (pollTimer) clearInterval(pollTimer);
+      try {
+        const cookie = await readYoutubeLoginCookieHeader(cookieSession);
+        resolve(youtubeCookieHasLogin(cookie) && isYoutubeReturnUrl(lastNavigationUrl)
+          ? { ok: true, cookie }
+          : { ok: false, cancelled: true, message: 'YouTube Music login window closed' });
+      } catch (e) {
+        resolve({ ok: false, error: e.message || 'YouTube Music login window closed' });
+      }
+    });
+
+    pollTimer = setInterval(checkCookies, 1500);
+    loginWindow.loadURL(YOUTUBE_LOGIN_URL).catch((e) => finish({ ok: false, error: e.message }));
+  });
+}
+
 async function clearQQMusicLoginSession() {
   const cookieSession = session.fromPartition(QQ_LOGIN_PARTITION);
   await cookieSession.clearStorageData({
@@ -610,6 +787,14 @@ async function clearQQMusicLoginSession() {
 
 async function clearNeteaseMusicLoginSession() {
   const cookieSession = session.fromPartition(NETEASE_LOGIN_PARTITION);
+  await cookieSession.clearStorageData({
+    storages: ['cookies', 'localstorage', 'indexdb', 'cachestorage'],
+  });
+  return { ok: true };
+}
+
+async function clearYoutubeMusicLoginSession() {
+  const cookieSession = session.fromPartition(YOUTUBE_LOGIN_PARTITION);
   await cookieSession.clearStorageData({
     storages: ['cookies', 'localstorage', 'indexdb', 'cachestorage'],
   });
@@ -1176,6 +1361,14 @@ ipcMain.handle('qq-music-clear-login', async () => {
   return clearQQMusicLoginSession();
 });
 
+ipcMain.handle('youtube-music-open-login', async (event) => {
+  return openYoutubeMusicLoginWindow(getSenderWindow(event));
+});
+
+ipcMain.handle('youtube-music-clear-login', async () => {
+  return clearYoutubeMusicLoginSession();
+});
+
 ipcMain.handle('mineradio-open-update-installer', async (_event, filePath) => {
   try {
     const target = path.resolve(String(filePath || ''));
@@ -1327,6 +1520,7 @@ async function createWindow() {
   process.env.PORT = String(port);
   process.env.COOKIE_FILE = path.join(app.getPath('userData'), '.cookie');
   process.env.QQ_COOKIE_FILE = path.join(app.getPath('userData'), '.qq-cookie');
+  process.env.YOUTUBE_COOKIE_FILE = path.join(app.getPath('userData'), '.youtube-cookie');
   process.env.MINERADIO_UPDATE_DIR = getUpdateDownloadDir();
   try {
     const legacyQQCookie = path.join(__dirname, '..', '.qq-cookie');
@@ -1338,6 +1532,17 @@ async function createWindow() {
     }
   } catch (e) {
     console.warn('QQ cookie migration skipped:', e.message);
+  }
+  try {
+    const legacyYoutubeCookie = path.join(__dirname, '..', '.youtube-cookie');
+    if (fs.existsSync(legacyYoutubeCookie)) {
+      if (!fs.existsSync(process.env.YOUTUBE_COOKIE_FILE)) {
+        fs.copyFileSync(legacyYoutubeCookie, process.env.YOUTUBE_COOKIE_FILE);
+      }
+      fs.unlinkSync(legacyYoutubeCookie);
+    }
+  } catch (e) {
+    console.warn('YouTube cookie migration skipped:', e.message);
   }
 
   localServer = require(path.join(__dirname, '..', 'server.js'));

--- a/desktop/preload.js
+++ b/desktop/preload.js
@@ -12,6 +12,8 @@ contextBridge.exposeInMainWorld('desktopWindow', {
   clearNeteaseMusicLogin: () => ipcRenderer.invoke('netease-music-clear-login'),
   openQQMusicLogin: () => ipcRenderer.invoke('qq-music-open-login'),
   clearQQMusicLogin: () => ipcRenderer.invoke('qq-music-clear-login'),
+  openYoutubeMusicLogin: () => ipcRenderer.invoke('youtube-music-open-login'),
+  clearYoutubeMusicLogin: () => ipcRenderer.invoke('youtube-music-clear-login'),
   openUpdateInstaller: (filePath) => ipcRenderer.invoke('mineradio-open-update-installer', filePath),
   restartApp: () => ipcRenderer.invoke('mineradio-restart-app'),
   configureGlobalHotkeys: (bindings) => ipcRenderer.invoke('mineradio-hotkeys-configure-global', bindings || []),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,37 @@
       "name": "mineradio",
       "version": "1.1.1",
       "dependencies": {
+        "ffmpeg-static": "^5.3.0",
         "gsap": "^3.15.0",
         "mpg123-decoder": "^1.0.3",
-        "NeteaseCloudMusicApi": "^4.32.0"
+        "NeteaseCloudMusicApi": "^4.32.0",
+        "youtubei.js": "^17.2.0"
       },
       "devDependencies": {
         "electron": "^42.4.1",
         "electron-builder": "^26.15.3",
         "rcedit": "^5.0.2"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.12.1.tgz",
+      "integrity": "sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "license": "MIT",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/@electron-internal/extract-zip": {
@@ -1037,7 +1060,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/builder-util": {
@@ -1181,6 +1203,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1310,6 +1338,35 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/content-disposition": {
       "version": "0.5.4",
@@ -2313,6 +2370,37 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
+    "node_modules/ffmpeg-static": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ffmpeg-static/-/ffmpeg-static-5.3.0.tgz",
+      "integrity": "sha512-H+K6sW6TiIX6VGend0KQwthe+kaceeH/luE8dIZyOP35ik7ahYojDuqlTV1bOrtEwl01sy2HFNGQfi5IDJvotg==",
+      "hasInstallScript": true,
+      "license": "GPL-3.0-or-later",
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/file-type": {
       "version": "16.5.4",
       "license": "MIT",
@@ -2798,6 +2886,21 @@
         "node": ">= 14"
       }
     },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "license": "MIT"
+    },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
@@ -3159,6 +3262,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/methods": {
@@ -3665,6 +3777,11 @@
         "node": ">= 14"
       }
     },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "license": "MIT",
@@ -3870,7 +3987,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
@@ -4752,6 +4868,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
     "node_modules/undici": {
       "version": "7.28.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
@@ -4827,7 +4949,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/utils-merge": {
@@ -4968,6 +5089,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/youtubei.js": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/youtubei.js/-/youtubei.js-17.2.0.tgz",
+      "integrity": "sha512-XLNsgRKO1h7t4i9tIMWSQSeWdD7Ujkk5v1m5YCaumaHMhu/xuLqtO3M0Hq7CXNup9HlJ1NGrT1Y+HLIHnL6Ujg==",
+      "funding": [
+        "https://github.com/sponsors/LuanRT"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.0.0",
+        "fflate": "^0.8.2",
+        "meriyah": "^6.1.4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -84,9 +84,11 @@
     }
   },
   "dependencies": {
+    "ffmpeg-static": "^5.3.0",
     "gsap": "^3.15.0",
     "mpg123-decoder": "^1.0.3",
-    "NeteaseCloudMusicApi": "^4.32.0"
+    "NeteaseCloudMusicApi": "^4.32.0",
+    "youtubei.js": "^17.2.0"
   },
   "devDependencies": {
     "electron": "^42.4.1",

--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@ try {
 html,body{font-family:var(--font-sans);background:#000;color:#fff;overflow:hidden;height:100vh;width:100vw;user-select:none;-webkit-font-smoothing:antialiased}
 body.cursor-hidden,body.cursor-hidden *{cursor:none!important}
 html.desktop-shell-root,html.desktop-shell-root body{background:transparent}
-:root{--font-sans:"Noto Sans SC","PingFang SC","HarmonyOS Sans SC","Alibaba PuHuiTi","Inter",-apple-system,BlinkMacSystemFont,system-ui,sans-serif;--font-mono:"JetBrains Mono","Geist Mono","SF Mono",ui-monospace,monospace;--fc-bg:#08090B;--fc-paper:#0E1014;--fc-ink:#E8ECEF;--fc-ink-2:#D2D7DC;--fc-muted:#8A9099;--fc-hair:#1A1D22;--fc-hair-2:#262A31;--fc-accent:#00F5D4;--fc-accent-hov:#00E0BE;--fc-accent-rgb:0,245,212;--fc-blue:#2442ff;--fc-warm:#f8f4ee;--chill-ink:#030608;--chill-deep:#061116;--chill-cyan:#8fe9ff;--chill-blue:#73a7ff;--chill-mint:#9cffdf;--chill-soft:rgba(214,248,255,.9);--champagne:#f4d28a;--champagne-deep:#9a6f2c;--home-accent:#00f5d4;--home-accent-rgb:0,245,212;--visual-tint:#9db8cf;--source-netease:#d95b67;--source-qq:#00F5D4;--source-local:#9db8cf}
+:root{--font-sans:"Noto Sans SC","PingFang SC","HarmonyOS Sans SC","Alibaba PuHuiTi","Inter",-apple-system,BlinkMacSystemFont,system-ui,sans-serif;--font-mono:"JetBrains Mono","Geist Mono","SF Mono",ui-monospace,monospace;--fc-bg:#08090B;--fc-paper:#0E1014;--fc-ink:#E8ECEF;--fc-ink-2:#D2D7DC;--fc-muted:#8A9099;--fc-hair:#1A1D22;--fc-hair-2:#262A31;--fc-accent:#00F5D4;--fc-accent-hov:#00E0BE;--fc-accent-rgb:0,245,212;--fc-blue:#2442ff;--fc-warm:#f8f4ee;--chill-ink:#030608;--chill-deep:#061116;--chill-cyan:#8fe9ff;--chill-blue:#73a7ff;--chill-mint:#9cffdf;--chill-soft:rgba(214,248,255,.9);--champagne:#f4d28a;--champagne-deep:#9a6f2c;--home-accent:#00f5d4;--home-accent-rgb:0,245,212;--visual-tint:#9db8cf;--source-netease:#d95b67;--source-qq:#00F5D4;--source-youtube:#ff4d5f;--source-local:#9db8cf}
 :root{--glass-bg:linear-gradient(112deg,rgba(72,74,76,.62),rgba(24,27,30,.70) 48%,rgba(8,12,14,.74));--glass-bg-focus:linear-gradient(112deg,rgba(88,91,92,.68),rgba(28,32,35,.76) 50%,rgba(8,13,15,.82));--glass-border:rgba(0,245,212,.30);--glass-border-soft:rgba(255,255,255,.095);--glass-shadow:0 22px 64px rgba(0,0,0,.30),0 0 34px rgba(0,245,212,.052),inset 0 1px 0 rgba(255,255,255,.16),inset 0 -24px 58px rgba(0,0,0,.16);--glass-shadow-focus:0 24px 72px rgba(0,0,0,.34),0 0 0 1px rgba(0,245,212,.13),0 0 42px rgba(0,245,212,.075),inset 0 1px 0 rgba(255,255,255,.20)}
 :root{--saved-panel-glass-bg:rgba(0,0,0,.10);--saved-panel-glass-filter:blur(12px) saturate(1.8) brightness(1.16);--saved-panel-glass-svg-filter:url(#mineradio-control-glass-filter) saturate(1);--saved-panel-glass-shadow:inset 0 0 2px 1px rgba(255,255,255,.35),inset 0 0 10px 4px rgba(255,255,255,.15),0 4px 16px rgba(17,17,26,.05),0 8px 24px rgba(17,17,26,.05),0 16px 56px rgba(17,17,26,.05),inset 0 4px 16px rgba(17,17,26,.05),inset 0 8px 24px rgba(17,17,26,.05),inset 0 16px 56px rgba(17,17,26,.05);--saved-panel-glass-radius:50px;--saved-button-glass-bg:rgba(0,0,0,.10);--saved-button-glass-filter:blur(12px) saturate(1.8) brightness(1.16);--saved-button-glass-svg-filter:url(#mineradio-control-glass-filter) saturate(1);--saved-button-glass-shadow:inset 0 0 2px 1px rgba(255,255,255,.34),inset 0 0 10px 4px rgba(255,255,255,.13),0 10px 30px rgba(0,0,0,.18);--saved-button-glass-hover-bg:rgba(255,255,255,.055);--saved-button-glass-hover-shadow:inset 0 0 2px 1px rgba(255,255,255,.42),inset 0 0 12px 5px rgba(255,255,255,.17),0 12px 34px rgba(0,0,0,.22),0 0 18px rgba(255,255,255,.06)}
 :root{--home-icon-color:#f4d28a;--home-icon-rgb:244,210,138;--visual-icon-color:#7fd8ff;--visual-icon-rgb:127,216,255}
@@ -196,8 +196,10 @@ body.empty-home-active.diy-mode #search-area:not(.has-results) #search-mode-tabs
 .tag-source{display:inline-flex;align-items:center;height:16px;padding:0 6px;border-radius:999px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.045);font-size:8.5px;font-weight:800;letter-spacing:.55px;line-height:1;flex-shrink:0}
 .tag-source.netease{color:#ffd8dd;border-color:rgba(217,91,103,.30);background:rgba(217,91,103,.075)}
 .tag-source.qq{color:#f0ffc8;border-color:rgba(191,214,107,.30);background:rgba(191,214,107,.075)}
+.tag-source.youtube{color:#ffd9df;border-color:rgba(255,77,95,.34);background:rgba(255,77,95,.085)}
 .search-result.qq-source:hover{background:rgba(191,214,107,.052)}
 .search-result.netease-source:hover{background:rgba(217,91,103,.045)}
+.search-result.youtube-source:hover{background:rgba(255,77,95,.050)}
 .podcast-result-head{display:flex;align-items:center;gap:10px;padding:11px 13px 9px;border-bottom:1px solid rgba(255,255,255,.04);background:rgba(255,255,255,.025)}
 .podcast-result-head img{width:40px;height:40px;border-radius:7px;object-fit:cover;background:rgba(255,255,255,.05);flex-shrink:0}
 .podcast-back-btn{width:28px;height:28px;border-radius:50%;border:1px solid rgba(255,255,255,.10);background:rgba(255,255,255,.045);color:rgba(255,255,255,.66);cursor:pointer;font-family:inherit;font-size:18px;line-height:1;display:flex;align-items:center;justify-content:center;transition:all .2s}
@@ -453,6 +455,7 @@ body.desktop-shell.empty-home-active.controls-visible #empty-home{bottom:126px}
 .account-source-dot{width:7px;height:7px;border-radius:50%;background:var(--source-local);box-shadow:0 0 12px currentColor;flex-shrink:0}
 .account-source-dot.netease{background:var(--source-netease);color:var(--source-netease)}
 .account-source-dot.qq{background:var(--source-qq);color:var(--source-qq)}
+.account-source-dot.youtube{background:var(--source-youtube);color:var(--source-youtube)}
 .top-account-pill{height:44px;min-width:0;display:flex;align-items:center;gap:8px;padding:0 14px 0 4px;border-radius:24px;border:1px solid rgba(244,210,138,.52);background:rgba(244,210,138,.07);box-shadow:0 0 0 1px rgba(244,210,138,.08),0 14px 42px rgba(0,0,0,.28),inset 0 1px 0 rgba(255,255,255,.08);transition:background .22s,border-color .22s,box-shadow .22s,transform .22s}
 #user-btn.multi-account:hover .top-account-pill{background:rgba(244,210,138,.10);border-color:rgba(244,210,138,.62);box-shadow:0 0 0 1px rgba(244,210,138,.10),0 16px 44px rgba(0,0,0,.32),inset 0 1px 0 rgba(255,255,255,.10)}
 .top-account-pill img{width:34px;height:34px;border-radius:50%;object-fit:cover;background:rgba(255,255,255,.08);flex-shrink:0}
@@ -802,18 +805,22 @@ body.login-guide-active #login-guide-canvas{opacity:1}
 .login-platform-tabs button.active,.user-platform-tabs button.active{color:#fff;box-shadow:inset 0 0 0 1px rgba(255,255,255,.08),0 10px 26px rgba(0,0,0,.20)}
 .login-platform-tabs button.netease.active,.user-platform-tabs button.netease.active{background:rgba(217,91,103,.16);color:#ffd7dc}
 .login-platform-tabs button.qq.active,.user-platform-tabs button.qq.active{background:rgba(191,214,107,.16);color:#f3ffd1}
+.login-platform-tabs button.youtube.active,.user-platform-tabs button.youtube.active{background:rgba(255,77,95,.16);color:#ffd9df}
 .user-platform-tabs button.both.active{background:rgba(244,210,138,.14);color:#fff0bf}
 .qr-shell{position:relative;width:200px;height:200px;margin:0 auto 16px;border-radius:16px}
 #qr-img{width:200px;height:200px;background:#fff;border-radius:14px;margin:0 auto 16px;display:block;padding:10px;box-shadow:0 16px 42px rgba(0,0,0,.32),0 0 0 1px rgba(244,210,138,.18)}
 .qr-shell #qr-img{margin:0}
 .qr-shell.web-login-preview{display:flex;align-items:center;justify-content:center;padding:14px;background:radial-gradient(circle at 50% 42%,rgba(191,214,107,.22),transparent 46%),rgba(255,255,255,.035);border:1px solid rgba(191,214,107,.26);box-shadow:0 16px 42px rgba(0,0,0,.32),inset 0 1px 0 rgba(255,255,255,.08)}
 .qr-shell.web-login-preview.netease-preview{background:radial-gradient(circle at 50% 42%,rgba(217,91,103,.22),transparent 46%),rgba(255,255,255,.035);border-color:rgba(217,91,103,.28)}
+.qr-shell.web-login-preview.youtube-preview{background:radial-gradient(circle at 50% 42%,rgba(255,77,95,.22),transparent 46%),rgba(255,255,255,.035);border-color:rgba(255,77,95,.30)}
 .qr-shell.web-login-preview #qr-img{display:none}
 .qq-login-mark{display:none;width:100%;height:100%;border-radius:12px;border:1px solid rgba(191,214,107,.30);align-items:center;justify-content:center;flex-direction:column;gap:8px;color:rgba(243,255,209,.88);background:linear-gradient(135deg,rgba(191,214,107,.10),rgba(157,184,207,.05));cursor:pointer;font-family:inherit;outline:none;transition:transform .22s,border-color .22s,background .22s,box-shadow .22s}
 .qr-shell.web-login-preview .qq-login-mark{display:flex}
 .qq-login-mark:hover{transform:translateY(-1px);border-color:rgba(191,214,107,.54);background:linear-gradient(135deg,rgba(191,214,107,.16),rgba(157,184,207,.08));box-shadow:inset 0 1px 0 rgba(255,255,255,.10),0 16px 38px rgba(0,0,0,.22)}
 .qr-shell.netease-preview .qq-login-mark{border-color:rgba(217,91,103,.34);color:#ffd7dc;background:linear-gradient(135deg,rgba(217,91,103,.10),rgba(244,210,138,.05))}
 .qr-shell.netease-preview .qq-login-mark:hover{border-color:rgba(217,91,103,.58);background:linear-gradient(135deg,rgba(217,91,103,.16),rgba(244,210,138,.08))}
+.qr-shell.youtube-preview .qq-login-mark{border-color:rgba(255,77,95,.38);color:#ffd9df;background:linear-gradient(135deg,rgba(255,77,95,.11),rgba(255,255,255,.04))}
+.qr-shell.youtube-preview .qq-login-mark:hover{border-color:rgba(255,77,95,.62);background:linear-gradient(135deg,rgba(255,77,95,.17),rgba(255,255,255,.07))}
 .qq-login-mark:disabled{opacity:.66;cursor:wait;transform:none}
 .qq-login-mark b{font-size:22px;letter-spacing:.08em}
 .qq-login-mark span{font-size:10.5px;color:rgba(255,255,255,.46);letter-spacing:.5px}
@@ -833,7 +840,8 @@ body.login-guide-active #login-guide-canvas{opacity:1}
 .account-provider-chip{display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 9px;margin-bottom:10px;border-radius:999px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.035);font-size:10.5px;letter-spacing:.5px;color:rgba(255,255,255,.58)}
 .account-provider-chip.netease{border-color:rgba(217,91,103,.26);color:#ffd7dc;background:rgba(217,91,103,.08)}
 .account-provider-chip.qq{border-color:rgba(191,214,107,.26);color:#f3ffd1;background:rgba(191,214,107,.08)}
-.account-modal-actions{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:14px}
+.account-provider-chip.youtube{border-color:rgba(255,77,95,.28);color:#ffd9df;background:rgba(255,77,95,.08)}
+.account-modal-actions{display:grid;grid-template-columns:repeat(auto-fit,minmax(118px,1fr));gap:8px;margin-top:14px}
 .account-modal-actions .modal-btn{padding:8px 10px}
 .account-hint{margin-top:10px;font-size:11px;line-height:1.45;color:rgba(255,255,255,.38)}
 .modal .btn-row{display:flex;gap:10px;justify-content:center;margin-top:16px}
@@ -1910,6 +1918,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
       <button id="search-mode-song" class="active" type="button" onclick="setSearchMode('song')" aria-selected="true">All</button>
       <button id="search-mode-netease" type="button" onclick="setSearchMode('netease')" aria-selected="false">NE</button>
       <button id="search-mode-qq" type="button" onclick="setSearchMode('qq')" aria-selected="false">QQ</button>
+      <button id="search-mode-youtube" type="button" onclick="setSearchMode('youtube')" aria-selected="false">YT</button>
       <button id="search-mode-podcast" type="button" onclick="setSearchMode('podcast')" aria-selected="false">Podcast</button>
     </div>
     <div id="search-results"></div>
@@ -2420,11 +2429,11 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
       <div id="quality-control" class="quality-control">
         <button id="quality-btn" class="ctrl-btn quality-pill" onclick="toggleQualityPanel(event)" title="音质"><span id="quality-btn-label">臻音</span></button>
         <div class="quality-popover" onclick="event.stopPropagation()">
-          <button class="quality-option svip-only" data-quality="jymaster" data-svip="1" onclick="setPlaybackQuality('jymaster')"><span>超清母带</span><small>SVIP / 最高规格</small></button>
-          <button class="quality-option" data-quality="hires" onclick="setPlaybackQuality('hires')"><span>高清臻音</span><small>默认 / 细节优先</small></button>
-          <button class="quality-option" data-quality="lossless" onclick="setPlaybackQuality('lossless')"><span>无损 SQ</span><small>FLAC 优先</small></button>
-          <button class="quality-option" data-quality="exhigh" onclick="setPlaybackQuality('exhigh')"><span>极高 HQ</span><small>320kbps</small></button>
-          <button class="quality-option" data-quality="standard" onclick="setPlaybackQuality('standard')"><span>标准</span><small>128kbps</small></button>
+          <button class="quality-option svip-only" data-quality="jymaster" data-svip="1" onclick="setPlaybackQuality(this.dataset.quality)"><span>超清母带</span><small>SVIP / 最高规格</small></button>
+          <button class="quality-option" data-quality="hires" onclick="setPlaybackQuality(this.dataset.quality)"><span>高清臻音</span><small>默认 / 细节优先</small></button>
+          <button class="quality-option" data-quality="lossless" onclick="setPlaybackQuality(this.dataset.quality)"><span>无损 SQ</span><small>FLAC 优先</small></button>
+          <button class="quality-option" data-quality="exhigh" onclick="setPlaybackQuality(this.dataset.quality)"><span>极高 HQ</span><small>320kbps</small></button>
+          <button class="quality-option" data-quality="standard" onclick="setPlaybackQuality(this.dataset.quality)"><span>标准</span><small>128kbps</small></button>
         </div>
       </div>
       <button id="heart-btn" class="ctrl-btn" onclick="toggleLikeCurrent()" title="红心喜欢"><svg class="heart-svg" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 21.45c-.32 0-.62-.12-.86-.34l-1.23-1.12C5.54 16.03 2.25 13.05 2.25 8.9 2.25 5.48 4.88 2.9 8.28 2.9c1.7 0 3.35.72 4.52 1.96C13.97 3.62 15.62 2.9 17.32 2.9c3.4 0 6.03 2.58 6.03 6 0 4.15-3.29 7.13-7.66 11.09l-1.23 1.12c-.24.22-.54.34-.86.34z"/></svg></button>
@@ -2468,6 +2477,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
     <div class="login-platform-tabs" id="login-platform-tabs">
       <button id="login-provider-netease" class="netease active" type="button" onclick="setLoginProvider('netease')">网易云</button>
       <button id="login-provider-qq" class="qq" type="button" onclick="setLoginProvider('qq')">QQ 音乐</button>
+      <button id="login-provider-youtube" class="youtube" type="button" onclick="setLoginProvider('youtube')">YouTube</button>
     </div>
     <div class="login-intro">
       <div class="login-intro-kicker">Mineradio</div>
@@ -2491,7 +2501,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
     <div class="btn-row">
       <button class="modal-btn" onclick="closeLoginModal()">取消</button>
       <button class="modal-btn" onclick="skipLoginAndFocusSearch()">先搜索一首歌</button>
-      <button id="login-both-btn" class="modal-btn" onclick="requestDualLoginMode()">我两个都要</button>
+      <button id="login-both-btn" class="modal-btn" onclick="requestDualLoginMode()">我全都要</button>
       <button id="qq-cookie-toggle-btn" class="modal-btn" type="button" onclick="toggleQQCookiePanel()">手动导入</button>
       <button id="refresh-qr-btn" class="modal-btn primary" onclick="refreshQr()">刷新二维码</button>
     </div>
@@ -2509,13 +2519,15 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
     <div class="user-platform-tabs" id="user-platform-tabs">
       <button id="user-provider-netease" class="netease active" type="button" onclick="setActiveAccountProvider('netease')">网易云</button>
       <button id="user-provider-qq" class="qq" type="button" onclick="setActiveAccountProvider('qq')">QQ 音乐</button>
-      <button id="user-provider-both" class="both" type="button" onclick="enableDualAccountView()">我两个都要</button>
+      <button id="user-provider-youtube" class="youtube" type="button" onclick="setActiveAccountProvider('youtube')">YouTube</button>
+      <button id="user-provider-both" class="both" type="button" onclick="enableDualAccountView()">我全都要</button>
     </div>
     <div class="account-modal-actions">
       <button id="account-add-netease" class="modal-btn" onclick="openProviderLogin('netease')">补登网易云</button>
       <button id="account-add-qq" class="modal-btn" onclick="openProviderLogin('qq')">补登 QQ 音乐</button>
+      <button id="account-add-youtube" class="modal-btn" onclick="openProviderLogin('youtube')">补登 YouTube</button>
     </div>
-    <div id="account-hint" class="account-hint">QQ 音乐真实登录暂未接入，当前先预览双平台账号交互。</div>
+    <div id="account-hint" class="account-hint">可切换右上角展示的平台；“我全都要”会并排放已登录状态。</div>
     <div class="btn-row">
       <button class="modal-btn" onclick="closeUserModal()">关闭</button>
       <button id="account-logout-btn" class="modal-btn primary" onclick="logoutActiveAccount()">退出当前平台</button>
@@ -2696,12 +2708,16 @@ var loginStatus = { loggedIn: false, vipType: 0, vipLevel: 'none', isVip: false,
 var qqLoginStatus = { provider: 'qq', loggedIn: false, preview: false, nickname: 'QQ 音乐', userId: '', avatar: '', vipType: 0 };
 var qqLoginAutoRefreshTimer = null;
 var qqLoginWasLoggedIn = false;
+var youtubeLoginStatus = { provider: 'youtube', loggedIn: false, nickname: 'YouTube Music', userId: '', avatar: '', stale: false };
+var youtubeLoginAutoRefreshTimer = null;
+var youtubeLoginWasLoggedIn = false;
 var loginProvider = 'netease';
 var activeAccountProvider = 'netease';
 var dualAccountMode = false;
 var qqCookieBusy = false;
 var neteaseWebLoginBusy = false;
 var qqWebLoginBusy = false;
+var youtubeWebLoginBusy = false;
 var qqManualCookieOpen = false;
 var loginStatusChecked = false, loginStatusCheckFailed = false;
 var qrPollTimer = null, qrKey = null;
@@ -2710,13 +2726,14 @@ var audioFadeTimer = null, audioElementFadeFrame = 0, audioFadeSerial = 0;
 var AUDIO_FADE_IN_MS = 460;
 var AUDIO_FADE_OUT_MS = 420;
 var AUDIO_SILENCE_GAIN = 0.0001;
-var userPlaylists = [], qqPlaylists = [], myPodcastCollections = [], myPodcastItems = {}, playlistCoverCache = {};
+var userPlaylists = [], qqPlaylists = [], youtubePlaylists = [], myPodcastCollections = [], myPodcastItems = {}, playlistCoverCache = {};
 var CUSTOM_COVER_STORE_KEY = 'mineradio-custom-covers';
 var CUSTOM_LYRIC_STORE_KEY = 'mineradio-custom-lyrics-v1';
 var CUSTOM_LYRIC_PREF_STORE_KEY = 'mineradio-custom-lyric-prefs-v1';
 var LYRIC_LAYOUT_STORE_KEY = 'mineradio-lyric-layout-v1';
 var VISUAL_PRESET_SCHEMA = 'skull-preset-v2';
 var PLAYBACK_QUALITY_STORE_KEY = 'mineradio-playback-quality-v1';
+var YOUTUBE_PLAYBACK_QUALITY_STORE_KEY = 'mineradio-youtube-playback-quality-v1';
 var UPLOAD_TIP_STORE_KEY = 'mineradio-upload-tip-seen';
 var DIY_MODE_STORE_KEY = 'mineradio-diy-player-mode-v1';
 var PLAYLIST_PANEL_PIN_STORE_KEY = 'mineradio-playlist-panel-pinned-v1';
@@ -2747,6 +2764,7 @@ var customLyricPrefs = readCustomLyricPrefs();
 var localBeatMapCache = readLocalBeatMapCache();
 var localBeatMapPrefs = readLocalBeatPrefs();
 var playbackQuality = readPlaybackQualityPreference();
+var youtubePlaybackQuality = readYoutubePlaybackQualityPreference();
 var qqPlaybackQualityCeiling = '';
 var coverCropState = null, coverCropBound = false;
 var currentLocalSong = null;
@@ -10201,6 +10219,7 @@ function beatMapSongKey(song) {
   if (!song) return '';
   if (song.type === 'local' && song.localKey) return 'local:' + song.localKey;
   if (songProviderKey(song) === 'qq') return 'qq:' + (song.mid || song.songmid || song.id || (song.name + '|' + song.artist));
+  if (songProviderKey(song) === 'youtube') return 'youtube:' + (song.videoId || song.id || (song.name + '|' + song.artist));
   if (song.id != null && song.id !== '') return 'song:' + song.id;
   return '';
 }
@@ -10308,15 +10327,23 @@ function normalizeBeatPrefetchState(state) {
 
 async function fetchBeatPrefetchAudioUrl(song) {
   if (!song) return null;
-  var isQQ = songProviderKey(song) === 'qq';
-  var requestedQuality = normalizePlaybackQuality(playbackQuality);
-  if (!isQQ && requestedQuality === 'jymaster' && !hasProviderSvip('netease', loginStatus)) requestedQuality = 'hires';
+  var provider = songProviderKey(song);
+  var isQQ = provider === 'qq';
+  var isYoutube = provider === 'youtube';
+  var requestedQuality = isYoutube ? normalizeYoutubePlaybackQuality(youtubePlaybackQuality) : normalizePlaybackQuality(playbackQuality);
+  if (provider === 'netease' && requestedQuality === 'jymaster' && !hasProviderSvip('netease', loginStatus)) requestedQuality = 'hires';
   if (isQQ && qqPlaybackQualityCeiling && (requestedQuality === 'jymaster' || requestedQuality === 'hires' || requestedQuality === 'lossless')) requestedQuality = qqPlaybackQualityCeiling;
   var qualityParam = '&quality=' + encodeURIComponent(requestedQuality);
   var data = isQQ
     ? await apiJson('/api/qq/song/url?mid=' + encodeURIComponent(song.mid || song.songmid || song.id || '') + '&mediaMid=' + encodeURIComponent(song.mediaMid || song.media_mid || '') + qualityParam)
-    : await apiJson('/api/song/url?id=' + encodeURIComponent(song.id) + qualityParam);
+    : (isYoutube
+      ? await apiJson('/api/youtube/song/url?videoId=' + encodeURIComponent(song.videoId || song.id || '') + qualityParam)
+      : await apiJson('/api/song/url?id=' + encodeURIComponent(song.id) + qualityParam));
   if (!data || !data.url || data.trial) return null;
+  if (isYoutube) {
+    var durationHint = playbackDurationFromSong(song);
+    return prepareYoutubeAudioProxyUrl(data.url, song, requestedQuality, durationHint);
+  }
   return '/api/audio?url=' + encodeURIComponent(data.url);
 }
 
@@ -13020,10 +13047,10 @@ function makeShelfManager() {
     if (hasAnyPlatformLogin() && (userPlaylists.length || myPodcastCollections.length)) {
       var source = activePlaylists();
       var items = source.map(function(pl){
-        var provider = pl.provider === 'qq' ? 'qq' : 'netease';
-        var sourceLabel = provider === 'qq' ? 'QQ' : 'NE';
+        var provider = pl.provider === 'youtube' ? 'youtube' : (pl.provider === 'qq' ? 'qq' : 'netease');
+        var sourceLabel = provider === 'youtube' ? 'YT' : (provider === 'qq' ? 'QQ' : 'NE');
         return { type:'playlist', title: pl.name, sub:sourceLabel + ' · ' + (pl.trackCount||0)+' 首 · 播放 '+compactCount(pl.playCount||0),
-          cover: pl.cover || '', tag: pl.subscribed ? '收藏歌单' : '我的歌单', playlistId: (provider === 'qq' ? 'qq:' : '') + pl.id, provider: provider };
+          cover: pl.cover || '', tag: pl.subscribed ? '收藏歌单' : '我的歌单', playlistId: playlistPanelProviderId(provider, pl.id), provider: provider };
       });
       if (shelfShowsPodcasts() && (shelfPane === 'mine' || shelfMergesCollections()) && myPodcastCollections.length) {
         myPodcastCollections.forEach(function(pc){
@@ -14410,15 +14437,18 @@ function makeContentListManager() {
       }
       var podcastCollectionKey = String(playlistId || '').indexOf('podcast:') === 0 ? String(playlistId).slice(8) : '';
       var qqPlaylistId = String(playlistId || '').indexOf('qq:') === 0 ? String(playlistId).slice(3) : '';
+      var youtubePlaylistId = String(playlistId || '').indexOf('youtube:') === 0 ? String(playlistId).slice(8) : '';
       contentKind = podcastCollectionKey ? 'podcast' : 'playlist';
       // 拉取歌单/播客集合
       var r = null;
       try {
         r = podcastCollectionKey
           ? await apiJson('/api/podcast/my/items?key=' + encodeURIComponent(podcastCollectionKey) + '&limit=36')
-          : (qqPlaylistId
-            ? await apiJson('/api/qq/playlist/tracks?id=' + encodeURIComponent(qqPlaylistId))
-            : await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(playlistId)));
+          : (youtubePlaylistId
+            ? await apiJson('/api/youtube/playlist/tracks?id=' + encodeURIComponent(youtubePlaylistId))
+            : (qqPlaylistId
+              ? await apiJson('/api/qq/playlist/tracks?id=' + encodeURIComponent(qqPlaylistId))
+              : await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(playlistId))));
       } catch (e) {
         if (!open || token !== requestToken) return;
         console.warn('[ShelfContentLoadApi]', playlistId, e);
@@ -15097,6 +15127,19 @@ async function apiJson(url, opts) {
     if (timer) clearTimeout(timer);
   }
 }
+function youtubeAudioPrepareEndpoint(dataUrl, song, requestedQuality, durationHint) {
+  return '/api/youtube/audio/prepare?url=' + encodeURIComponent(dataUrl)
+    + '&videoId=' + encodeURIComponent(song && (song.videoId || song.id) || '')
+    + '&quality=' + encodeURIComponent(requestedQuality || youtubePlaybackQuality)
+    + (durationHint ? ('&duration=' + encodeURIComponent(durationHint)) : '');
+}
+async function prepareYoutubeAudioProxyUrl(dataUrl, song, requestedQuality, durationHint) {
+  var prepared = await apiJson(youtubeAudioPrepareEndpoint(dataUrl, song, requestedQuality, durationHint));
+  if (!prepared || !prepared.ready || !prepared.url) {
+    throw new Error((prepared && prepared.error) || 'YouTube audio prepare failed');
+  }
+  return prepared.url;
+}
 function escHtml(s){ var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
 function normalizePlaybackQuality(value) {
   value = String(value || '').toLowerCase();
@@ -15107,6 +15150,12 @@ function normalizePlaybackQuality(value) {
   if (value === 'standard' || value === 'normal' || value === 'std') return 'standard';
   return 'hires';
 }
+function normalizeYoutubePlaybackQuality(value) {
+  value = String(value || '').toLowerCase();
+  if (value === 'youtube-low' || value === 'yt-low' || value === 'low' || value === 'standard' || value === 'std') return 'youtube-low';
+  if (value === 'youtube-high' || value === 'yt-high' || value === 'high' || value === 'best' || value === 'hires') return 'youtube-high';
+  return 'youtube-auto';
+}
 function playbackQualityLabel(value) {
   value = normalizePlaybackQuality(value);
   if (value === 'jymaster') return '超清母带';
@@ -15116,6 +15165,12 @@ function playbackQualityLabel(value) {
   if (value === 'standard') return '标准';
   return '高清臻音';
 }
+function youtubePlaybackQualityLabel(value) {
+  value = normalizeYoutubePlaybackQuality(value);
+  if (value === 'youtube-high') return 'YouTube 高音质';
+  if (value === 'youtube-low') return 'YouTube 省流';
+  return 'YouTube 自动';
+}
 function playbackQualityShortLabel(value) {
   value = normalizePlaybackQuality(value);
   if (value === 'jymaster') return '母带';
@@ -15124,6 +15179,28 @@ function playbackQualityShortLabel(value) {
   if (value === 'exhigh') return 'HQ';
   if (value === 'standard') return 'STD';
   return '臻音';
+}
+function youtubePlaybackQualityShortLabel(value) {
+  value = normalizeYoutubePlaybackQuality(value);
+  if (value === 'youtube-high') return 'YT-H';
+  if (value === 'youtube-low') return 'YT-L';
+  return 'YT-A';
+}
+function qualityProviderForCurrentTrack() {
+  var song = currentIdx >= 0 && currentIdx < playQueue.length ? playQueue[currentIdx] : null;
+  if (songProviderKey(song) === 'youtube') return 'youtube';
+  if (!song && activeAccountProvider === 'youtube') return 'youtube';
+  return 'default';
+}
+function activePlaybackQualityLabel(value) {
+  return qualityProviderForCurrentTrack() === 'youtube'
+    ? youtubePlaybackQualityLabel(value || youtubePlaybackQuality)
+    : playbackQualityLabel(value || playbackQuality);
+}
+function activePlaybackQualityShortLabel(value) {
+  return qualityProviderForCurrentTrack() === 'youtube'
+    ? youtubePlaybackQualityShortLabel(value || youtubePlaybackQuality)
+    : playbackQualityShortLabel(value || playbackQuality);
 }
 function playbackQualityRank(value) {
   value = normalizePlaybackQuality(value);
@@ -15145,6 +15222,9 @@ function playbackBitrateLabel(br) {
 }
 function playbackResolvedQualityText(data) {
   data = data || {};
+  if (data.provider === 'youtube' || /^youtube-/i.test(String(data.level || ''))) {
+    return data.quality || ('YouTube Music' + (data.br ? (' · ' + playbackBitrateLabel(data.br)) : ''));
+  }
   var label = playbackQualityLabel(data.level || data.quality || playbackQuality);
   var br = playbackBitrateLabel(data.br);
   return br ? (label + ' · ' + br) : label;
@@ -15156,28 +15236,83 @@ function readPlaybackQualityPreference() {
     return 'hires';
   }
 }
+function readYoutubePlaybackQualityPreference() {
+  try {
+    return normalizeYoutubePlaybackQuality(localStorage.getItem(YOUTUBE_PLAYBACK_QUALITY_STORE_KEY) || 'youtube-auto');
+  } catch (e) {
+    return 'youtube-auto';
+  }
+}
 function savePlaybackQualityPreference() {
   try { localStorage.setItem(PLAYBACK_QUALITY_STORE_KEY, playbackQuality); } catch (e) {}
+}
+function saveYoutubePlaybackQualityPreference() {
+  try { localStorage.setItem(YOUTUBE_PLAYBACK_QUALITY_STORE_KEY, youtubePlaybackQuality); } catch (e) {}
+}
+var DEFAULT_QUALITY_OPTIONS = [
+  { quality: 'jymaster', label: '超清母带', sub: 'SVIP / 最高规格', svip: true },
+  { quality: 'hires', label: '高清臻音', sub: '默认 / 细节优先' },
+  { quality: 'lossless', label: '无损 SQ', sub: 'FLAC 优先' },
+  { quality: 'exhigh', label: '极高 HQ', sub: '320kbps' },
+  { quality: 'standard', label: '标准', sub: '128kbps' }
+];
+var YOUTUBE_QUALITY_OPTIONS = [
+  { quality: 'youtube-auto', label: 'YouTube 自动', sub: '官方可用格式优先' },
+  { quality: 'youtube-high', label: 'YouTube 高音质', sub: 'AAC 约 128kbps' },
+  { quality: 'youtube-low', label: 'YouTube 省流', sub: 'AAC 约 50kbps' }
+];
+function applyQualityOptionConfig(option, config) {
+  if (!config) {
+    option.style.display = 'none';
+    option.disabled = true;
+    return;
+  }
+  option.style.display = '';
+  option.dataset.quality = config.quality;
+  if (config.svip) option.dataset.svip = '1';
+  else delete option.dataset.svip;
+  option.classList.toggle('svip-only', !!config.svip);
+  var span = option.querySelector('span');
+  var small = option.querySelector('small');
+  if (span) span.textContent = config.label;
+  if (small) small.textContent = config.sub;
 }
 function updatePlaybackQualityUi() {
   var label = document.getElementById('quality-btn-label');
   var btn = document.getElementById('quality-btn');
+  var provider = qualityProviderForCurrentTrack();
+  var youtubeMode = provider === 'youtube';
   var canUseSvip = hasProviderSvip('netease', loginStatus);
-  var displayQuality = playbackQuality === 'jymaster' && !canUseSvip ? 'hires' : playbackQuality;
-  if (label) label.textContent = playbackQualityShortLabel(displayQuality);
-  if (btn) btn.title = playbackQuality === 'jymaster' && !canUseSvip
-    ? '音质: ' + playbackQualityLabel(displayQuality) + ' · 超清母带需网易云 SVIP'
-    : '音质: ' + playbackQualityLabel(displayQuality);
-  document.querySelectorAll('.quality-option').forEach(function(option){
-    var q = normalizePlaybackQuality(option.dataset.quality);
-    var locked = option.dataset.svip === '1' && !canUseSvip;
+  var displayQuality = youtubeMode ? youtubePlaybackQuality : (playbackQuality === 'jymaster' && !canUseSvip ? 'hires' : playbackQuality);
+  var options = youtubeMode ? YOUTUBE_QUALITY_OPTIONS : DEFAULT_QUALITY_OPTIONS;
+  document.querySelectorAll('.quality-option').forEach(function(option, index){
+    applyQualityOptionConfig(option, options[index]);
+    if (option.style.display === 'none') return;
+    var q = youtubeMode ? normalizeYoutubePlaybackQuality(option.dataset.quality) : normalizePlaybackQuality(option.dataset.quality);
+    var locked = !youtubeMode && option.dataset.svip === '1' && !canUseSvip;
     option.classList.toggle('active', q === displayQuality);
     option.classList.toggle('locked', locked);
     option.disabled = locked;
-    option.title = locked ? '需要网易云 SVIP 账号' : playbackQualityLabel(q);
+    option.title = locked ? '需要网易云 SVIP 账号' : (youtubeMode ? youtubePlaybackQualityLabel(q) : playbackQualityLabel(q));
   });
+  if (label) label.textContent = youtubeMode ? youtubePlaybackQualityShortLabel(displayQuality) : playbackQualityShortLabel(displayQuality);
+  if (btn) btn.title = youtubeMode
+    ? ('音质: ' + youtubePlaybackQualityLabel(displayQuality))
+    : (playbackQuality === 'jymaster' && !canUseSvip
+      ? '音质: ' + playbackQualityLabel(displayQuality) + ' · 超清母带需网易云 SVIP'
+      : '音质: ' + playbackQualityLabel(displayQuality));
 }
 function setPlaybackQuality(value) {
+  if (qualityProviderForCurrentTrack() === 'youtube') {
+    var youtubeNext = normalizeYoutubePlaybackQuality(value);
+    youtubePlaybackQuality = youtubeNext;
+    saveYoutubePlaybackQualityPreference();
+    updatePlaybackQualityUi();
+    var youtubeWrap = document.getElementById('quality-control');
+    if (youtubeWrap) youtubeWrap.classList.remove('open');
+    applyPlaybackQualityToCurrentTrack(youtubeNext);
+    return;
+  }
   var next = normalizePlaybackQuality(value);
   if (next === 'jymaster' && !hasProviderSvip('netease', loginStatus)) {
     showToast(hasPlatformLogin('netease') ? '超清母带需要网易云 SVIP' : '登录网易云 SVIP 后可用超清母带');
@@ -15196,10 +15331,13 @@ function canReloadCurrentTrackForQuality() {
   if (!audio || !audio.src || audio.paused || audio.ended) return false;
   var song = playQueue[currentIdx];
   if (!song || song.type === 'local' || song.source === 'local') return false;
-  return songProviderKey(song) === 'netease' || songProviderKey(song) === 'qq';
+  return songProviderKey(song) === 'netease' || songProviderKey(song) === 'qq' || songProviderKey(song) === 'youtube';
 }
 function applyPlaybackQualityToCurrentTrack(nextQuality) {
-  var label = playbackQualityLabel(nextQuality || playbackQuality);
+  var provider = qualityProviderForCurrentTrack();
+  var label = provider === 'youtube'
+    ? youtubePlaybackQualityLabel(nextQuality || youtubePlaybackQuality)
+    : playbackQualityLabel(nextQuality || playbackQuality);
   if (!canReloadCurrentTrackForQuality()) {
     showToast('音质偏好: ' + label + ' · 下次播放生效');
     return;
@@ -15207,7 +15345,7 @@ function applyPlaybackQualityToCurrentTrack(nextQuality) {
   var resumeAt = audio && isFinite(audio.currentTime) ? audio.currentTime : 0;
   showToast('正在切换音质: ' + label);
   Promise.resolve(playQueueAt(currentIdx, {
-    qualityOverride: nextQuality || playbackQuality,
+    qualityOverride: nextQuality || (provider === 'youtube' ? youtubePlaybackQuality : playbackQuality),
     qualitySwitch: true,
     resumeAt: resumeAt,
     preserveHomeState: true,
@@ -15219,6 +15357,7 @@ function applyPlaybackQualityToCurrentTrack(nextQuality) {
 function toggleQualityPanel(e) {
   if (e) e.stopPropagation();
   var wrap = document.getElementById('quality-control');
+  updatePlaybackQualityUi();
   if (wrap) wrap.classList.toggle('open');
 }
 function bindQualityControl() {
@@ -15278,6 +15417,7 @@ function coverUrlWithSize(url, size) {
 function songCustomCoverKey(song) {
   if (!song) return '';
   if (song.customCoverKey) return String(song.customCoverKey);
+  if (song.provider === 'youtube' || song.source === 'youtube' || song.type === 'youtube') return 'youtube:' + (song.videoId || song.id || (song.name + '|' + song.artist));
   if (song.provider === 'qq' || song.source === 'qq' || song.type === 'qq') return 'qq:' + (song.mid || song.songmid || song.id || (song.name + '|' + song.artist));
   if (song.localKey) return 'local:' + song.localKey;
   if (song.type === 'podcast' && song.programId) return 'podcast:' + song.programId;
@@ -16243,12 +16383,14 @@ function songFromListenRecord(record) {
   if (!record) return null;
   var provider = record.sourceKey || '';
   if (!provider && record.type === 'qq') provider = 'qq';
+  if (!provider && record.type === 'youtube') provider = 'youtube';
   if (!provider) provider = record.mid ? 'qq' : 'netease';
   return {
     provider: provider,
     source: provider,
-    type: record.type || (provider === 'qq' ? 'qq' : 'song'),
+    type: record.type || (provider === 'qq' ? 'qq' : (provider === 'youtube' ? 'youtube' : 'song')),
     id: record.id || record.mid || record.key || '',
+    videoId: record.videoId || (provider === 'youtube' ? (record.id || record.key || '') : ''),
     mid: record.mid || '',
     songmid: record.mid || '',
     mediaMid: record.mediaMid || '',
@@ -16337,6 +16479,7 @@ function songDurationLabel(song) {
 function songSourceLabel(song) {
   if (!song) return '未知';
   if (song.provider === 'qq' || song.source === 'qq' || song.type === 'qq') return 'QQ 音乐';
+  if (song.provider === 'youtube' || song.source === 'youtube' || song.type === 'youtube') return 'YouTube Music';
   if (song.type === 'local') return '本地上传';
   if (song.type === 'podcast' || song.source === 'podcast') return '网易云播客';
   return '网易云音乐';
@@ -16574,6 +16717,10 @@ function openTrackDetailModal(type, songOverride) {
 }
 function openArtistDetailForSong(song) {
   if (!song) { showToast('未找到歌手信息'); return; }
+  if (songProviderKey(song) === 'youtube') {
+    showToast('YouTube Music 歌手主页暂未接入');
+    return;
+  }
   if (currentArtistId(song) || currentQQArtistMid(song)) {
     openTrackDetailModal('artist', song);
     return;
@@ -16730,14 +16877,15 @@ function setOriginalLyricsState(lines, hasNativeKaraoke, timingSource) {
   originalLyricsState = {
     lines: cloneLyricLines(lines || []),
     hasNativeKaraoke: !!hasNativeKaraoke,
-    timingSource: timingSource || 'fallback'
+    timingSource: timingSource || 'none'
   };
 }
 function applyLyricsState(lines, hasNativeKaraoke, timingSource) {
+  timingSource = timingSource || 'fallback';
   lyricsHasNativeKaraoke = !!hasNativeKaraoke;
-  lyricsTimingSource = timingSource || 'fallback';
+  lyricsTimingSource = timingSource;
   lyricsLines = cloneLyricLines(lines || []);
-  if (!lyricsLines.length) lyricsLines = withLyricFallback([]);
+  if (!lyricsLines.length && timingSource !== 'none') lyricsLines = withLyricFallback([]);
   if (lyricsLines.length && lyricsLines[0].fallback) lyricsTimingSource = 'fallback';
   renderLyrics();
   updateCustomLyricControls();
@@ -16919,6 +17067,7 @@ function deleteCustomLyricForCurrent() {
 function isCloudSong(song) {
   if (!song || !song.id) return false;
   if (song.provider === 'qq' || song.source === 'qq' || song.type === 'qq') return false;
+  if (song.provider === 'youtube' || song.source === 'youtube' || song.type === 'youtube') return false;
   if (song.type === 'local' || song.type === 'podcast' || song.source === 'podcast') return false;
   return !song.provider || song.provider === 'netease' || song.source === 'netease' || song.type === 'song';
 }
@@ -17007,7 +17156,7 @@ function refreshSearchResultActionStates() {
 }
 async function toggleLikeSong(song) {
   if (!isCloudSong(song)) {
-    showToast(songProviderKey(song) === 'qq' ? 'QQ 音乐红心同步待登录接口接入' : '本地文件暂不支持红心同步');
+    showToast(songProviderKey(song) === 'youtube' ? 'YouTube Music 暂不支持红心同步' : (songProviderKey(song) === 'qq' ? 'QQ 音乐红心同步待登录接口接入' : '本地文件暂不支持红心同步'));
     return;
   }
   if (!ensureLoggedInForAction()) return;
@@ -17040,7 +17189,7 @@ function toggleLikeQueueIndex(i) { if (playQueue[i]) toggleLikeSong(playQueue[i]
 function toggleLikeDetailSong(song) { toggleLikeSong(song); }
 function openCollectModal(song) {
   if (!isCloudSong(song)) {
-    showToast(songProviderKey(song) === 'qq' ? 'QQ 音乐收藏到歌单待登录接口接入' : '本地文件暂不支持收藏到网易云歌单');
+    showToast(songProviderKey(song) === 'youtube' ? 'YouTube Music 暂不支持收藏到网易云歌单' : (songProviderKey(song) === 'qq' ? 'QQ 音乐收藏到歌单待登录接口接入' : '本地文件暂不支持收藏到网易云歌单'));
     return;
   }
   if (!ensureLoggedInForAction()) return;
@@ -17267,6 +17416,7 @@ function updateSearchModeTabs() {
   var songBtn = document.getElementById('search-mode-song');
   var neteaseBtn = document.getElementById('search-mode-netease');
   var qqBtn = document.getElementById('search-mode-qq');
+  var youtubeBtn = document.getElementById('search-mode-youtube');
   var podcastBtn = document.getElementById('search-mode-podcast');
   if (songBtn) {
     songBtn.classList.toggle('active', searchMode === 'song');
@@ -17280,6 +17430,10 @@ function updateSearchModeTabs() {
     qqBtn.classList.toggle('active', searchMode === 'qq');
     qqBtn.setAttribute('aria-selected', searchMode === 'qq' ? 'true' : 'false');
   }
+  if (youtubeBtn) {
+    youtubeBtn.classList.toggle('active', searchMode === 'youtube');
+    youtubeBtn.setAttribute('aria-selected', searchMode === 'youtube' ? 'true' : 'false');
+  }
   if (podcastBtn) {
     podcastBtn.classList.toggle('active', searchMode === 'podcast');
     podcastBtn.setAttribute('aria-selected', searchMode === 'podcast' ? 'true' : 'false');
@@ -17287,12 +17441,12 @@ function updateSearchModeTabs() {
   if ($input) {
     $input.placeholder = searchMode === 'podcast'
       ? '搜索播客、电台...'
-      : (searchMode === 'qq' ? '搜索 QQ 音乐...' : (searchMode === 'netease' ? '搜索网易云音乐...' : '搜索歌曲、歌手...'));
+      : (searchMode === 'youtube' ? '搜索 YouTube Music...' : (searchMode === 'qq' ? '搜索 QQ 音乐...' : (searchMode === 'netease' ? '搜索网易云音乐...' : '搜索歌曲、歌手...')));
   }
   requestAnimationFrame(updateSearchPillGlassDisplacementMap);
 }
 function setSearchMode(mode) {
-  mode = (mode === 'podcast' || mode === 'netease' || mode === 'qq') ? mode : 'song';
+  mode = (mode === 'podcast' || mode === 'netease' || mode === 'qq' || mode === 'youtube') ? mode : 'song';
   if (searchMode === mode) return;
   searchMode = mode;
   updateSearchModeTabs();
@@ -17506,12 +17660,13 @@ document.addEventListener('click', function(e){
 updateSearchModeTabs();
 
 function songProviderKey(song) {
+  if (song && (song.provider === 'youtube' || song.source === 'youtube' || song.type === 'youtube')) return 'youtube';
   if (song && (song.provider === 'qq' || song.source === 'qq' || song.type === 'qq')) return 'qq';
   return 'netease';
 }
 function songSourceTagHtml(song) {
   var key = songProviderKey(song);
-  var label = key === 'qq' ? 'QQ' : 'NE';
+  var label = key === 'youtube' ? 'YT' : (key === 'qq' ? 'QQ' : 'NE');
   return '<span class="tag-source ' + key + '">' + label + '</span>';
 }
 function searchResultMetaText(song) {
@@ -17519,6 +17674,7 @@ function searchResultMetaText(song) {
   if (song.artist) bits.push(song.artist);
   if (song.album) bits.push(song.album);
   if (songProviderKey(song) === 'qq' && !song.playable) bits.push('QQ 播放需会话/授权');
+  if (songProviderKey(song) === 'youtube' && song.youtubeType === 'video') bits.push('YouTube 视频');
   return bits.join('  ·  ') || songSourceLabel(song);
 }
 function searchResultMetaHtml(song, index) {
@@ -17527,6 +17683,7 @@ function searchResultMetaHtml(song, index) {
   var bits = [];
   if (song.album) bits.push(song.album);
   if (songProviderKey(song) === 'qq' && !song.playable) bits.push('QQ 播放需会话/授权');
+  if (songProviderKey(song) === 'youtube' && song.youtubeType === 'video') bits.push('YouTube 视频');
   var tail = bits.length ? (' · ' + escHtml(bits.join('  ·  '))) : '';
   if (!artist) return escHtml(searchResultMetaText(song));
   return '<button class="search-artist-link" type="button" onclick="event.stopPropagation();openSearchResultArtist(' + index + ')">' + escHtml(artist) + '</button>' + tail;
@@ -17539,6 +17696,10 @@ function openSearchResultArtist(index) {
 function searchIntentPrefersQQ(q) {
   q = String(q || '').toLowerCase();
   return /(^|\s)qq($|\s)|qq音乐|qq音樂|周杰伦|周杰倫|jay\s*chou|jay/.test(q);
+}
+function searchIntentPrefersYoutube(q) {
+  q = String(q || '').toLowerCase();
+  return /youtube|ytmusic|yt music|油管|youtu\.be|music\.youtube/.test(q);
 }
 function simpleSearchNorm(text) {
   return String(text || '').toLowerCase()
@@ -17620,6 +17781,8 @@ function scoreSongSearchResult(song, q, sourceIndex) {
   if (/周杰伦|周杰倫|jay\s*chou/i.test(String(q || '')) && !artistMentioned) score -= 28;
   if (album && nq && (album.indexOf(nq) >= 0 || nq.indexOf(album) >= 0)) score += 8;
   if (songProviderKey(song) === 'qq') score += searchIntentPrefersQQ(q) ? 48 : 4;
+  if (songProviderKey(song) === 'youtube') score += searchIntentPrefersYoutube(q) ? 48 : 2;
+  if (songProviderKey(song) === 'youtube' && song && song.youtubeType === 'video') score -= derivative ? 12 : 4;
   if (song && song.playable === false) score -= 12;
   if (!qAsksDerivative) {
     if (derivative) score -= artistMentioned ? 76 : 96;
@@ -17629,12 +17792,12 @@ function scoreSongSearchResult(song, q, sourceIndex) {
   score -= (sourceIndex || 0) * 0.75;
   return score;
 }
-function mergeSongSearchResults(neteaseSongs, qqSongs, limit, q) {
+function mergeSongSearchResults(neteaseSongs, qqSongs, youtubeSongs, limit, q) {
   var out = [];
   var seen = {};
   function push(song, sourceIndex) {
     if (!song || !song.name) return;
-    var key = songProviderKey(song) + ':' + (song.mid || song.id || (song.name + '|' + song.artist));
+    var key = songProviderKey(song) + ':' + (song.videoId || song.mid || song.id || (song.name + '|' + song.artist));
     if (seen[key]) return;
     seen[key] = true;
     song._searchScore = scoreSongSearchResult(song, q, sourceIndex);
@@ -17642,26 +17805,34 @@ function mergeSongSearchResults(neteaseSongs, qqSongs, limit, q) {
   }
   (neteaseSongs || []).forEach(function(song, i){ push(song, i); });
   (qqSongs || []).forEach(function(song, i){ push(song, i); });
+  (youtubeSongs || []).forEach(function(song, i){ push(song, i); });
   out.sort(function(a, b){ return (b._searchScore || 0) - (a._searchScore || 0); });
   return out.slice(0, limit);
 }
 async function fetchMusicSearchResults(q, mode) {
   if (mode === 'qq') {
     var qqOnly = await apiJson('/api/qq/search?keywords=' + encodeURIComponent(q) + '&limit=12');
-    return mergeSongSearchResults([], qqOnly.songs || [], 18, q);
+    return mergeSongSearchResults([], qqOnly.songs || [], [], 18, q);
   }
   if (mode === 'netease') {
     var neOnly = await apiJson('/api/search?keywords=' + encodeURIComponent(q) + '&limit=18');
-    return mergeSongSearchResults(neOnly.songs || [], [], 18, q);
+    return mergeSongSearchResults(neOnly.songs || [], [], [], 18, q);
+  }
+  if (mode === 'youtube') {
+    var ytOnly = await apiJson('/api/youtube/search?keywords=' + encodeURIComponent(q) + '&limit=18');
+    return mergeSongSearchResults([], [], ytOnly.songs || [], 18, q);
   }
   var result = await Promise.allSettled([
     apiJson('/api/search?keywords=' + encodeURIComponent(q) + '&limit=14'),
-    apiJson('/api/qq/search?keywords=' + encodeURIComponent(q) + '&limit=12')
+    apiJson('/api/qq/search?keywords=' + encodeURIComponent(q) + '&limit=12'),
+    apiJson('/api/youtube/search?keywords=' + encodeURIComponent(q) + '&limit=10')
   ]);
   var neteaseSongs = result[0].status === 'fulfilled' ? ((result[0].value && result[0].value.songs) || []) : [];
   var qqSongs = result[1].status === 'fulfilled' ? ((result[1].value && result[1].value.songs) || []) : [];
+  var youtubeSongs = result[2].status === 'fulfilled' ? ((result[2].value && result[2].value.songs) || []) : [];
   if (result[1].status === 'rejected') console.warn('QQ search failed:', result[1].reason);
-  return mergeSongSearchResults(neteaseSongs, qqSongs, 18, q);
+  if (result[2].status === 'rejected') console.warn('YouTube Music search failed:', result[2].reason);
+  return mergeSongSearchResults(neteaseSongs, qqSongs, youtubeSongs, 18, q);
 }
 function renderSongSearchResults(songs) {
   playlist = songs || [];
@@ -18044,6 +18215,7 @@ function bindVolumeControls() {
 // ============================================================
 function queueItemKey(song) {
   if (!song) return '';
+  if (song.provider === 'youtube' || song.source === 'youtube' || song.type === 'youtube') return 'youtube:' + (song.videoId || song.id || (song.name + '|' + song.artist));
   if (song.provider === 'qq' || song.source === 'qq' || song.type === 'qq') return 'qq:' + (song.mid || song.songmid || song.id || (song.name + '|' + song.artist));
   if (song.type === 'podcast' && song.programId) return 'podcast:' + song.programId;
   if (song.localKey) return 'local:' + song.localKey;
@@ -18133,10 +18305,14 @@ function playSearchResult(i) {
 var firstPlayDone = false;
 
 function playbackProviderLabel(song) {
-  return songProviderKey(song) === 'qq' ? 'QQ 音乐' : '网易云';
+  var provider = songProviderKey(song);
+  if (provider === 'youtube') return 'YouTube Music';
+  return provider === 'qq' ? 'QQ 音乐' : '网易云';
 }
 function playbackLoginProvider(song) {
-  return songProviderKey(song) === 'qq' ? 'qq' : 'netease';
+  var provider = songProviderKey(song);
+  if (provider === 'youtube') return 'youtube';
+  return provider === 'qq' ? 'qq' : 'netease';
 }
 function playbackRestrictionMessage(song, data) {
   data = data || {};
@@ -18229,7 +18405,9 @@ function isSameTitleArtist(source, candidate) {
   return a.some(function(name){ return b.indexOf(name) >= 0; });
 }
 function alternatePlaybackProvider(song) {
-  return songProviderKey(song) === 'qq' ? 'netease' : 'qq';
+  var provider = songProviderKey(song);
+  if (provider === 'qq' || provider === 'youtube') return 'netease';
+  return 'qq';
 }
 async function searchAlternatePlatformSong(song) {
   var target = alternatePlaybackProvider(song);
@@ -18285,7 +18463,8 @@ async function tryAutoPlaybackFallback(song, data, idx, token, opts) {
   var restriction = (data && data.restriction) || {};
   var category = (data && data.reason) || restriction.category || '';
   var fromLabel = playbackProviderLabel(song);
-  var targetLabel = alternatePlaybackProvider(song) === 'qq' ? 'QQ 音乐' : '网易云';
+  var targetProvider = alternatePlaybackProvider(song);
+  var targetLabel = targetProvider === 'youtube' ? 'YouTube Music' : (targetProvider === 'qq' ? 'QQ 音乐' : '网易云');
   showSourceFallbackNotice('正在自动换源', fromLabel + ' 当前不可播，正在查找 ' + targetLabel + ' 的同名同歌手版本。');
   try {
     var alternate = await searchAlternatePlatformSong(song);
@@ -18315,7 +18494,7 @@ function handlePlaybackUnavailable(song, data) {
   var restriction = (data && data.restriction) || {};
   var category = (data && data.reason) || restriction.category || '';
   showToast(playbackRestrictionMessage(song, data));
-  if (category === 'login_required') {
+  if (category === 'login_required' && provider) {
     setTimeout(function(){
       var modal = document.getElementById('login-modal');
       if (!modal || modal.classList.contains('show')) return;
@@ -18365,13 +18544,13 @@ function playbackFailureToastText(err) {
   if (isPlaybackRecursionError(err)) return '播放准备异常，已保持播放器可操作';
   return '播放失败: ' + (err && err.message ? err.message : err);
 }
-function scheduleAudioResumePosition(media, seconds, token) {
+function scheduleAudioResumePosition(media, seconds, token, durationHint) {
   seconds = Math.max(0, Number(seconds) || 0);
   if (!media || seconds < 0.35) return;
   var applied = false;
   function applyResume() {
     if (applied || token !== trackSwitchToken || !media) return;
-    var duration = Number(media.duration) || 0;
+    var duration = normalizePlaybackDurationSeconds(durationHint) || Number(media.duration) || 0;
     var target = duration > 0 ? Math.min(seconds, Math.max(0, duration - 0.45)) : seconds;
     try {
       media.currentTime = target;
@@ -18431,12 +18610,14 @@ async function playQueueAt(idx, opts) {
     document.getElementById('thumb-title').textContent = song.name;
     document.getElementById('thumb-artist').textContent = song.artist;
     updateControlTrackInfo(song);
+    updatePlaybackQualityUi();
     document.getElementById('thumb-wrap').classList.add('visible');
   });
   markPlayPhase('lyric-prep');
   safePlaybackStep('lyric-prep', function(){
-    var initialLyricLines = withLyricFallback([]);
-    setOriginalLyricsState(initialLyricLines, false, 'fallback');
+    var allowLyricFallback = songProviderKey(song) !== 'youtube';
+    var initialLyricLines = withLyricFallback([], { allowFallback: allowLyricFallback });
+    setOriginalLyricsState(initialLyricLines, false, initialLyricLines.length ? 'fallback' : 'none');
     applyPreferredLyricsForCurrent(true);
   });
 
@@ -18461,16 +18642,22 @@ async function playQueueAt(idx, opts) {
 
   try {
     markPlayPhase('source-url');
-    var isQQPlayback = songProviderKey(song) === 'qq';
-    var requestedQuality = normalizePlaybackQuality(opts.qualityOverride || playbackQuality);
-    if (!isQQPlayback && requestedQuality === 'jymaster' && !hasProviderSvip('netease', loginStatus)) requestedQuality = 'hires';
+    var playbackProvider = songProviderKey(song);
+    var isQQPlayback = playbackProvider === 'qq';
+    var isYoutubePlayback = playbackProvider === 'youtube';
+    var requestedQuality = isYoutubePlayback
+      ? normalizeYoutubePlaybackQuality(opts.qualityOverride || youtubePlaybackQuality)
+      : normalizePlaybackQuality(opts.qualityOverride || playbackQuality);
+    if (playbackProvider === 'netease' && requestedQuality === 'jymaster' && !hasProviderSvip('netease', loginStatus)) requestedQuality = 'hires';
     if (isQQPlayback && qqPlaybackQualityCeiling && (requestedQuality === 'jymaster' || requestedQuality === 'hires' || requestedQuality === 'lossless')) {
       requestedQuality = qqPlaybackQualityCeiling;
     }
     var qualityParam = '&quality=' + encodeURIComponent(requestedQuality);
     var data = isQQPlayback
       ? await apiJson('/api/qq/song/url?mid=' + encodeURIComponent(song.mid || song.songmid || song.id || '') + '&mediaMid=' + encodeURIComponent(song.mediaMid || song.media_mid || '') + qualityParam)
-      : await apiJson('/api/song/url?id=' + song.id + qualityParam);
+      : (isYoutubePlayback
+        ? await apiJson('/api/youtube/song/url?videoId=' + encodeURIComponent(song.videoId || song.id || '') + qualityParam)
+        : await apiJson('/api/song/url?id=' + encodeURIComponent(song.id) + qualityParam));
     if (token !== trackSwitchToken) return;
     if (!data.url) {
       if (isQQPlayback && await retryQQPlaybackWithCompatibleQuality(song, idx, token, opts, data, requestedQuality)) return;
@@ -18479,7 +18666,7 @@ async function playQueueAt(idx, opts) {
       return;
     }
     var resolvedQualityText = playbackResolvedQualityText(data);
-    if (!isQQPlayback && playbackQualityWasDowngraded(requestedQuality, data.level)) {
+    if (playbackProvider === 'netease' && playbackQualityWasDowngraded(requestedQuality, data.level)) {
       showSourceFallbackNotice('网易云音质自动降级', '请求 ' + playbackQualityLabel(requestedQuality) + '，实际播放 ' + resolvedQualityText + '。');
     } else if (opts.qualitySwitch) {
       showSourceFallbackNotice('音质已切换', '实际播放: ' + resolvedQualityText + '。');
@@ -18507,16 +18694,39 @@ async function playQueueAt(idx, opts) {
     }
     bindPlaybackProgressEvents(audio);
     applyVolumeToAudio();
+    var playbackDurationHint = playbackDurationFromSong(song);
     var proxyAudioUrl = '/api/audio?url=' + encodeURIComponent(data.url);
+    if (isYoutubePlayback) {
+      markPlayPhase('youtube-audio-prepare');
+      proxyAudioUrl = await prepareYoutubeAudioProxyUrl(data.url, song, requestedQuality, playbackDurationHint);
+      if (token !== trackSwitchToken) return;
+      markPlayPhase('audio-element');
+    }
     audio.src = proxyAudioUrl;
     updatePlaybackProgressUi();
+    var youtubeEarlyEndedRetries = 0;
     audio.onended = function(){
       if (token !== trackSwitchToken) return;
+      if (isYoutubePlayback) {
+        var expectedDuration = normalizePlaybackDurationSeconds(playbackDurationHint);
+        var endedAt = audio && isFinite(audio.currentTime) ? audio.currentTime : 0;
+        if (expectedDuration > 75 && endedAt > 0 && endedAt < expectedDuration - 2 && youtubeEarlyEndedRetries < 2) {
+          youtubeEarlyEndedRetries++;
+          console.warn('[YouTubePlayback] ignored early ended:', endedAt, expectedDuration);
+          try { audio.currentTime = endedAt; } catch (e) {}
+          try {
+            var resumePromise = audio.play();
+            if (resumePromise && resumePromise.catch) resumePromise.catch(function(err){ console.warn('[YouTubePlayback] early-ended resume failed:', err); });
+          } catch (e) {}
+          updatePlaybackProgressUi();
+          return;
+        }
+      }
       finalizeListenSession(true);
       if (playMode === 'single') setTimeout(function(){ playQueueAt(currentIdx, { autoRepeat: true }); }, 0);
       else setTimeout(nextTrack, 0);
     };
-    scheduleAudioResumePosition(audio, opts.resumeAt, token);
+    scheduleAudioResumePosition(audio, opts.resumeAt, token, playbackDurationHint);
     audio.load();
     markPlayPhase('visual-prep');
     try {
@@ -19015,14 +19225,17 @@ function clearPlayerControlFocusState(reason) {
 //  歌词
 // ============================================================
 async function fetchLyric(songOrId, token) {
+  var song = (songOrId && typeof songOrId === 'object') ? songOrId : null;
+  var provider = songProviderKey(song);
+  var allowFallback = provider !== 'youtube';
   try {
-    var song = (songOrId && typeof songOrId === 'object') ? songOrId : null;
-    var provider = songProviderKey(song);
     var endpoint;
     if (provider === 'qq') {
       var mid = song.mid || song.songmid || song.id || '';
       var qqId = song.qqId || (/^\d+$/.test(String(song.id || '')) ? song.id : '');
       endpoint = '/api/qq/lyric?mid=' + encodeURIComponent(mid) + '&id=' + encodeURIComponent(qqId);
+    } else if (provider === 'youtube') {
+      endpoint = '/api/youtube/lyric?videoId=' + encodeURIComponent(song.videoId || song.id || '');
     } else {
       var songId = song ? song.id : songOrId;
       endpoint = '/api/lyric?id=' + encodeURIComponent(songId);
@@ -19031,16 +19244,18 @@ async function fetchLyric(songOrId, token) {
     if (token !== trackSwitchToken) return;
     var nativeLines = parseYrcText(r.yrc || '');
     var lrcLines = parseLyricText(r.lyric || '');
+    var plainLines = provider === 'youtube' ? parsePlainLyricText(r.lyric || '', 'youtube-text') : [];
+    var lyricLines = nativeLines.length ? nativeLines : (lrcLines.length ? lrcLines : plainLines);
     var hasNativeKaraoke = nativeLines.some(function(line){ return line.words && line.words.length; });
-    var timingSource = hasNativeKaraoke ? 'yrc-word' : (nativeLines.length ? 'yrc-line' : (lrcLines.length ? 'lrc-line' : 'fallback'));
-    var lines = withLyricFallback(nativeLines.length ? nativeLines : lrcLines);
+    var timingSource = hasNativeKaraoke ? 'yrc-word' : (nativeLines.length ? 'yrc-line' : (lrcLines.length ? 'lrc-line' : (plainLines.length ? 'plain-line' : 'none')));
+    var lines = withLyricFallback(lyricLines, { allowFallback: allowFallback });
     if (lines.length && lines[0].fallback) timingSource = 'fallback';
     setOriginalLyricsState(lines, hasNativeKaraoke, timingSource);
     applyPreferredLyricsForCurrent(true);
   } catch (e) {
     if (token !== trackSwitchToken) return;
-    var fallbackLines = withLyricFallback([]);
-    setOriginalLyricsState(fallbackLines, false, 'fallback');
+    var fallbackLines = withLyricFallback([], { allowFallback: allowFallback });
+    setOriginalLyricsState(fallbackLines, false, fallbackLines.length ? 'fallback' : 'none');
     applyPreferredLyricsForCurrent(true);
   }
 }
@@ -19052,6 +19267,9 @@ function currentLyricFallbackText() {
   return artist ? title + ' - ' + artist : title;
 }
 function isNoLyricText(text) {
+  var raw = String(text || '').trim();
+  if (/lyrics unavailable|lyrics not available|no lyrics|instrumental/i.test(raw)) return true;
+  if (/暂无歌词|纯音乐|没有填词|敬请期待/.test(raw)) return true;
   var compact = String(text || '').replace(/\s+/g, '').replace(/[，,。.!！?？、~～]/g, '');
   return !compact ||
     compact === '纯音乐请欣赏' ||
@@ -19059,9 +19277,11 @@ function isNoLyricText(text) {
     compact === '暂无歌词敬请期待' ||
     compact === '此歌曲为没有填词的纯音乐请您欣赏';
 }
-function withLyricFallback(lines) {
+function withLyricFallback(lines, opts) {
+  opts = opts || {};
   lines = Array.isArray(lines) ? lines.filter(function(line){ return line && String(line.text || '').trim(); }) : [];
   if (lines.length && !lines.every(function(line){ return isNoLyricText(line.text); })) return lines;
+  if (opts.allowFallback === false) return [];
   var text = currentLyricFallbackText();
   return text ? [{ t:0, text:text, duration:9999, charCount:Math.max(1, text.length), fallback:true }] : [];
 }
@@ -19093,6 +19313,18 @@ function parseLyricText(text) {
     times.forEach(function(t){ lines.push({ t: t, text: txt, source:'lrc' }); });
   });
   return finalizeLyricLineDurations(lines);
+}
+function parsePlainLyricText(text, source) {
+  var rows = String(text || '').split(/\r?\n/)
+    .map(function(line){ return line.trim(); })
+    .filter(function(line){ return line && !isNoLyricText(line); });
+  if (!rows.length) return [];
+  var song = currentLyricSong();
+  var duration = playbackDurationFromSong(song) || getPlaybackDurationSeconds();
+  var gap = duration ? Math.max(2.8, Math.min(7.2, duration / Math.max(1, rows.length))) : 4.8;
+  return finalizeLyricLineDurations(rows.map(function(line, i){
+    return { t: i * gap, duration: gap, text: line, source: source || 'plain-text', charCount: Math.max(1, line.length) };
+  }));
 }
 function parseYrcText(text) {
   var lines = [];
@@ -19418,7 +19650,7 @@ function renderQueuePanel(opts) {
   renderMiniQueuePanel({ scrollCurrent: miniQueueOpen });
 }
 async function refreshUserPlaylists(force) {
-  if (!loginStatus.loggedIn && !qqLoginStatus.loggedIn) {
+  if (!loginStatus.loggedIn && !qqLoginStatus.loggedIn && !youtubeLoginStatus.loggedIn) {
     resetPlaylistPanelRenderLimit();
     document.getElementById('pl-list').innerHTML = '<div style="text-align:center;padding:24px 0;color:rgba(255,255,255,.32);font-size:11.5px">登录后显示个人歌单</div>';
     var podcastListLoggedOut = document.getElementById('podcast-list');
@@ -19427,8 +19659,10 @@ async function refreshUserPlaylists(force) {
   }
   if (force) resetPlaylistPanelRenderLimit();
   var hasCachedQQPlaylists = userPlaylists.some(function(pl){ return pl && pl.provider === 'qq'; });
+  var hasCachedYoutubePlaylists = userPlaylists.some(function(pl){ return pl && pl.provider === 'youtube'; });
   var needsQQRefresh = qqLoginStatus.loggedIn && !hasCachedQQPlaylists;
-  if (!force && !needsQQRefresh && (userPlaylists.length || myPodcastCollections.length)) {
+  var needsYoutubeRefresh = youtubeLoginStatus.loggedIn && !hasCachedYoutubePlaylists;
+  if (!force && !needsQQRefresh && !needsYoutubeRefresh && (userPlaylists.length || myPodcastCollections.length)) {
     var cachedAnimate = isPlaylistPanelVisibleForRender();
     renderUserPlaylistsList({ animate: cachedAnimate });
     renderMyPodcastCollections({ animate: cachedAnimate });
@@ -19445,11 +19679,13 @@ async function refreshUserPlaylists(force) {
     var result = await Promise.all([
       loginStatus.loggedIn ? apiJson('/api/user/playlists') : Promise.resolve({ playlists: [] }),
       loginStatus.loggedIn ? apiJson('/api/podcast/my') : Promise.resolve({ collections: [], loggedIn: false }),
-      qqLoginStatus.loggedIn ? apiJson('/api/qq/user/playlists') : Promise.resolve({ playlists: [] })
+      qqLoginStatus.loggedIn ? apiJson('/api/qq/user/playlists') : Promise.resolve({ playlists: [] }),
+      youtubeLoginStatus.loggedIn ? apiJson('/api/youtube/user/playlists') : Promise.resolve({ playlists: [] })
     ]);
     var neteaseLists = (result[0].playlists || []).map(function(pl){ pl.provider = 'netease'; pl.source = 'netease'; return pl; });
     qqPlaylists = (result[2].playlists || []).map(function(pl){ pl.provider = 'qq'; pl.source = 'qq'; return pl; });
-    userPlaylists = neteaseLists.concat(qqPlaylists);
+    youtubePlaylists = (result[3].playlists || []).map(function(pl){ pl.provider = 'youtube'; pl.source = 'youtube'; return pl; });
+    userPlaylists = neteaseLists.concat(qqPlaylists, youtubePlaylists);
     myPodcastCollections = result[1].collections || [];
     var animatePanel = isPlaylistPanelVisibleForRender();
     renderUserPlaylistsList({ animate: animatePanel, reset: true });
@@ -19460,9 +19696,11 @@ async function refreshUserPlaylists(force) {
 }
 var playlistPanelDetailState = { key: '', loading: false, playlist: null, tracks: [], token: 0, renderLimit: PLAYLIST_DETAIL_INITIAL_RENDER };
 function playlistPanelKey(provider, id) {
-  return (provider === 'qq' ? 'qq' : 'netease') + ':' + String(id || '');
+  provider = provider === 'youtube' ? 'youtube' : (provider === 'qq' ? 'qq' : 'netease');
+  return provider + ':' + String(id || '');
 }
 function playlistPanelProviderId(provider, id) {
+  if (provider === 'youtube') return 'youtube:' + id;
   return provider === 'qq' ? ('qq:' + id) : id;
 }
 function playlistPanelDetailHtml(pl, provider) {
@@ -19470,7 +19708,7 @@ function playlistPanelDetailHtml(pl, provider) {
   if (playlistPanelDetailState.key !== key) return '';
   var tracks = playlistPanelDetailState.tracks || [];
   var loading = playlistPanelDetailState.loading;
-  var cover = pl && pl.cover ? (provider === 'qq' ? pl.cover : (pl.cover + '?param=96y96')) : '';
+  var cover = pl && pl.cover ? (provider === 'netease' ? (pl.cover + '?param=96y96') : pl.cover) : '';
   var img = cover ? '<img class="pl-detail-cover" src="' + escHtml(cover) + '" alt="" decoding="async" onerror="this.style.opacity=0.2">' : '<div class="pl-detail-cover"></div>';
   var renderLimit = loading ? 0 : Math.max(PLAYLIST_DETAIL_INITIAL_RENDER, playlistPanelDetailState.renderLimit || PLAYLIST_DETAIL_INITIAL_RENDER);
   renderLimit = Math.min(tracks.length, renderLimit);
@@ -19494,7 +19732,7 @@ function playlistPanelDetailHtml(pl, provider) {
   }
   return '<div class="pl-inline-detail" data-pl-detail="' + escHtml(key) + '">' +
     '<div class="pl-detail-sticky">' +
-      '<div class="pl-detail-head">' + img + '<div style="flex:1;min-width:0"><div class="pl-detail-title">' + escHtml(pl.name || '歌单详情') + '</div><div class="pl-detail-sub">' + escHtml((pl.trackCount || tracks.length || 0) + ' 首 · ' + (pl.creator || (provider === 'qq' ? 'QQ 音乐' : '网易云音乐'))) + '</div></div><div class="pl-detail-count">' + (loading ? '载入中' : (renderLimit + '/' + tracks.length)) + '</div></div>' +
+      '<div class="pl-detail-head">' + img + '<div style="flex:1;min-width:0"><div class="pl-detail-title">' + escHtml(pl.name || '歌单详情') + '</div><div class="pl-detail-sub">' + escHtml((pl.trackCount || tracks.length || 0) + ' 首 · ' + (pl.creator || platformMeta(provider).label)) + '</div></div><div class="pl-detail-count">' + (loading ? '载入中' : (renderLimit + '/' + tracks.length)) + '</div></div>' +
       '<div class="pl-detail-actions"><button class="pl-detail-play" type="button" data-pl-detail-play="' + escHtml(key) + '"><svg viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>播放歌单</button><button class="fx-mini-btn ghost pl-detail-top-btn" type="button" data-pl-detail-top="1">回到顶部</button></div>' +
     '</div>' +
     '<div class="pl-detail-list">' + rows + '</div>' +
@@ -19530,9 +19768,9 @@ function scrollPlaylistPanelDetailIntoView(key) {
 }
 async function openPlaylistPanelDetail(provider, pid, title) {
   if (!pid) return;
-  provider = provider === 'qq' ? 'qq' : 'netease';
+  provider = provider === 'youtube' ? 'youtube' : (provider === 'qq' ? 'qq' : 'netease');
   var key = playlistPanelKey(provider, pid);
-  var pl = userPlaylists.find(function(item){ return playlistPanelKey(item.provider === 'qq' ? 'qq' : 'netease', item.id) === key; }) || { id: pid, provider: provider, name: title || '歌单详情' };
+  var pl = userPlaylists.find(function(item){ return playlistPanelKey(item.provider === 'youtube' ? 'youtube' : (item.provider === 'qq' ? 'qq' : 'netease'), item.id) === key; }) || { id: pid, provider: provider, name: title || '歌单详情' };
   if (playlistPanelDetailState.key === key && !playlistPanelDetailState.loading && playlistPanelDetailState.tracks.length) {
     playlistPanelDetailState.key = '';
     playlistPanelDetailState.tracks = [];
@@ -19546,9 +19784,12 @@ async function openPlaylistPanelDetail(provider, pid, title) {
   renderPlaylistPanelDetailState();
   scrollPlaylistPanelDetailIntoView(key);
   try {
-    var r = provider === 'qq'
-      ? await apiJson('/api/qq/playlist/tracks?id=' + encodeURIComponent(pid))
-      : await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(pid));
+    var detailUrl = provider === 'youtube'
+      ? '/api/youtube/playlist/tracks?id=' + encodeURIComponent(pid)
+      : (provider === 'qq'
+        ? '/api/qq/playlist/tracks?id=' + encodeURIComponent(pid)
+        : '/api/playlist/tracks?id=' + encodeURIComponent(pid));
+    var r = await apiJson(detailUrl);
     if (playlistPanelDetailState.token !== token) return;
     playlistPanelDetailState.loading = false;
     playlistPanelDetailState.tracks = (r && r.tracks || []).map(cloneSong);
@@ -19568,7 +19809,7 @@ function playPlaylistPanelDetail() {
   var st = playlistPanelDetailState;
   if (!st || !st.key) return;
   var parts = st.key.split(':');
-  var provider = parts[0] === 'qq' ? 'qq' : 'netease';
+  var provider = parts[0] === 'youtube' ? 'youtube' : (parts[0] === 'qq' ? 'qq' : 'netease');
   var pid = parts.slice(1).join(':');
   loadPlaylistIntoQueueById(playlistPanelProviderId(provider, pid), true, st.playlist && st.playlist.name || '');
 }
@@ -19638,9 +19879,9 @@ function renderUserPlaylistsList(opts) {
     return;
   }
   function playlistCardHtml(pl) {
-    var provider = pl.provider === 'qq' ? 'qq' : 'netease';
-    var providerLabel = provider === 'qq' ? 'QQ' : 'NE';
-    var thumb = pl.cover ? (provider === 'qq' ? pl.cover : (pl.cover + '?param=88y88')) : '';
+    var provider = pl.provider === 'youtube' ? 'youtube' : (pl.provider === 'qq' ? 'qq' : 'netease');
+    var providerLabel = provider === 'youtube' ? 'YT' : (provider === 'qq' ? 'QQ' : 'NE');
+    var thumb = pl.cover ? (provider === 'netease' ? (pl.cover + '?param=88y88') : pl.cover) : '';
     var imgTag = thumb ? '<img src="' + thumb + '" alt="" loading="lazy" decoding="async" onerror="this.style.opacity=0.2">' : '<div style="width:44px;height:44px;border-radius:8px;background:rgba(255,255,255,.06);flex-shrink:0"></div>';
     var key = playlistPanelKey(provider, pl.id);
     var expanded = playlistPanelDetailState.key === key ? ' expanded' : '';
@@ -19650,8 +19891,9 @@ function renderUserPlaylistsList(opts) {
     '</div>' + playlistPanelDetailHtml(pl, provider);
   }
   var groups = [
-    { key:'netease', label:'网易云歌单', items:userPlaylists.filter(function(pl){ return pl.provider !== 'qq'; }) },
-    { key:'qq', label:'QQ 音乐歌单', items:userPlaylists.filter(function(pl){ return pl.provider === 'qq'; }) }
+    { key:'netease', label:'网易云歌单', items:userPlaylists.filter(function(pl){ return pl.provider !== 'qq' && pl.provider !== 'youtube'; }) },
+    { key:'qq', label:'QQ 音乐歌单', items:userPlaylists.filter(function(pl){ return pl.provider === 'qq'; }) },
+    { key:'youtube', label:'YouTube Music 歌单', items:userPlaylists.filter(function(pl){ return pl.provider === 'youtube'; }) }
   ];
   if (opts.reset) resetPlaylistPanelRenderLimit();
   playlistPanelRenderLimit = Math.max(PLAYLIST_PANEL_BATCH_SIZE, Math.min(userPlaylists.length, playlistPanelRenderLimit || PLAYLIST_PANEL_BATCH_SIZE));
@@ -19842,11 +20084,14 @@ async function loadPlaylistIntoQueueById(id, autoplay, title) {
   updateEmptyHomeVisibility();
   showLoading();
   var qqPlaylistId = String(id || '').indexOf('qq:') === 0 ? String(id).slice(3) : '';
+  var youtubePlaylistId = String(id || '').indexOf('youtube:') === 0 ? String(id).slice(8) : '';
   var r = null;
   try {
-    r = qqPlaylistId
-      ? await apiJson('/api/qq/playlist/tracks?id=' + encodeURIComponent(qqPlaylistId))
-      : await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(id));
+    r = youtubePlaylistId
+      ? await apiJson('/api/youtube/playlist/tracks?id=' + encodeURIComponent(youtubePlaylistId))
+      : (qqPlaylistId
+        ? await apiJson('/api/qq/playlist/tracks?id=' + encodeURIComponent(qqPlaylistId))
+        : await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(id)));
   } catch (e) {
     console.warn('[PlaylistLoadApi]', id, e);
     showToast('歌单加载失败');
@@ -19857,8 +20102,8 @@ async function loadPlaylistIntoQueueById(id, autoplay, title) {
     if (r.error) { showToast('歌单加载失败: ' + r.error); return; }
     if (!r.tracks || !r.tracks.length) { showToast('歌单为空'); return; }
     playQueue = r.tracks.map(cloneSong);
-    if (!qqPlaylistId && isLikedPlaylistContext(id, title, r.playlist)) markSongsLiked(playQueue, true);
-    if (!qqPlaylistId) syncLikeStatusForSongs(playQueue);
+    if (!qqPlaylistId && !youtubePlaylistId && isLikedPlaylistContext(id, title, r.playlist)) markSongsLiked(playQueue, true);
+    if (!qqPlaylistId && !youtubePlaylistId) syncLikeStatusForSongs(playQueue);
     currentIdx = 0;
     safeRenderQueuePanel('playlist-load');
     safeSwitchPlaylistTab('queue', 'playlist-load');
@@ -19895,8 +20140,11 @@ function playbackDurationFromSong(song) {
   return normalizePlaybackDurationSeconds(song.duration || song.durationMs || song.dt || 0);
 }
 function getPlaybackDurationSeconds() {
-  if (audio && isFinite(audio.duration) && audio.duration > 0) return audio.duration;
-  return playbackDurationFromSong(currentCoverSong());
+  var song = currentCoverSong();
+  var songDuration = playbackDurationFromSong(song);
+  var mediaDuration = audio && isFinite(audio.duration) && audio.duration > 0 ? audio.duration : 0;
+  if (songProviderKey(song) === 'youtube' && songDuration > 0) return songDuration;
+  return mediaDuration || songDuration;
 }
 function getPlaybackCurrentSeconds() {
   return audio && isFinite(audio.currentTime) && audio.currentTime > 0 ? audio.currentTime : 0;
@@ -19946,17 +20194,26 @@ function emitProgressDragParticles(x, y) {
 function seekFromProgressPointer(e, emitParticles) {
   var durationSec = getPlaybackDurationSeconds();
   if (!audio || !durationSec) return;
+  if (audio.readyState === 0) return;
   var bar = document.getElementById('progress-bar');
   var rect = bar.getBoundingClientRect();
   var ratio = clampRange((e.clientX - rect.left) / rect.width, 0, 1);
-  audio.currentTime = ratio * durationSec;
+  var target = ratio * durationSec;
+  try {
+    audio.currentTime = target;
+  } catch (err) {
+    console.warn('[PlaybackSeek] failed:', err);
+    return;
+  }
   setProgressVisual(ratio * 100);
-  syncBeatMapPlaybackCursor(audio.currentTime);
+  syncBeatMapPlaybackCursor(target);
+  if (typeof syncPodcastDjMapCursor === 'function') syncPodcastDjMapCursor(target);
+  updateLyricsHighlight();
   if (emitParticles) emitProgressDragParticles(e.clientX, rect.top + rect.height / 2);
 }
 var progressBar = document.getElementById('progress-bar');
 progressBar.addEventListener('pointerdown', function(e){
-  if (!audio || !audio.duration) return;
+  if (!audio || !getPlaybackDurationSeconds() || audio.readyState === 0) return;
   progressDragState.active = true;
   progressBar.classList.add('is-dragging');
   try { progressBar.setPointerCapture(e.pointerId); } catch (err) {}
@@ -23232,10 +23489,12 @@ function onUserBtnClick() {
   else showLoginModal();
 }
 function platformMeta(provider) {
+  if (provider === 'youtube') return { key: 'youtube', short: 'YT', label: 'YouTube Music', app: 'YouTube Music', dot: 'youtube' };
   if (provider === 'qq') return { key: 'qq', short: 'QQ', label: 'QQ 音乐', app: 'QQ 音乐 App', dot: 'qq' };
   return { key: 'netease', short: 'NE', label: '网易云音乐', app: '网易云音乐 App', dot: 'netease' };
 }
 function platformStatus(provider) {
+  if (provider === 'youtube') return youtubeLoginStatus;
   return provider === 'qq' ? qqLoginStatus : loginStatus;
 }
 function providerVipType(provider, status) {
@@ -23244,6 +23503,7 @@ function providerVipType(provider, status) {
 }
 function providerVipLevel(provider, status) {
   status = status || platformStatus(provider) || {};
+  if (provider === 'youtube') return 'none';
   var raw = String(status.vipLevel || status.vip_level || '').toLowerCase();
   if (raw === 'svip' || raw === 'vip' || raw === 'none') return raw;
   var vip = providerVipType(provider, status);
@@ -23273,20 +23533,21 @@ function hasPlatformLogin(provider) {
   return !!(st && st.loggedIn);
 }
 function hasAnyPlatformLogin() {
-  return hasPlatformLogin('netease') || hasPlatformLogin('qq');
+  return hasPlatformLogin('netease') || hasPlatformLogin('qq') || hasPlatformLogin('youtube');
 }
 function firstLoggedProvider() {
   if (hasPlatformLogin(activeAccountProvider)) return activeAccountProvider;
   if (hasPlatformLogin('netease')) return 'netease';
   if (hasPlatformLogin('qq')) return 'qq';
+  if (hasPlatformLogin('youtube')) return 'youtube';
   return 'netease';
 }
 function providerAvatarSrc(provider, status) {
   status = status || platformStatus(provider) || {};
   if (status.avatar) return avatarSrc(status.avatar);
   var meta = platformMeta(provider);
-  var fill = provider === 'qq' ? '#bfd66b' : '#d95b67';
-  var bg = provider === 'qq' ? '#11150b' : '#180b0f';
+  var fill = provider === 'youtube' ? '#ff4d5f' : (provider === 'qq' ? '#bfd66b' : '#d95b67');
+  var bg = provider === 'youtube' ? '#19080b' : (provider === 'qq' ? '#11150b' : '#180b0f');
   var svg = '<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96"><rect width="96" height="96" rx="48" fill="' + bg + '"/><circle cx="48" cy="48" r="34" fill="' + fill + '" opacity=".16"/><text x="48" y="56" text-anchor="middle" font-family="Arial, sans-serif" font-size="26" font-weight="700" fill="' + fill + '">' + meta.short + '</text></svg>';
   return 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(svg);
 }
@@ -23317,7 +23578,7 @@ async function refreshLoginStatus(force) {
       loadHomeDiscover(true);
       syncLikeStatusForSongs(playQueue.concat(playlist || []));
     } else {
-      userPlaylists = qqPlaylists.slice();
+      userPlaylists = qqPlaylists.concat(youtubePlaylists);
       myPodcastCollections = [];
       myPodcastItems = {};
       likedSongMap = {};
@@ -23389,16 +23650,71 @@ function startQQLoginStatusAutoRefresh() {
     refreshQQLoginStatus().catch(function(e){ console.warn('QQ login auto refresh failed:', e); });
   }, 45000);
 }
+function normalizeYoutubeLoginStatus(info) {
+  var fallback = { provider: 'youtube', loggedIn: false, nickname: 'YouTube Music', userId: '', avatar: '', stale: false };
+  if (!info || !info.loggedIn) return Object.assign({}, fallback, info || {}, {
+    provider: 'youtube',
+    loggedIn: false,
+    nickname: info && info.nickname || fallback.nickname,
+    userId: info && info.userId || '',
+    avatar: info && info.avatar || '',
+    stale: !!(info && info.stale)
+  });
+  return Object.assign({}, fallback, info, {
+    provider: 'youtube',
+    loggedIn: true,
+    nickname: info.nickname || fallback.nickname,
+    userId: info.userId || '',
+    avatar: info.avatar || '',
+    stale: !!info.stale
+  });
+}
+async function refreshYoutubeLoginStatus() {
+  try {
+    var info = await apiJson('/api/youtube/login/status?t=' + Date.now());
+    var prevLogged = !!youtubeLoginStatus.loggedIn;
+    youtubeLoginStatus = normalizeYoutubeLoginStatus(info);
+    if (!youtubeLoginStatus.loggedIn) {
+      if (prevLogged || youtubeLoginWasLoggedIn) showToast(youtubeLoginStatus.stale ? 'YouTube Music 登录已失效' : 'YouTube Music 已掉登录');
+      youtubePlaylists = [];
+      userPlaylists = userPlaylists.filter(function(pl){ return pl.provider !== 'youtube'; });
+      homeDiscoverState.loaded = false;
+    } else if (!userPlaylists.some(function(pl){ return pl && pl.provider === 'youtube'; })) {
+      homeDiscoverState.loaded = false;
+      homeDiscoverState.loggedIn = true;
+      loadHomeDiscover(true);
+      refreshUserPlaylists(true);
+    } else if (youtubeLoginStatus.stale) {
+      showToast('YouTube Music 登录状态可能已失效');
+    }
+    youtubeLoginWasLoggedIn = !!youtubeLoginStatus.loggedIn;
+    if (!hasPlatformLogin(activeAccountProvider)) activeAccountProvider = firstLoggedProvider();
+    renderUserBtn();
+    return youtubeLoginStatus;
+  } catch (e) {
+    console.warn('YouTube login status failed:', e);
+    youtubeLoginStatus = normalizeYoutubeLoginStatus(null);
+    renderUserBtn();
+    return youtubeLoginStatus;
+  }
+}
+function startYoutubeLoginStatusAutoRefresh() {
+  if (youtubeLoginAutoRefreshTimer) clearInterval(youtubeLoginAutoRefreshTimer);
+  youtubeLoginAutoRefreshTimer = setInterval(function(){
+    refreshYoutubeLoginStatus().catch(function(e){ console.warn('YouTube login auto refresh failed:', e); });
+  }, 60000);
+}
 function renderUserBtn() {
   var btn = document.getElementById('user-btn');
   if (!btn) return;
   btn.classList.remove('multi-account');
   if (dualAccountMode && hasAnyPlatformLogin()) {
     activeAccountProvider = firstLoggedProvider();
+    var loggedProviders = ['netease', 'qq', 'youtube'].filter(hasPlatformLogin);
     btn.classList.add('logged-in', 'multi-account');
     btn.classList.remove('logged-out');
-    btn.title = '账号信息 · 双平台登录状态';
-    btn.innerHTML = renderTopAccountPill('netease') + renderTopAccountPill('qq');
+    btn.title = '账号信息 · 多平台登录状态';
+    btn.innerHTML = loggedProviders.map(renderTopAccountPill).join('');
   } else if (hasAnyPlatformLogin()) {
     activeAccountProvider = firstLoggedProvider();
     var st = platformStatus(activeAccountProvider);
@@ -23417,9 +23733,12 @@ function renderUserBtn() {
   }
   updatePlaybackQualityUi();
 }
+function normalizeAccountProvider(provider) {
+  return provider === 'youtube' ? 'youtube' : (provider === 'qq' ? 'qq' : 'netease');
+}
 async function showLoginModal(opts) {
   opts = opts || {};
-  if (opts.provider) loginProvider = opts.provider === 'qq' ? 'qq' : 'netease';
+  if (opts.provider) loginProvider = normalizeAccountProvider(opts.provider);
   var modal = document.getElementById('login-modal');
   openGsapModal(modal);
   updateLoginProviderUi();
@@ -23430,13 +23749,14 @@ function closeLoginModal() {
   closeGsapModal(document.getElementById('login-modal'));
 }
 function setLoginProvider(provider, silent) {
-  loginProvider = provider === 'qq' ? 'qq' : 'netease';
+  loginProvider = normalizeAccountProvider(provider);
   updateLoginProviderUi();
   if (!silent && document.getElementById('login-modal').classList.contains('show')) refreshQr();
 }
 function updateLoginProviderUi() {
   var meta = platformMeta(loginProvider);
   var isQQ = loginProvider === 'qq';
+  var isYoutube = loginProvider === 'youtube';
   var title = document.getElementById('login-modal-title');
   var desc = document.getElementById('login-modal-desc');
   var shell = document.getElementById('qr-shell');
@@ -23447,19 +23767,26 @@ function updateLoginProviderUi() {
   var qqCard = document.getElementById('qq-web-login-card');
   var neteaseBtn = document.getElementById('login-provider-netease');
   var qqBtn = document.getElementById('login-provider-qq');
+  var youtubeBtn = document.getElementById('login-provider-youtube');
   var canOpenNeteaseWeb = !!(window.desktopWindow && typeof window.desktopWindow.openNeteaseMusicLogin === 'function');
+  var canOpenYoutubeWeb = !!(window.desktopWindow && typeof window.desktopWindow.openYoutubeMusicLogin === 'function');
+  var providerBusy = isYoutube ? youtubeWebLoginBusy : (isQQ ? qqWebLoginBusy : neteaseWebLoginBusy);
   if (neteaseBtn) neteaseBtn.classList.toggle('active', loginProvider === 'netease');
   if (qqBtn) qqBtn.classList.toggle('active', isQQ);
+  if (youtubeBtn) youtubeBtn.classList.toggle('active', isYoutube);
   if (title) title.textContent = '扫码登录' + meta.label;
-  if (desc) desc.innerHTML = isQQ
-    ? '打开 <b>QQ 音乐官方网页登录窗口</b> 扫码，成功后会自动同步账号会话。'
-    : (canOpenNeteaseWeb
-      ? '打开 <b>网易云音乐官方网页登录窗口</b> 扫码，避开接口二维码风控；成功后会自动同步账号会话。'
-      : '使用 <b>网易云音乐 App</b> 扫码，可同步歌单、红心与播客。');
+  if (desc) desc.innerHTML = isYoutube
+    ? '打开 <b>YouTube Music 官方网页登录窗口</b>，成功后会同步 YouTube Music 歌单。'
+    : (isQQ
+      ? '打开 <b>QQ 音乐官方网页登录窗口</b> 扫码，成功后会自动同步账号会话。'
+      : (canOpenNeteaseWeb
+        ? '打开 <b>网易云音乐官方网页登录窗口</b> 扫码，避开接口二维码风控；成功后会自动同步账号会话。'
+        : '使用 <b>网易云音乐 App</b> 扫码，可同步歌单、红心与播客。'));
   if (shell) {
-    shell.classList.toggle('web-login-preview', isQQ || canOpenNeteaseWeb);
+    shell.classList.toggle('web-login-preview', isQQ || isYoutube || canOpenNeteaseWeb);
     shell.classList.toggle('qq-preview', isQQ);
-    shell.classList.toggle('netease-preview', !isQQ && canOpenNeteaseWeb);
+    shell.classList.toggle('youtube-preview', isYoutube);
+    shell.classList.toggle('netease-preview', !isQQ && !isYoutube && canOpenNeteaseWeb);
   }
   if (qqPanel) qqPanel.classList.toggle('show', isQQ && qqManualCookieOpen);
   if (qqCookieToggle) {
@@ -23467,24 +23794,25 @@ function updateLoginProviderUi() {
     qqCookieToggle.textContent = qqManualCookieOpen ? '收起导入' : '手动导入';
   }
   if (qqCard) {
-    qqCard.disabled = isQQ ? !!qqWebLoginBusy : !!neteaseWebLoginBusy;
+    qqCard.disabled = !!providerBusy;
     var cardMark = qqCard.querySelector('b');
     var cardLabel = qqCard.querySelector('span');
-    if (cardMark) cardMark.textContent = isQQ ? 'QQ' : 'NE';
-    if (cardLabel) cardLabel.textContent = isQQ
-      ? (qqWebLoginBusy ? '等待扫码确认' : '打开官方扫码窗口')
-      : (neteaseWebLoginBusy ? '等待扫码确认' : '打开官方登录窗口');
+    if (cardMark) cardMark.textContent = meta.short;
+    if (cardLabel) cardLabel.textContent = providerBusy ? '等待登录确认' : (isQQ ? '打开官方扫码窗口' : '打开官方登录窗口');
   }
   if (st) {
-    st.className = isQQ ? 'preview' : '';
-    st.textContent = isQQ
-      ? (qqLoginStatus.loggedIn ? ('已保存 QQ 音乐会话 · ' + (qqLoginStatus.nickname || '')) : '点击“扫码登录”打开 QQ 音乐官方窗口')
-      : (canOpenNeteaseWeb ? '点击“网页登录”打开网易云官方窗口' : '正在生成二维码…');
+    st.className = (isQQ || isYoutube || canOpenNeteaseWeb) ? 'preview' : '';
+    st.textContent = isYoutube
+      ? (youtubeLoginStatus.loggedIn ? ('已保存 YouTube Music 会话 · ' + (youtubeLoginStatus.nickname || '')) : '点击“登录”打开 YouTube Music 官方窗口')
+      : (isQQ
+        ? (qqLoginStatus.loggedIn ? ('已保存 QQ 音乐会话 · ' + (qqLoginStatus.nickname || '')) : '点击“扫码登录”打开 QQ 音乐官方窗口')
+        : (canOpenNeteaseWeb ? '点击“网页登录”打开网易云官方窗口' : '正在生成二维码…'));
   }
   if (refreshBtn) {
-    refreshBtn.disabled = isQQ ? !!qqWebLoginBusy : !!neteaseWebLoginBusy;
-    refreshBtn.textContent = isQQ ? (qqWebLoginBusy ? '等待扫码…' : '扫码登录') : (canOpenNeteaseWeb ? (neteaseWebLoginBusy ? '等待扫码…' : '网页登录') : '刷新二维码');
-    refreshBtn.onclick = isQQ ? openQQWebLogin : (canOpenNeteaseWeb ? openNeteaseWebLogin : refreshQr);
+    refreshBtn.disabled = !!providerBusy;
+    refreshBtn.textContent = isYoutube ? (youtubeWebLoginBusy ? '等待登录…' : '登录')
+      : (isQQ ? (qqWebLoginBusy ? '等待扫码…' : '扫码登录') : (canOpenNeteaseWeb ? (neteaseWebLoginBusy ? '等待扫码…' : '网页登录') : '刷新二维码'));
+    refreshBtn.onclick = isYoutube ? openYoutubeWebLogin : (isQQ ? openQQWebLogin : (canOpenNeteaseWeb ? openNeteaseWebLogin : refreshQr));
   }
 }
 async function refreshQr() {
@@ -23499,6 +23827,18 @@ async function refreshQr() {
     if (qqStatus) {
       qqStatus.textContent = info && info.loggedIn ? ('已保存 QQ 音乐会话 · ' + (info.nickname || '')) : '点击“扫码登录”打开 QQ 音乐官方窗口';
       qqStatus.className = 'preview';
+    }
+    return;
+  }
+  if (loginProvider === 'youtube') {
+    qrKey = null;
+    var ytStatus = document.getElementById('qr-status');
+    var ytImg = document.getElementById('qr-img');
+    if (ytImg) ytImg.src = '';
+    var ytInfo = await refreshYoutubeLoginStatus();
+    if (ytStatus) {
+      ytStatus.textContent = ytInfo && ytInfo.loggedIn ? ('已保存 YouTube Music 会话 · ' + (ytInfo.nickname || '')) : '点击“登录”打开 YouTube Music 官方窗口';
+      ytStatus.className = 'preview';
     }
     return;
   }
@@ -23535,6 +23875,7 @@ function toggleQQCookiePanel() {
 }
 function openProviderWebLogin() {
   if (loginProvider === 'qq') return openQQWebLogin();
+  if (loginProvider === 'youtube') return openYoutubeWebLogin();
   return openNeteaseWebLogin();
 }
 async function openNeteaseWebLogin() {
@@ -23630,6 +23971,51 @@ async function openQQWebLogin() {
     }
   }
 }
+async function openYoutubeWebLogin() {
+  if (youtubeWebLoginBusy) return;
+  var statusEl = document.getElementById('qr-status');
+  var api = window.desktopWindow;
+  if (!api || !api.isDesktop || typeof api.openYoutubeMusicLogin !== 'function') {
+    updateLoginProviderUi();
+    if (statusEl) { statusEl.textContent = '当前环境不支持 YouTube Music 官方网页登录'; statusEl.className = 'fail'; }
+    return;
+  }
+
+  youtubeWebLoginBusy = true;
+  updateLoginProviderUi();
+  if (statusEl) { statusEl.textContent = '已打开 YouTube Music 窗口，请在官方页面完成登录…'; statusEl.className = 'preview'; }
+  try {
+    var result = await api.openYoutubeMusicLogin();
+    if (!result || !result.ok || !result.cookie) {
+      throw new Error((result && (result.message || result.error)) || 'YouTube Music 登录未完成');
+    }
+    if (statusEl) { statusEl.textContent = '正在同步 YouTube Music 会话…'; statusEl.className = 'preview'; }
+    var info = await apiJson('/api/youtube/login/cookie', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ cookie: result.cookie })
+    });
+    if (!info || !info.loggedIn) throw new Error((info && (info.message || info.error)) || 'YouTube Music 会话不可用');
+    youtubeLoginStatus = normalizeYoutubeLoginStatus(info);
+    activeAccountProvider = 'youtube';
+    renderUserBtn();
+    refreshUserPlaylists(true);
+    if (statusEl) { statusEl.textContent = 'YouTube Music 会话已保存'; statusEl.className = 'scan'; }
+    setTimeout(function(){
+      closeLoginModal();
+      showToast('YouTube Music 已登录');
+    }, 420);
+  } catch (e) {
+    youtubeWebLoginBusy = false;
+    updateLoginProviderUi();
+    if (statusEl) { statusEl.textContent = e && e.message ? e.message : 'YouTube Music 登录失败'; statusEl.className = 'fail'; }
+  } finally {
+    if (youtubeWebLoginBusy) {
+      youtubeWebLoginBusy = false;
+      updateLoginProviderUi();
+    }
+  }
+}
 async function submitQQCookieLogin() {
   if (qqCookieBusy) return;
   var input = document.getElementById('qq-cookie-input');
@@ -23710,6 +24096,7 @@ function updateUserModalUi() {
   var logoutBtn = document.getElementById('account-logout-btn');
   var addNetease = document.getElementById('account-add-netease');
   var addQQ = document.getElementById('account-add-qq');
+  var addYoutube = document.getElementById('account-add-youtube');
   if (chip) {
     chip.className = 'account-provider-chip ' + activeAccountProvider;
     chip.innerHTML = '<span class="account-source-dot ' + meta.dot + '"></span><span>' + meta.label + '</span>';
@@ -23722,22 +24109,26 @@ function updateUserModalUi() {
       var vipLabel = neVipLevel === 'svip' ? '网易云 SVIP' : (neVipLevel === 'vip' ? '网易云 VIP' : '普通用户');
       vipEl.textContent = 'UID: ' + ((st && st.userId) || '-') + '  ·  ' + vipLabel;
       vipEl.style.color = hasProviderVip('netease', st) ? 'rgba(244,210,138,0.86)' : 'rgba(255,255,255,0.5)';
-    } else {
+    } else if (activeAccountProvider === 'qq') {
       var qqVipLabel = hasProviderVip('qq', st) ? 'QQ VIP 会员' : 'QQ 音乐会话';
       vipEl.textContent = 'UID: ' + ((st && st.userId) || '-') + '  ·  ' + qqVipLabel;
       vipEl.style.color = hasProviderVip('qq', st) ? 'rgba(0,245,212,0.82)' : 'rgba(0,245,212,0.58)';
+    } else {
+      vipEl.textContent = 'YouTube Music 会话';
+      vipEl.style.color = 'rgba(255,217,223,0.70)';
     }
   }
-  ['netease','qq','both'].forEach(function(key){
+  ['netease','qq','youtube','both'].forEach(function(key){
     var btn = document.getElementById('user-provider-' + key);
     if (btn) btn.classList.toggle('active', key === 'both' ? dualAccountMode : (!dualAccountMode && activeAccountProvider === key));
   });
   if (addNetease) addNetease.style.display = hasPlatformLogin('netease') ? 'none' : '';
   if (addQQ) addQQ.textContent = hasPlatformLogin('qq') ? '查看 QQ 音乐' : '补登 QQ 音乐';
-  if (logoutBtn) logoutBtn.textContent = activeAccountProvider === 'qq' ? '退出 QQ 音乐' : '退出网易云';
+  if (addYoutube) addYoutube.textContent = hasPlatformLogin('youtube') ? '查看 YouTube' : '补登 YouTube';
+  if (logoutBtn) logoutBtn.textContent = activeAccountProvider === 'youtube' ? '退出 YouTube' : (activeAccountProvider === 'qq' ? '退出 QQ 音乐' : '退出网易云');
   if (hint) hint.textContent = dualAccountMode
-    ? '右上角已切换为双平台并排展示。'
-    : '可切换右上角展示的平台；“我两个都要”会并排放两个登录状态。';
+    ? '右上角已切换为多平台并排展示。'
+    : '可切换右上角展示的平台；“我全都要”会并排放已登录状态。';
 }
 function showUserModal() {
   if (!hasAnyPlatformLogin()) return showLoginModal();
@@ -23746,7 +24137,7 @@ function showUserModal() {
 }
 function closeUserModal() { closeGsapModal(document.getElementById('user-modal')); }
 function setActiveAccountProvider(provider) {
-  provider = provider === 'qq' ? 'qq' : 'netease';
+  provider = normalizeAccountProvider(provider);
   if (!hasPlatformLogin(provider)) {
     openProviderLogin(provider);
     return;
@@ -23757,33 +24148,48 @@ function setActiveAccountProvider(provider) {
   updateUserModalUi();
 }
 function enableDualAccountView() {
-  if (!hasPlatformLogin('netease') && !hasPlatformLogin('qq')) {
+  var loggedProviders = ['netease', 'qq', 'youtube'].filter(hasPlatformLogin);
+  if (loggedProviders.length >= 2) {
+    dualAccountMode = true;
+    renderUserBtn();
+    updateUserModalUi();
+    showToast('已启用多平台账号展示');
+    return;
+  }
+  if (!hasPlatformLogin('netease') && !hasPlatformLogin('qq') && !hasPlatformLogin('youtube')) {
     openProviderLogin('netease');
     return;
   }
-  if (!hasPlatformLogin('netease')) {
-    openProviderLogin('netease');
-    return;
-  }
-  if (!hasPlatformLogin('qq')) {
-    openProviderLogin('qq');
-    return;
-  }
-  dualAccountMode = true;
-  renderUserBtn();
-  updateUserModalUi();
-  showToast('已启用双平台账号展示');
+  openProviderLogin(!hasPlatformLogin('netease') ? 'netease' : (!hasPlatformLogin('qq') ? 'qq' : 'youtube'));
 }
 function requestDualLoginMode() {
   enableDualAccountView();
 }
 function openProviderLogin(provider) {
-  provider = provider === 'qq' ? 'qq' : 'netease';
+  provider = normalizeAccountProvider(provider);
   closeUserModal();
   loginProvider = provider;
   showLoginModal({ provider: provider });
 }
 async function logoutActiveAccount() {
+  if (activeAccountProvider === 'youtube') {
+    try { await apiJson('/api/youtube/logout'); } catch (e) {}
+    try {
+      if (window.desktopWindow && typeof window.desktopWindow.clearYoutubeMusicLogin === 'function') {
+        await window.desktopWindow.clearYoutubeMusicLogin();
+      }
+    } catch (e) {}
+    youtubeLoginStatus = { provider: 'youtube', loggedIn: false, nickname: 'YouTube Music', userId: '', avatar: '', stale: false };
+    youtubePlaylists = [];
+    userPlaylists = userPlaylists.filter(function(pl){ return pl.provider !== 'youtube'; });
+    if (['netease', 'qq', 'youtube'].filter(hasPlatformLogin).length < 2) dualAccountMode = false;
+    activeAccountProvider = firstLoggedProvider();
+    renderUserBtn();
+    if (hasAnyPlatformLogin()) updateUserModalUi();
+    else closeUserModal();
+    showToast('已退出 YouTube Music');
+    return;
+  }
   if (activeAccountProvider === 'qq') {
     try { await apiJson('/api/qq/logout'); } catch (e) {}
     try {
@@ -23794,7 +24200,7 @@ async function logoutActiveAccount() {
     qqLoginStatus = { provider: 'qq', loggedIn: false, preview: false, nickname: 'QQ 音乐', userId: '', avatar: '', vipType: 0 };
     qqPlaylists = [];
     userPlaylists = userPlaylists.filter(function(pl){ return pl.provider !== 'qq'; });
-    dualAccountMode = false;
+    if (['netease', 'qq', 'youtube'].filter(hasPlatformLogin).length < 2) dualAccountMode = false;
     activeAccountProvider = firstLoggedProvider();
     renderUserBtn();
     if (hasAnyPlatformLogin()) updateUserModalUi();
@@ -23812,9 +24218,9 @@ async function doLogout() {
     }
   } catch (e) {}
   loginStatus = { loggedIn: false };
-  if (!hasPlatformLogin('netease') || !hasPlatformLogin('qq')) dualAccountMode = false;
+  if (['netease', 'qq', 'youtube'].filter(hasPlatformLogin).length < 2) dualAccountMode = false;
   activeAccountProvider = firstLoggedProvider();
-  userPlaylists = qqPlaylists.slice();
+  userPlaylists = qqPlaylists.concat(youtubePlaylists);
   myPodcastCollections = [];
   myPodcastItems = {};
   likedSongMap = {};
@@ -26523,8 +26929,9 @@ if (fx.floatLayer) createFloatLayer();
 if (fx.particleLyrics) createLyricsParticles();
 if (fx.backCover) createBackCoverLayer();
 initIdleGuideCanvas();
-var startupLoginStatusPromise = Promise.all([refreshLoginStatus(), refreshQQLoginStatus()]);
+var startupLoginStatusPromise = Promise.all([refreshLoginStatus(), refreshQQLoginStatus(), refreshYoutubeLoginStatus()]);
 startQQLoginStatusAutoRefresh();
+startYoutubeLoginStatusAutoRefresh();
 if (startupLoginStatusPromise && startupLoginStatusPromise.then) {
   startupLoginStatusPromise.then(function(){
     if (hasAnyPlatformLogin()) {

--- a/server.js
+++ b/server.js
@@ -52,23 +52,35 @@ const crypto = require('crypto');
 const tls = require('tls');
 const { once } = require('events');
 const { fileURLToPath } = require('url');
+const { spawn } = require('child_process');
 const { analyzePodcastDjStream, analyzePodcastDjIntro } = require('./dj-analyzer');
+
+let FFMPEG_PATH = '';
+try { FFMPEG_PATH = require('ffmpeg-static') || ''; } catch (e) { FFMPEG_PATH = ''; }
+const YTDLP_BUNDLED_PATH = path.join(__dirname, 'bin', 'yt-dlp.exe');
+const YTDLP_CACHE_PATH = process.env.YTDLP_PATH || path.join(process.env.MINERADIO_TOOL_CACHE_DIR || 'D:\\MineradioCache\\bin', 'yt-dlp.exe');
+const YTDLP_DOWNLOAD_URL = 'https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe';
 
 const PORT = process.env.PORT || 3000;
 const HOST = process.env.HOST || '0.0.0.0';
 const UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 const COOKIE_FILE = process.env.COOKIE_FILE || path.join(__dirname, '.cookie');
 const QQ_COOKIE_FILE = process.env.QQ_COOKIE_FILE || path.join(__dirname, '.qq-cookie');
+const YOUTUBE_COOKIE_FILE = process.env.YOUTUBE_COOKIE_FILE || path.join(__dirname, '.youtube-cookie');
 const UPDATE_WORK_DIR = process.env.MINERADIO_UPDATE_DIR || path.join(__dirname, 'updates');
 const UPDATE_DOWNLOAD_DIR = process.env.MINERADIO_UPDATE_DOWNLOAD_DIR || path.join(UPDATE_WORK_DIR, 'downloads');
 const UPDATE_PATCH_BACKUP_DIR = process.env.MINERADIO_PATCH_BACKUP_DIR || path.join(UPDATE_WORK_DIR, 'backups', 'patches');
 const BEATMAP_CACHE_DIR = process.env.MINERADIO_BEAT_CACHE_DIR || 'D:\\MineradioCache\\beatmaps';
+const YOUTUBE_AUDIO_CACHE_DIR = process.env.MINERADIO_YOUTUBE_AUDIO_CACHE_DIR || 'D:\\MineradioCache\\youtube-audio';
+const YOUTUBE_AUDIO_CACHE_MAX_BYTES = 2 * 1024 * 1024 * 1024;
 const APP_PACKAGE = readPackageInfo();
 const APP_VERSION = process.env.MINERADIO_VERSION || APP_PACKAGE.version || '0.9.11';
 const UPDATE_CONFIG = readUpdateConfig(APP_PACKAGE);
 const PATCH_MAX_BYTES = 12 * 1024 * 1024;
 const PATCH_ALLOWED_ROOTS = new Set(['public', 'desktop', 'build']);
 const PATCH_ALLOWED_FILES = new Set(['server.js', 'dj-analyzer.js', 'package.json', 'package-lock.json']);
+const youtubeAudioTranscodeJobs = new Map();
+let youtubeAudioCachePruneAt = 0;
 const UPDATE_FALLBACK_NOTES = [
   '电影镜头节奏更松',
   '音源失败自动换源',
@@ -184,6 +196,15 @@ catch (e) { qqCookie = ''; }
 function saveQQCookie(c) {
   qqCookie = normalizeCookieHeader(c) || rawCookieFallback(c);
   try { fs.writeFileSync(QQ_COOKIE_FILE, qqCookie); } catch (e) {}
+}
+
+let youtubeCookie = '';
+try { if (fs.existsSync(YOUTUBE_COOKIE_FILE)) youtubeCookie = fs.readFileSync(YOUTUBE_COOKIE_FILE, 'utf8').trim(); }
+catch (e) { youtubeCookie = ''; }
+function saveYoutubeCookie(c) {
+  youtubeCookie = normalizeCookieHeader(c) || rawCookieFallback(c);
+  youtubeMusicUserClientPromise = null;
+  try { fs.writeFileSync(YOUTUBE_COOKIE_FILE, youtubeCookie); } catch (e) {}
 }
 
 // ---------- 工具 ----------
@@ -1555,6 +1576,15 @@ function normalizeQualityPreference(value) {
   if (['standard', 'normal', '128', '128k', 'std'].includes(raw)) return 'standard';
   return 'hires';
 }
+
+function normalizeYoutubeQualityPreference(value) {
+  const raw = String(value || '').toLowerCase().trim();
+  if (['youtube-low', 'yt-low', 'low', 'audio-low', 'bestefficiency', 'efficient', 'save', 'standard', 'normal', 'std', '50', '50k', '139'].includes(raw)) return 'low';
+  if (['youtube-auto', 'yt-auto', 'auto', 'default', ''].includes(raw)) return 'auto';
+  if (['youtube-high', 'yt-high', 'high', 'audio-high', 'best', 'medium', '128', '128k', '140', 'hires', 'lossless', 'exhigh', 'jymaster'].includes(raw)) return 'high';
+  return 'auto';
+}
+
 function qualityCandidatesFrom(target, candidates) {
   target = normalizeQualityPreference(target);
   let start = candidates.findIndex(item => item.level === target);
@@ -1737,6 +1767,13 @@ const QQ_HEADERS = {
   Referer: 'https://y.qq.com/',
   'User-Agent': UA,
 };
+const YOUTUBE_MUSIC_HEADERS = {
+  Referer: 'https://music.youtube.com/',
+  Origin: 'https://music.youtube.com',
+  'User-Agent': UA,
+};
+let youtubeMusicAnonClientPromise = null;
+let youtubeMusicUserClientPromise = null;
 
 function requestText(targetUrl, opts, body) {
   opts = opts || {};
@@ -2339,11 +2376,565 @@ async function qqGetJSON(targetUrl, params, opts) {
   return parseJSONText(text);
 }
 
+function youtubeCookieHasLogin(cookieText) {
+  const obj = parseCookieString(cookieText);
+  const accountId = obj.SID || obj.__Secure_1PSID || obj.__Secure_3PSID ||
+    obj['__Secure-1PSID'] || obj['__Secure-3PSID'] || obj.LOGIN_INFO || '';
+  const authToken = obj.SAPISID || obj.APISID || obj.SSID || obj.HSID ||
+    obj.__Secure_1PAPISID || obj.__Secure_3PAPISID ||
+    obj['__Secure-1PAPISID'] || obj['__Secure-3PAPISID'] || obj.LOGIN_INFO || '';
+  return !!(accountId && authToken);
+}
+
+function youtubeMusicClientOptions(authenticated) {
+  const options = {
+    lang: process.env.YOUTUBE_MUSIC_LANG || 'zh-CN',
+    location: process.env.YOUTUBE_MUSIC_LOCATION || 'US',
+  };
+  if (authenticated && youtubeCookie) options.cookie = youtubeCookie;
+  return options;
+}
+
+async function getYoutubeMusicClient(opts) {
+  opts = opts || {};
+  const authenticated = !!opts.authenticated && !!youtubeCookie;
+  if (authenticated) {
+    if (!youtubeMusicUserClientPromise) {
+      youtubeMusicUserClientPromise = import('youtubei.js')
+        .then(mod => mod.Innertube.create(youtubeMusicClientOptions(true)))
+        .catch(err => {
+          youtubeMusicUserClientPromise = null;
+          throw err;
+        });
+    }
+    return youtubeMusicUserClientPromise;
+  }
+  if (!youtubeMusicAnonClientPromise) {
+    youtubeMusicAnonClientPromise = import('youtubei.js')
+      .then(mod => mod.Innertube.create(youtubeMusicClientOptions(false)))
+      .catch(err => {
+        youtubeMusicAnonClientPromise = null;
+        throw err;
+      });
+  }
+  return youtubeMusicAnonClientPromise;
+}
+
+function youtubeText(value) {
+  if (value == null) return '';
+  if (typeof value === 'string') return value.trim();
+  if (typeof value.text === 'string') return value.text.trim();
+  if (Array.isArray(value.runs)) return value.runs.map(run => run && (run.text || run.content || '')).join('').trim();
+  try {
+    const text = value.toString && value.toString();
+    return typeof text === 'string' && text !== '[object Object]' ? text.trim() : '';
+  } catch (e) {
+    return '';
+  }
+}
+
+function youtubeThumbnailUrl(thumbnails) {
+  const raw = thumbnails && thumbnails.contents ? thumbnails.contents : thumbnails;
+  const list = Array.isArray(raw) ? raw : [];
+  if (!list.length) return '';
+  const best = list.slice().sort((a, b) => {
+    const aw = Number(a && a.width) || 0;
+    const ah = Number(a && a.height) || 0;
+    const bw = Number(b && b.width) || 0;
+    const bh = Number(b && b.height) || 0;
+    return (bw * bh) - (aw * ah);
+  })[0];
+  return best && best.url || '';
+}
+
+function youtubeArtistsFromItem(item) {
+  const raw = (item && (item.artists || item.authors)) || [];
+  const artists = (Array.isArray(raw) ? raw : [])
+    .map(a => ({
+      id: a && (a.channel_id || a.id),
+      name: youtubeText(a && a.name),
+    }))
+    .filter(a => a.name);
+  if (artists.length) return artists;
+  const subtitle = youtubeText(item && item.subtitle);
+  const fallback = subtitle
+    .split(/\s+[·•]\s+|\s*\/\s*|\s*,\s*|、/)
+    .map(text => text.trim())
+    .filter(text => text && !/^(song|songs|video|videos|album|playlist|single|ep|artist|views?|次观看)$/i.test(text));
+  return fallback.length ? [{ name: fallback[0] }] : [];
+}
+
+function mapYoutubeMusicItem(item, sourceIndex) {
+  item = item || {};
+  const itemType = String(item.item_type || item.type || '').toLowerCase();
+  if (!item.id || !['song', 'video', 'non_music_track'].includes(itemType)) return null;
+  const artists = youtubeArtistsFromItem(item);
+  const album = item.album || {};
+  const thumbnails = item.thumbnails || item.thumbnail || [];
+  const seconds = Number(item.duration && item.duration.seconds) || 0;
+  return {
+    provider: 'youtube',
+    source: 'youtube',
+    type: 'youtube',
+    youtubeType: itemType,
+    id: item.id,
+    videoId: item.id,
+    name: youtubeText(item.title || item.name) || item.id,
+    artist: artists.map(a => a.name).join(' / '),
+    artists,
+    artistId: artists[0] && artists[0].id,
+    album: youtubeText(album.name || album.title),
+    cover: youtubeThumbnailUrl(thumbnails),
+    duration: seconds ? seconds * 1000 : 0,
+    fee: 0,
+    playable: true,
+    youtubeUrl: 'https://music.youtube.com/watch?v=' + encodeURIComponent(item.id),
+    sourceIndex: sourceIndex || 0,
+  };
+}
+
+function youtubeNumberFromText(text, trackOnly) {
+  const raw = String(text || '').replace(/,/g, '').trim();
+  if (!raw) return 0;
+  const trackMatch = raw.match(/([\d.]+)\s*(?:songs?|tracks?|videos?|首(?:歌曲|曲目|歌)?|曲目|支(?:视频|影片)?)/i);
+  if (trackMatch) return Math.round(Number(trackMatch[1]) || 0);
+  if (trackOnly) return 0;
+  const plain = raw.match(/[\d.]+/);
+  return plain ? Math.round(Number(plain[0]) || 0) : 0;
+}
+
+function youtubeViewCountFromText(text) {
+  const raw = String(text || '').replace(/,/g, '').trim();
+  if (!raw) return 0;
+  const match = raw.match(/([\d.]+)\s*(?:views?|次观看|次觀看|觀看|回視聴)/i);
+  return match ? Math.round(Number(match[1]) || 0) : 0;
+}
+
+function youtubePlaylistIdFromItem(item) {
+  item = item || {};
+  const endpoint = item.endpoint && item.endpoint.payload ? item.endpoint.payload : {};
+  return String(item.id || item.playlist_id || item.playlistId || endpoint.playlistId || endpoint.browseId || '').trim();
+}
+
+function youtubePlaylistCreator(item) {
+  item = item || {};
+  const direct = youtubeText(item.author && item.author.name) ||
+    youtubeText(item.authors && item.authors[0] && item.authors[0].name) ||
+    youtubeText(item.artists && item.artists[0] && item.artists[0].name);
+  if (direct) return direct;
+  const subtitle = youtubeText(item.subtitle);
+  const parts = subtitle.split(/[•路]/).map(part => part.trim()).filter(Boolean);
+  return parts.find(part => !youtubeNumberFromText(part, true) && !/playlist|song|track|video|播放列表|歌曲|曲目|视频/i.test(part)) || 'YouTube Music';
+}
+
+function mapYoutubePlaylistItem(item, kind) {
+  item = item || {};
+  const itemType = String(item.item_type || item.type || '').toLowerCase();
+  const id = youtubePlaylistIdFromItem(item);
+  const name = youtubeText(item.title || item.name);
+  if (!id || !name) return null;
+  if (itemType && !/playlist/.test(itemType) && !(item.item_count || item.song_count)) return null;
+  const subtitle = youtubeText(item.subtitle);
+  const count = youtubeNumberFromText(item.song_count || item.item_count || subtitle, false);
+  return {
+    provider: 'youtube',
+    source: 'youtube',
+    id,
+    name,
+    cover: youtubeThumbnailUrl(item.thumbnails || item.thumbnail),
+    trackCount: count,
+    playCount: youtubeViewCountFromText(item.views || subtitle),
+    creator: youtubePlaylistCreator(item),
+    subscribed: kind === 'library',
+    specialType: 0,
+  };
+}
+
+function collectYoutubePlaylistItems(value, out, seen, depth) {
+  if (!value || depth > 8) return out;
+  out = out || [];
+  seen = seen || new WeakSet();
+  if (Array.isArray(value)) {
+    value.forEach(item => collectYoutubePlaylistItems(item, out, seen, depth + 1));
+    return out;
+  }
+  if (typeof value !== 'object') return out;
+  if (seen.has(value)) return out;
+  seen.add(value);
+  if (mapYoutubePlaylistItem(value, 'library')) out.push(value);
+  ['contents', 'items', 'contents_memo', 'shelves'].forEach(key => {
+    if (value[key]) collectYoutubePlaylistItems(value[key], out, seen, depth + 1);
+  });
+  return out;
+}
+
+function normalizeYoutubePlaylistId(input) {
+  let value = String(input || '').trim();
+  if (/^https?:\/\//i.test(value)) {
+    try {
+      const parsed = new URL(value);
+      value = parsed.searchParams.get('list') || parsed.searchParams.get('playlist') || value;
+    } catch (e) {}
+  }
+  return value.replace(/^youtube:/i, '').trim();
+}
+
+function youtubePlaylistIdCandidates(input) {
+  const id = normalizeYoutubePlaylistId(input);
+  const candidates = [];
+  function push(value) {
+    value = String(value || '').trim();
+    if (value && !candidates.includes(value)) candidates.push(value);
+  }
+  push(id);
+  if (/^VL/i.test(id)) push(id.slice(2));
+  else push('VL' + id);
+  return candidates;
+}
+
+function mapYoutubePlaylistHeader(playlist, id, fallback, tracks) {
+  const header = playlist && playlist.header || {};
+  const subtitle = youtubeText(header.second_subtitle) || youtubeText(header.subtitle) || '';
+  const playableCount = tracks && tracks.length ? tracks.length : 0;
+  const trackCount = playableCount ||
+    youtubeNumberFromText(subtitle, true) ||
+    youtubeNumberFromText(header.song_count || header.item_count, false) ||
+    (fallback && fallback.trackCount) || 0;
+  const creator = youtubeText(header.strapline_text_one);
+  return {
+    provider: 'youtube',
+    source: 'youtube',
+    id,
+    name: youtubeText(header.title) || (fallback && fallback.name) || id,
+    cover: youtubeThumbnailUrl(header.thumbnail || playlist && playlist.background) || (fallback && fallback.cover) || '',
+    trackCount,
+    playCount: youtubeViewCountFromText(subtitle),
+    creator: creator && creator !== 'N/A' ? creator : ((fallback && fallback.creator) || 'YouTube Music'),
+  };
+}
+
+async function getYoutubeLoginInfo() {
+  const hasCookie = youtubeCookieHasLogin(youtubeCookie);
+  if (!hasCookie) {
+    return { provider: 'youtube', loggedIn: false, nickname: 'YouTube Music', userId: '', avatar: '', stale: false };
+  }
+  try {
+    const yt = await getYoutubeMusicClient({ authenticated: true });
+    if (yt && yt.session && yt.session.logged_in === false) {
+      return { provider: 'youtube', loggedIn: false, nickname: 'YouTube Music', userId: '', avatar: '', stale: true };
+    }
+    return { provider: 'youtube', loggedIn: true, nickname: 'YouTube Music', userId: '', avatar: '', stale: false };
+  } catch (e) {
+    console.warn('[YouTubeLogin] session check failed:', e.message);
+    return { provider: 'youtube', loggedIn: false, nickname: 'YouTube Music', userId: '', avatar: '', stale: true, error: e.message };
+  }
+}
+
+function collectYoutubeMusicItems(result) {
+  const shelves = [];
+  if (result && result.songs && Array.isArray(result.songs.contents)) shelves.push(result.songs);
+  if (result && result.videos && Array.isArray(result.videos.contents)) shelves.push(result.videos);
+  if (result && Array.isArray(result.contents)) {
+    result.contents.forEach(section => {
+      if (section && Array.isArray(section.contents)) shelves.push(section);
+    });
+  }
+  const items = [];
+  shelves.forEach(shelf => {
+    (shelf.contents || []).forEach(item => items.push(item));
+  });
+  return items;
+}
+
+async function handleYoutubeSearch(keywords, limit) {
+  const kw = String(keywords || '').trim();
+  if (!kw) return [];
+  const max = Math.max(4, Math.min(18, parseInt(limit || '10', 10) || 10));
+  console.log('[YouTubeMusicSearch]', kw, 'limit:', max);
+  const yt = await getYoutubeMusicClient();
+  let result;
+  try {
+    result = await yt.music.search(kw, { type: 'song' });
+  } catch (e) {
+    console.warn('[YouTubeMusicSearch] filtered search failed:', e.message);
+  }
+  let items = collectYoutubeMusicItems(result);
+  if (!items.length) {
+    result = await yt.music.search(kw);
+    items = collectYoutubeMusicItems(result);
+  }
+  const seen = new Set();
+  const songs = [];
+  items.forEach((item, i) => {
+    const song = mapYoutubeMusicItem(item, i);
+    if (!song || !song.name) return;
+    const key = song.videoId || song.id;
+    if (!key || seen.has(key)) return;
+    seen.add(key);
+    songs.push(song);
+  });
+  return songs.slice(0, max);
+}
+
+async function handleYoutubeUserPlaylists() {
+  const info = await getYoutubeLoginInfo();
+  if (!info.loggedIn) return { loggedIn: false, provider: 'youtube', stale: !!info.stale, playlists: [] };
+  const yt = await getYoutubeMusicClient({ authenticated: true });
+  let library = await yt.music.getLibrary();
+  try {
+    const filter = (library.filters || []).find(name => /playlist|播放列表|歌单/i.test(String(name || '')));
+    if (filter) library = await library.applyFilter(filter);
+  } catch (e) {
+    console.warn('[YouTubeUserPlaylists] playlist filter skipped:', e.message);
+  }
+
+  const rawItems = [];
+  collectYoutubePlaylistItems(library.contents || library, rawItems, new WeakSet(), 0);
+  let page = library;
+  for (let guard = 0; page && page.has_continuation && guard < 8; guard++) {
+    try {
+      page = await page.getContinuation();
+      collectYoutubePlaylistItems(page && page.contents, rawItems, new WeakSet(), 0);
+    } catch (e) {
+      console.warn('[YouTubeUserPlaylists] continuation skipped:', e.message);
+      break;
+    }
+  }
+
+  const seen = new Set();
+  const playlists = rawItems
+    .map(item => mapYoutubePlaylistItem(item, 'library'))
+    .filter(pl => {
+      if (!pl || !pl.id || !pl.name || seen.has(pl.id)) return false;
+      seen.add(pl.id);
+      return true;
+    });
+  return { loggedIn: true, provider: 'youtube', playlists };
+}
+
+async function handleYoutubePlaylistTracks(id) {
+  const candidates = youtubePlaylistIdCandidates(id);
+  if (!candidates.length) return { provider: 'youtube', error: 'Missing YouTube playlist id', tracks: [] };
+  const clients = [];
+  if (youtubeCookieHasLogin(youtubeCookie)) clients.push({ authenticated: true });
+  clients.push({ authenticated: false });
+
+  let playlist = null;
+  let resolvedId = candidates[0];
+  let lastError = null;
+  for (const clientOpts of clients) {
+    let yt;
+    try {
+      yt = await getYoutubeMusicClient(clientOpts);
+    } catch (e) {
+      lastError = e;
+      continue;
+    }
+    for (const candidate of candidates) {
+      try {
+        playlist = await yt.music.getPlaylist(candidate);
+        resolvedId = candidate;
+        break;
+      } catch (e) {
+        lastError = e;
+      }
+    }
+    if (playlist) break;
+  }
+  if (!playlist) {
+    return {
+      provider: 'youtube',
+      error: (lastError && lastError.message) || 'YOUTUBE_PLAYLIST_UNAVAILABLE',
+      tracks: [],
+    };
+  }
+
+  const rawTracks = [];
+  let page = playlist;
+  for (let guard = 0; page && guard < 20; guard++) {
+    (page.items || page.contents || []).forEach(item => rawTracks.push(item));
+    if (!page.has_continuation) break;
+    try {
+      page = await page.getContinuation();
+    } catch (e) {
+      console.warn('[YouTubePlaylistTracks] continuation skipped:', e.message);
+      break;
+    }
+  }
+
+  const seen = new Set();
+  const tracks = rawTracks
+    .map((item, index) => mapYoutubeMusicItem(item, index))
+    .filter(song => {
+      const key = song && (song.videoId || song.id);
+      if (!key || seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  return {
+    loggedIn: youtubeCookieHasLogin(youtubeCookie),
+    provider: 'youtube',
+    playlist: mapYoutubePlaylistHeader(playlist, resolvedId, { id: candidates[0] }, tracks),
+    tracks,
+  };
+}
+
+function classifyYoutubePlaybackRestriction(err, playability) {
+  const status = String(playability && playability.status || '').toUpperCase();
+  const reason = String(playability && (playability.reason || playability.message) || err && err.message || '').trim();
+  if (status === 'LOGIN_REQUIRED' || /login|sign.?in|age/i.test(reason)) {
+    return playbackRestriction('youtube', 'login_required', 'YouTube Music 需要登录或年龄验证，当前无法在本地取到可播放音频', '', { rawMessage: reason });
+  }
+  if (status === 'UNPLAYABLE' || /unavailable|region|country|copyright|private/i.test(reason)) {
+    return playbackRestriction('youtube', 'copyright_unavailable', reason || 'YouTube Music 当前地区或版权暂不可播，可以换一个搜索结果或切到其它音源', 'switch_source', { rawMessage: reason });
+  }
+  return playbackRestriction('youtube', 'url_unavailable', reason || 'YouTube Music 没有返回可播放音频地址', 'switch_source', { rawMessage: reason });
+}
+
+function youtubeAudioQualityLabel(format) {
+  const mime = String(format && format.mime_type || '').toLowerCase();
+  const codec = /opus/.test(mime) ? 'Opus' : (/mp4a|m4a/.test(mime) ? 'AAC' : 'Audio');
+  const br = Number(format && (format.bitrate || format.average_bitrate)) || 0;
+  return br ? ('YouTube Music ' + codec + ' · ' + Math.round(br / 1000) + ' kbps') : ('YouTube Music ' + codec);
+}
+
+function youtubeQualityLevelForFormat(format) {
+  const itag = Number(format && format.itag) || 0;
+  const br = Number(format && (format.bitrate || format.average_bitrate)) || 0;
+  const audioQuality = String(format && format.audio_quality || '').toUpperCase();
+  if (itag === 139 || br && br < 80000 || /LOW|ULTRALOW/.test(audioQuality)) return 'low';
+  return 'high';
+}
+
+function youtubeStreamingQualityCandidates(preference) {
+  const requested = normalizeYoutubeQualityPreference(preference);
+  if (requested === 'low') {
+    return [
+      { level: 'low', quality: 'bestefficiency' },
+      { level: 'high', quality: 'best' },
+    ];
+  }
+  if (requested === 'high') {
+    return [
+      { level: 'high', quality: 'best' },
+      { level: 'low', quality: 'bestefficiency' },
+    ];
+  }
+  return [
+    { level: 'high', quality: 'best' },
+    { level: 'low', quality: 'bestefficiency' },
+  ];
+}
+
+function pickYoutubeAudioFormat(formats, preference) {
+  const requested = normalizeYoutubeQualityPreference(preference);
+  const list = (formats || [])
+    .filter(f => f && f.has_audio && !f.has_video && f.url)
+    .sort((a, b) => (Number(b.bitrate || b.average_bitrate) || 0) - (Number(a.bitrate || a.average_bitrate) || 0));
+  if (!list.length) return null;
+  if (requested === 'low') return list.slice().sort((a, b) => (Number(a.bitrate || a.average_bitrate) || 0) - (Number(b.bitrate || b.average_bitrate) || 0))[0] || null;
+  return list[0] || null;
+}
+
+async function handleYoutubeSongUrl(videoId, qualityPreference) {
+  const id = String(videoId || '').trim();
+  if (!id) return { provider: 'youtube', url: '', playable: false, error: 'MISSING_VIDEO_ID', message: 'Missing YouTube Music video id' };
+  const requestedQuality = normalizeYoutubeQualityPreference(qualityPreference);
+  const yt = await getYoutubeMusicClient();
+  let format = null;
+  let playability = null;
+  let lastError = null;
+  try {
+    const info = await yt.getBasicInfo(id, { client: 'IOS' });
+    playability = info && info.playability_status;
+    const formats = [
+      ...((info && info.streaming_data && info.streaming_data.formats) || []),
+      ...((info && info.streaming_data && info.streaming_data.adaptive_formats) || []),
+    ];
+    format = pickYoutubeAudioFormat(formats, requestedQuality);
+  } catch (innerErr) {
+    lastError = innerErr;
+  }
+  if (!format || !format.url) {
+    for (const candidate of youtubeStreamingQualityCandidates(requestedQuality)) {
+      try {
+        format = await yt.getStreamingData(id, { client: 'IOS', type: 'audio', quality: candidate.quality, format: 'any' });
+        if (format && format.url) break;
+      } catch (err) {
+        lastError = err;
+      }
+    }
+  }
+  if (!format) {
+    const restriction = classifyYoutubePlaybackRestriction(lastError, playability);
+    return {
+      provider: 'youtube',
+      url: '',
+      playable: false,
+      error: 'YOUTUBE_URL_UNAVAILABLE',
+      reason: restriction.category,
+      message: restriction.message,
+      restriction,
+      requestedQuality: 'youtube-' + requestedQuality,
+    };
+  }
+  const directUrl = format && format.url;
+  if (!directUrl) {
+    const restriction = classifyYoutubePlaybackRestriction(null, playability);
+    return {
+      provider: 'youtube',
+      url: '',
+      playable: false,
+      error: 'YOUTUBE_URL_UNAVAILABLE',
+      reason: restriction.category,
+      message: restriction.message,
+      restriction,
+      requestedQuality: 'youtube-' + requestedQuality,
+    };
+  }
+  const resolvedQuality = youtubeQualityLevelForFormat(format);
+  return {
+    provider: 'youtube',
+    url: directUrl,
+    playable: true,
+    trial: false,
+    level: 'youtube-' + resolvedQuality,
+    quality: youtubeAudioQualityLabel(format),
+    br: Number(format.bitrate || format.average_bitrate) || 0,
+    itag: format.itag,
+    mimeType: format.mime_type || '',
+    contentLength: format.content_length || 0,
+    requestedQuality: 'youtube-' + requestedQuality,
+    youtubeQuality: resolvedQuality,
+  };
+}
+
+async function handleYoutubeLyric(videoId) {
+  const id = String(videoId || '').trim();
+  if (!id) return { provider: 'youtube', lyric: '', yrc: '', unavailable: true };
+  try {
+    const yt = await getYoutubeMusicClient({ authenticated: youtubeCookieHasLogin(youtubeCookie) });
+    const data = await yt.music.getLyrics(id);
+    const text = youtubeText(data && (data.description || data.contents || data))
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(Boolean)
+      .join('\n');
+    if (!text || /lyrics unavailable|lyrics not available|no lyrics|instrumental/i.test(text)) {
+      return { provider: 'youtube', lyric: '', yrc: '', unavailable: true };
+    }
+    return { provider: 'youtube', lyric: text, yrc: '', unavailable: false };
+  } catch (e) {
+    return { provider: 'youtube', lyric: '', yrc: '', unavailable: true };
+  }
+}
+
 function audioProxyHeadersFor(audioUrl, range) {
   const headers = { 'User-Agent': UA, Referer: 'https://music.163.com/' };
   try {
     const host = new URL(audioUrl).hostname.toLowerCase();
     if (host.includes('qq.com') || host.includes('qpic.cn')) headers.Referer = 'https://y.qq.com/';
+    if (host.includes('googlevideo.com') || host.includes('youtube.com')) Object.assign(headers, YOUTUBE_MUSIC_HEADERS);
   } catch (e) {}
   if (range) headers.Range = range;
   return headers;
@@ -2358,6 +2949,481 @@ function audioContentTypeForUrl(audioUrl, upstreamType) {
   if (/\.ogg$/.test(pathname)) return 'audio/ogg';
   if (/\.wav$/.test(pathname)) return 'audio/wav';
   return upstreamType || 'audio/mpeg';
+}
+
+function isYoutubeAudioUrl(audioUrl) {
+  try {
+    const host = new URL(audioUrl).hostname.toLowerCase();
+    return host.includes('googlevideo.com') || host.endsWith('youtube.com') || host.endsWith('.youtube.com');
+  } catch (e) {
+    return false;
+  }
+}
+
+function youtubeAudioProxyError(message, status) {
+  const err = new Error(message);
+  err.status = status;
+  return err;
+}
+
+function assertYoutubeAudioProxyReady(audioUrl) {
+  if (!FFMPEG_PATH) throw youtubeAudioProxyError('ffmpeg is not available', 500);
+  if (!/^https?:\/\//i.test(String(audioUrl || '')) || !isYoutubeAudioUrl(audioUrl)) {
+    throw youtubeAudioProxyError('Invalid YouTube audio url', 400);
+  }
+}
+
+function youtubeAudioProxyUrl(audioUrl, opts) {
+  opts = opts || {};
+  const params = new URLSearchParams();
+  params.set('url', audioUrl);
+  if (opts.videoId) params.set('videoId', opts.videoId);
+  if (opts.quality) params.set('quality', opts.quality);
+  if (opts.durationSec) params.set('duration', String(opts.durationSec));
+  return '/api/youtube/audio?' + params.toString();
+}
+
+function youtubeTranscodeBitrate(opts) {
+  const quality = normalizeYoutubeQualityPreference(opts && (opts.quality || opts.qualityPreference));
+  if (quality === 'low') return '96k';
+  if (quality === 'high') return '192k';
+  return '160k';
+}
+
+let youtubeDlpInstallPromise = null;
+
+function isUsableYoutubeDlpFile(filePath) {
+  try {
+    const stat = fs.statSync(filePath);
+    return stat.isFile() && stat.size > 1024 * 1024;
+  } catch (e) {
+    return false;
+  }
+}
+
+function findYoutubeDlpPathSync() {
+  const candidates = [process.env.YTDLP_PATH, YTDLP_BUNDLED_PATH, YTDLP_CACHE_PATH].filter(Boolean);
+  return candidates.find(isUsableYoutubeDlpFile) || '';
+}
+
+function youtubeDlpAvailable() {
+  return !!findYoutubeDlpPathSync();
+}
+
+async function downloadYoutubeDlp() {
+  const targetPath = YTDLP_CACHE_PATH;
+  fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+  const tmpPath = targetPath + '.' + process.pid + '-' + Date.now() + '.tmp';
+  const response = await fetch(YTDLP_DOWNLOAD_URL, {
+    headers: {
+      'User-Agent': UA,
+      Accept: 'application/octet-stream',
+    },
+  });
+  if (!response.ok || !response.body) throw new Error(`yt-dlp download failed ${response.status} ${response.statusText || ''}`.trim());
+
+  const output = fs.createWriteStream(tmpPath, { flags: 'w' });
+  try {
+    const reader = response.body.getReader();
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      if (!output.write(chunk.value)) await once(output, 'drain');
+    }
+    await new Promise((resolve, reject) => output.end(err => err ? reject(err) : resolve()));
+    const stat = fs.statSync(tmpPath);
+    if (!stat.isFile() || stat.size <= 1024 * 1024) throw new Error('yt-dlp download was empty');
+    fs.renameSync(tmpPath, targetPath);
+    return targetPath;
+  } catch (err) {
+    try { output.destroy(); } catch (e) {}
+    try { fs.unlinkSync(tmpPath); } catch (e) {}
+    throw err;
+  }
+}
+
+async function ensureYoutubeDlpPath() {
+  const existing = findYoutubeDlpPathSync();
+  if (existing) return existing;
+  if (!youtubeDlpInstallPromise) {
+    youtubeDlpInstallPromise = downloadYoutubeDlp().finally(() => {
+      youtubeDlpInstallPromise = null;
+    });
+  }
+  return youtubeDlpInstallPromise;
+}
+
+function youtubeDlpFormat(opts) {
+  const quality = normalizeYoutubeQualityPreference(opts && (opts.quality || opts.qualityPreference));
+  if (quality === 'low') return 'worstaudio/bestaudio';
+  return 'bestaudio/best';
+}
+
+function youtubeDlpTargetUrl(opts) {
+  const videoId = String(opts && opts.videoId || '').trim();
+  return videoId ? ('https://music.youtube.com/watch?v=' + encodeURIComponent(videoId)) : '';
+}
+
+async function feedYoutubeAudioFromYtDlp(child, opts) {
+  opts = opts || {};
+  const targetUrl = youtubeDlpTargetUrl(opts);
+  if (!targetUrl) throw new Error('Missing YouTube video id for yt-dlp');
+  const ytdlpPath = await ensureYoutubeDlpPath();
+  const args = [
+    '--no-playlist',
+    '--no-warnings',
+    '--quiet',
+    '--no-cache-dir',
+    '-f', youtubeDlpFormat(opts),
+    '-o', '-',
+    '--add-header', 'Referer:https://music.youtube.com/',
+    '--add-header', `User-Agent:${UA}`,
+  ];
+  if (youtubeCookie) args.push('--add-header', `Cookie:${youtubeCookie}`);
+  args.push(targetUrl);
+
+  let stderr = '';
+  const downloader = spawn(ytdlpPath, args, { windowsHide: true, stdio: ['ignore', 'pipe', 'pipe'] });
+  const stopDownloader = () => {
+    try { downloader.kill('SIGKILL'); } catch (e) {}
+  };
+  child.stdin.on('error', stopDownloader);
+
+  await new Promise((resolve, reject) => {
+    let settled = false;
+    function done(err) {
+      if (settled) return;
+      settled = true;
+      child.stdin.removeListener('error', stopDownloader);
+      if (err) reject(err);
+      else resolve();
+    }
+    downloader.on('error', done);
+    downloader.stderr.on('data', chunk => {
+      stderr += chunk.toString();
+      if (stderr.length > 2400) stderr = stderr.slice(-2400);
+    });
+    downloader.stdout.on('data', chunk => {
+      if (child.stdin.destroyed) {
+        stopDownloader();
+        return;
+      }
+      if (!child.stdin.write(chunk)) {
+        downloader.stdout.pause();
+        child.stdin.once('drain', () => downloader.stdout.resume());
+      }
+    });
+    downloader.stdout.on('end', () => {
+      try { child.stdin.end(); } catch (e) {}
+    });
+    downloader.on('close', code => {
+      if (code) done(new Error(`yt-dlp exited ${code}: ${stderr.trim()}`));
+      else done();
+    });
+  });
+}
+
+function youtubeAudioContentLength(audioUrl) {
+  try {
+    const len = Number(new URL(audioUrl).searchParams.get('clen')) || 0;
+    return len > 0 ? len : 0;
+  } catch (e) {
+    return 0;
+  }
+}
+
+function contentRangeTotal(value) {
+  const match = String(value || '').match(/\/(\d+)\s*$/);
+  return match ? (Number(match[1]) || 0) : 0;
+}
+
+function ensureYoutubeAudioCacheDir() {
+  fs.mkdirSync(YOUTUBE_AUDIO_CACHE_DIR, { recursive: true });
+  return YOUTUBE_AUDIO_CACHE_DIR;
+}
+
+function youtubeAudioCacheKey(audioUrl, opts) {
+  opts = opts || {};
+  const videoId = String(opts.videoId || '').trim();
+  if (videoId) return 'yt:' + videoId + ':' + normalizeYoutubeQualityPreference(opts.quality || opts.qualityPreference || '');
+  return String(audioUrl || '');
+}
+
+function youtubeAudioCacheFile(audioUrl, opts) {
+  const hash = crypto.createHash('sha1').update(youtubeAudioCacheKey(audioUrl, opts)).digest('hex');
+  return path.join(ensureYoutubeAudioCacheDir(), hash + '.mp3');
+}
+
+function isUsableYoutubeAudioCache(filePath) {
+  try {
+    const stat = fs.statSync(filePath);
+    return stat.isFile() && stat.size > 4096;
+  } catch (e) {
+    return false;
+  }
+}
+
+function maybePruneYoutubeAudioCache() {
+  const now = Date.now();
+  if (now < youtubeAudioCachePruneAt) return;
+  youtubeAudioCachePruneAt = now + 30 * 60 * 1000;
+  setTimeout(() => {
+    try {
+      const dir = ensureYoutubeAudioCacheDir();
+      const files = fs.readdirSync(dir)
+        .filter(name => /\.mp3$/i.test(name))
+        .map(name => {
+          const file = path.join(dir, name);
+          const stat = fs.statSync(file);
+          return { file, size: stat.size, mtimeMs: stat.mtimeMs };
+        })
+        .sort((a, b) => b.mtimeMs - a.mtimeMs);
+      let total = files.reduce((sum, item) => sum + item.size, 0);
+      for (let i = files.length - 1; i >= 0 && total > YOUTUBE_AUDIO_CACHE_MAX_BYTES; i--) {
+        total -= files[i].size;
+        try { fs.unlinkSync(files[i].file); } catch (e) {}
+      }
+    } catch (e) {}
+  }, 0);
+}
+
+function parseByteRange(rangeHeader, size) {
+  const match = String(rangeHeader || '').match(/^bytes=(\d*)-(\d*)$/i);
+  if (!match || !size) return null;
+  let start;
+  let end;
+  if (match[1] === '' && match[2] === '') return null;
+  if (match[1] === '') {
+    const suffix = Number(match[2]) || 0;
+    if (suffix <= 0) return null;
+    start = Math.max(0, size - suffix);
+    end = size - 1;
+  } else {
+    start = Number(match[1]);
+    end = match[2] === '' ? size - 1 : Number(match[2]);
+  }
+  if (!Number.isFinite(start) || !Number.isFinite(end) || start < 0 || end < start || start >= size) return null;
+  return { start, end: Math.min(end, size - 1) };
+}
+
+function serveYoutubeAudioCache(req, res, filePath, opts) {
+  opts = opts || {};
+  const stat = fs.statSync(filePath);
+  const size = stat.size;
+  const durationSec = Math.max(0, Number(opts.durationSec) || 0);
+  const baseHeaders = {
+    'Content-Type': 'audio/mpeg',
+    'Access-Control-Allow-Origin': '*',
+    'Cross-Origin-Resource-Policy': 'cross-origin',
+    'Accept-Ranges': 'bytes',
+    'Cache-Control': 'private, max-age=3600',
+    'X-Mineradio-Audio-Proxy': 'youtube-ffmpeg-cache',
+  };
+  if (durationSec > 0) baseHeaders['X-Content-Duration'] = String(durationSec);
+
+  const range = parseByteRange(req.headers.range, size);
+  if (req.headers.range && !range) {
+    res.writeHead(416, {
+      ...baseHeaders,
+      'Content-Range': 'bytes */' + size,
+      'Content-Length': '0',
+    });
+    res.end();
+    return;
+  }
+
+  const start = range ? range.start : 0;
+  const end = range ? range.end : size - 1;
+  const status = range ? 206 : 200;
+  const headers = {
+    ...baseHeaders,
+    'Content-Length': String(end - start + 1),
+  };
+  if (range) headers['Content-Range'] = `bytes ${start}-${end}/${size}`;
+  res.writeHead(status, headers);
+  if (req.method === 'HEAD') {
+    res.end();
+    return;
+  }
+  const stream = fs.createReadStream(filePath, { start, end });
+  stream.on('error', err => {
+    console.warn('[YouTubeAudioCache] stream failed:', err.message);
+    if (!res.destroyed) res.end();
+  });
+  res.on('close', () => {
+    try { stream.destroy(); } catch (e) {}
+  });
+  stream.pipe(res);
+}
+
+async function refreshYoutubeAudioUrlForProxy(opts) {
+  opts = opts || {};
+  const videoId = String(opts.videoId || '').trim();
+  if (!videoId) return '';
+  const info = await handleYoutubeSongUrl(videoId, opts.quality || opts.qualityPreference || '');
+  return info && info.url ? info.url : '';
+}
+
+async function feedYoutubeAudioToFfmpeg(child, audioUrl, opts) {
+  opts = opts || {};
+  let currentUrl = audioUrl;
+  let start = 0;
+  let total = youtubeAudioContentLength(currentUrl);
+  const chunkSize = 1024 * 1024;
+  let refreshAttempts = 0;
+  while (true) {
+    const end = total ? Math.min(total - 1, start + chunkSize - 1) : start + chunkSize - 1;
+    const range = `bytes=${start}-${end}`;
+    let up = await fetch(currentUrl, { headers: audioProxyHeadersFor(currentUrl, range) });
+    if ((!up.ok || !up.body) && (up.status === 403 || up.status === 410) && refreshAttempts < 2) {
+      const nextUrl = await refreshYoutubeAudioUrlForProxy(opts);
+      if (nextUrl && nextUrl !== currentUrl) {
+        refreshAttempts++;
+        currentUrl = nextUrl;
+        total = youtubeAudioContentLength(currentUrl) || total;
+        up = await fetch(currentUrl, { headers: audioProxyHeadersFor(currentUrl, range) });
+      }
+    }
+    if (!up.ok || !up.body) throw new Error(`upstream ${up.status} ${up.statusText || ''}`.trim());
+    const contentRange = up.headers.get('content-range');
+    if (!total) total = contentRangeTotal(contentRange);
+    const reader = up.body.getReader();
+    let received = 0;
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      received += chunk.value.byteLength;
+      if (!child.stdin.destroyed && !child.stdin.write(chunk.value)) await once(child.stdin, 'drain');
+    }
+    if (!received) break;
+    start += received;
+    if (total && start >= total) break;
+    if (up.status === 200 && !contentRange) break;
+  }
+  try { child.stdin.end(); } catch (e) {}
+}
+
+async function transcodeYoutubeAudioToCache(audioUrl, finalPath, opts) {
+  opts = opts || {};
+  maybePruneYoutubeAudioCache();
+  if (isUsableYoutubeAudioCache(finalPath)) return finalPath;
+  const tmpPath = finalPath + '.' + process.pid + '-' + Date.now() + '.tmp';
+  const args = [
+    '-hide_banner',
+    '-loglevel', 'error',
+    '-i', 'pipe:0',
+    '-map', '0:a:0',
+    '-vn',
+    '-f', 'mp3',
+    '-codec:a', 'libmp3lame',
+    '-b:a', youtubeTranscodeBitrate(opts),
+    '-write_xing', '1',
+    '-id3v2_version', '3',
+    'pipe:1',
+  ];
+  let stderr = '';
+  const child = spawn(FFMPEG_PATH, args, { windowsHide: true, stdio: ['pipe', 'pipe', 'pipe'] });
+  const output = fs.createWriteStream(tmpPath, { flags: 'w' });
+
+  try {
+    await new Promise((resolve, reject) => {
+      let settled = false;
+      function done(err) {
+        if (settled) return;
+        settled = true;
+        if (err) {
+          try { child.kill('SIGKILL'); } catch (e) {}
+          try { output.destroy(); } catch (e) {}
+          reject(err);
+          return;
+        }
+        output.end(resolve);
+      }
+      child.stdout.on('data', chunk => {
+        if (!output.write(chunk)) child.stdout.pause();
+      });
+      output.on('drain', () => child.stdout.resume());
+      output.on('error', done);
+      child.stdin.on('error', () => {});
+      child.stderr.on('data', chunk => {
+        stderr += chunk.toString();
+        if (stderr.length > 2400) stderr = stderr.slice(-2400);
+      });
+      child.on('error', done);
+      child.on('close', code => {
+        if (code) done(new Error(`ffmpeg exited ${code}: ${stderr.trim()}`));
+        else done();
+      });
+      const feedPromise = opts.videoId
+        ? feedYoutubeAudioFromYtDlp(child, opts)
+        : feedYoutubeAudioToFfmpeg(child, audioUrl, opts);
+      feedPromise.catch(done);
+    });
+    const stat = fs.statSync(tmpPath);
+    if (!stat.isFile() || stat.size <= 4096) throw new Error('empty ffmpeg output');
+    fs.renameSync(tmpPath, finalPath);
+    return finalPath;
+  } catch (err) {
+    try { fs.unlinkSync(tmpPath); } catch (e) {}
+    throw err;
+  }
+}
+
+async function getYoutubeTranscodedAudioFile(audioUrl, opts) {
+  opts = opts || {};
+  const filePath = youtubeAudioCacheFile(audioUrl, opts);
+  if (isUsableYoutubeAudioCache(filePath)) {
+    try { fs.utimesSync(filePath, new Date(), new Date()); } catch (e) {}
+    maybePruneYoutubeAudioCache();
+    return filePath;
+  }
+  let job = youtubeAudioTranscodeJobs.get(filePath);
+  if (!job) {
+    job = transcodeYoutubeAudioToCache(audioUrl, filePath, opts)
+      .finally(() => youtubeAudioTranscodeJobs.delete(filePath));
+    youtubeAudioTranscodeJobs.set(filePath, job);
+  }
+  return job;
+}
+
+async function prepareYoutubeAudioProxy(audioUrl, opts) {
+  opts = opts || {};
+  assertYoutubeAudioProxyReady(audioUrl);
+  const filePath = await getYoutubeTranscodedAudioFile(audioUrl, opts);
+  const stat = fs.statSync(filePath);
+  return {
+    provider: 'youtube',
+    ready: true,
+    url: youtubeAudioProxyUrl(audioUrl, opts),
+    size: stat.size,
+    duration: Math.max(0, Number(opts.durationSec) || 0),
+    proxy: 'youtube-ffmpeg-cache',
+    downloader: youtubeDlpAvailable() && opts.videoId ? 'yt-dlp' : 'youtube-range',
+  };
+}
+
+async function streamYoutubeAudioTranscode(req, res, audioUrl, opts) {
+  opts = opts || {};
+  try {
+    assertYoutubeAudioProxyReady(audioUrl);
+  } catch (err) {
+    const status = err && err.status ? err.status : 500;
+    res.writeHead(status, {
+      'Content-Type': 'text/plain; charset=utf-8',
+      'Access-Control-Allow-Origin': '*',
+    });
+    res.end(err && err.message ? err.message : 'YouTube audio proxy is not available');
+    return;
+  }
+
+  try {
+    const filePath = await getYoutubeTranscodedAudioFile(audioUrl, opts);
+    serveYoutubeAudioCache(req, res, filePath, opts);
+  } catch (err) {
+    console.warn('[YouTubeAudioTranscode] cache failed:', err.message);
+    if (!res.headersSent) res.writeHead(500, { 'Access-Control-Allow-Origin': '*' });
+    if (!res.destroyed) res.end();
+  }
 }
 
 function mapQQPlaylist(pl, kind) {
@@ -3436,6 +4502,19 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  if (pn === '/api/youtube/search') {
+    try {
+      const kw = url.searchParams.get('keywords') || '';
+      const limit = Math.max(4, Math.min(18, parseInt(url.searchParams.get('limit') || '10', 10) || 10));
+      const songs = await handleYoutubeSearch(kw, limit);
+      sendJSON(res, { provider: 'youtube', songs });
+    } catch (err) {
+      console.error('[YouTubeMusicSearch]', err);
+      sendJSON(res, { provider: 'youtube', error: err.message, songs: [] }, 500);
+    }
+    return;
+  }
+
   if (pn === '/api/qq/song/url') {
     try {
       const mid = url.searchParams.get('mid') || url.searchParams.get('id') || '';
@@ -3446,6 +4525,19 @@ const server = http.createServer(async (req, res) => {
     } catch (err) {
       console.error('[QQSongUrl]', err);
       sendJSON(res, { provider: 'qq', url: '', playable: false, error: err.message }, 500);
+    }
+    return;
+  }
+
+  if (pn === '/api/youtube/song/url') {
+    try {
+      const videoId = url.searchParams.get('videoId') || url.searchParams.get('id') || '';
+      const quality = url.searchParams.get('quality') || '';
+      const info = await handleYoutubeSongUrl(videoId, quality);
+      sendJSON(res, info);
+    } catch (err) {
+      console.error('[YouTubeMusicSongUrl]', err);
+      sendJSON(res, { provider: 'youtube', url: '', playable: false, error: err.message }, 500);
     }
     return;
   }
@@ -3464,7 +4556,78 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  if (pn === '/api/youtube/lyric') {
+    try {
+      const videoId = url.searchParams.get('videoId') || url.searchParams.get('id') || '';
+      const data = await handleYoutubeLyric(videoId);
+      sendJSON(res, data);
+    } catch (err) {
+      console.error('[YouTubeMusicLyric]', err);
+      sendJSON(res, { provider: 'youtube', error: err.message, lyric: '', yrc: '' }, 500);
+    }
+    return;
+  }
+
   // ---------- 歌曲URL ----------
+  if (pn === '/api/youtube/login/status') {
+    try {
+      const info = await getYoutubeLoginInfo();
+      sendJSON(res, info);
+    } catch (err) {
+      console.error('[YouTubeLoginStatus]', err);
+      sendJSON(res, { provider: 'youtube', loggedIn: false, error: err.message }, 500);
+    }
+    return;
+  }
+
+  if (pn === '/api/youtube/login/cookie') {
+    try {
+      const body = await readRequestBody(req);
+      const raw = body.cookie || body.data || body.text || '';
+      const normalized = normalizeCookieHeader(raw) || rawCookieFallback(raw);
+      if (!youtubeCookieHasLogin(normalized)) {
+        sendJSON(res, { provider: 'youtube', loggedIn: false, error: 'INVALID_YOUTUBE_COOKIE', message: 'YouTube cookie missing Google login tokens' }, 400);
+        return;
+      }
+      saveYoutubeCookie(normalized);
+      const info = await getYoutubeLoginInfo();
+      sendJSON(res, { ...info, saved: true });
+    } catch (err) {
+      console.error('[YouTubeLoginCookie]', err);
+      sendJSON(res, { provider: 'youtube', loggedIn: false, error: err.message }, 500);
+    }
+    return;
+  }
+
+  if (pn === '/api/youtube/logout') {
+    saveYoutubeCookie('');
+    sendJSON(res, { provider: 'youtube', ok: true, loggedIn: false });
+    return;
+  }
+
+  if (pn === '/api/youtube/user/playlists') {
+    try {
+      const data = await handleYoutubeUserPlaylists();
+      sendJSON(res, data);
+    } catch (err) {
+      console.error('[YouTubeUserPlaylists]', err);
+      sendJSON(res, { provider: 'youtube', loggedIn: false, error: err.message, playlists: [] }, 500);
+    }
+    return;
+  }
+
+  if (pn === '/api/youtube/playlist/tracks') {
+    try {
+      const id = url.searchParams.get('id') || url.searchParams.get('list') || '';
+      const data = await handleYoutubePlaylistTracks(id);
+      sendJSON(res, data);
+    } catch (err) {
+      console.error('[YouTubePlaylistTracks]', err);
+      sendJSON(res, { provider: 'youtube', error: err.message, tracks: [] }, 500);
+    }
+    return;
+  }
+
   if (pn === '/api/qq/login/status') {
     try {
       const info = await getQQLoginInfo();
@@ -4160,6 +5323,35 @@ const server = http.createServer(async (req, res) => {
   }
 
   // ---------- 音频代理 (支持 Range) ----------
+  if (pn === '/api/youtube/audio/prepare') {
+    const audioUrl = url.searchParams.get('url');
+    const durationSec = Math.max(0, Number(url.searchParams.get('duration') || 0) || 0);
+    const videoId = url.searchParams.get('videoId') || url.searchParams.get('id') || '';
+    const quality = url.searchParams.get('quality') || '';
+    try {
+      const data = await prepareYoutubeAudioProxy(audioUrl, { durationSec, videoId, quality });
+      sendJSON(res, data);
+    } catch (err) {
+      const status = err && err.status ? err.status : 502;
+      console.warn('[YouTubeAudioPrepare] failed:', err && err.message ? err.message : err);
+      sendJSON(res, {
+        provider: 'youtube',
+        ready: false,
+        error: err && err.message ? err.message : 'YouTube audio prepare failed',
+      }, status);
+    }
+    return;
+  }
+
+  if (pn === '/api/youtube/audio') {
+    const audioUrl = url.searchParams.get('url');
+    const durationSec = Math.max(0, Number(url.searchParams.get('duration') || 0) || 0);
+    const videoId = url.searchParams.get('videoId') || url.searchParams.get('id') || '';
+    const quality = url.searchParams.get('quality') || '';
+    await streamYoutubeAudioTranscode(req, res, audioUrl, { durationSec, videoId, quality });
+    return;
+  }
+
   if (pn === '/api/audio') {
     try {
       const audioUrl = url.searchParams.get('url');


### PR DESCRIPTION
## Summary
- Add YouTube Music playback support paths that keep the existing Mineradio UI style and desktop integration.
- Route YouTube playback through a prepared, cache-backed MP3 proxy so Electron receives stable seekable audio.
- Use `yt-dlp` at runtime, auto-downloaded into the Mineradio cache when missing, so no large binary is committed.
- Keep YouTube quality handling separate from the other providers and avoid showing lyrics when YouTube lyrics are unavailable.

## Root Cause
YouTube `googlevideo` URLs returned through the previous flow can reject later range or continuation requests with `403 Forbidden`. The old live ffmpeg stream then exposed partial audio to the Electron `<audio>` element, which caused seeking to restart playback and some tracks to end around the one-minute mark.

## User Impact
This should fix the main-process `upstream 403 Forbidden` crash, the one-minute truncation/auto-skip behavior, and the seek bar restarting the current track after dragging.

## Validation
- `node --check server.js`
- Inline `public/index.html` script syntax check with Node
- `git diff --check HEAD~1 HEAD`
- Local YouTube prepare/range probe returned the cache-backed ffmpeg path with HTTP 206 ranges
- Hidden Electron audio probe played, seeked to 120s, and continued without `ended` or `error`