### PR TITLE
fix: resume AudioContext before audio.play() on manual playback

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -18635,8 +18635,8 @@ async function attemptAudioPlay(opts) {
       if (!audioReady) initAudio();
       if (opts.fade !== false) preparePlaybackFadeIn();
       if (opts.manual) {
-        var manualPlay = audio.play();
         await resumeAudioAnalysis();
+        var manualPlay = audio.play();
         await manualPlay;
       } else {
         await resumeAudioAnalysis();


### PR DESCRIPTION
## Summary

Fixes #165

When playback is paused for an extended period and then resumed via the play button (or spacebar), no audio is produced despite the UI showing playback as active. The user must switch to the next track to recover audio.

## Root Cause

In `attemptAudioPlay()`, the **manual** path (used by the play button / spacebar → `togglePlay()`) called `audio.play()` **before** `resumeAudioAnalysis()`:

```javascript
// ❌ Manual path — wrong order
if (opts.manual) {
    var manualPlay = audio.play();       // play() before context resume
    await resumeAudioAnalysis();
    await manualPlay;
}
```

Meanwhile, the **automatic** path (used during track switching → `playAudio()`) had the correct order:

```javascript
// ✅ Automatic path — correct order
} else {
    await resumeAudioAnalysis();         // context resumed first
    await audio.play();
}
```

### Why this matters

- The `<audio>` element's output is routed through a `MediaElementSourceNode` connected to the Web Audio `AudioContext`
- Per the Web Audio API spec, when the `AudioContext` is suspended, `MediaElementSourceNode` outputs **silence**
- Chromium/Electron automatically suspends the `AudioContext` after extended idle periods to save resources
- Calling `audio.play()` while the context is suspended starts the media element but produces no sound
- `resumeAudioAnalysis()` only handles the `'suspended'` state — if called after `play()`, the pipeline may already be in a broken state

This explains why:
- ❌ Pause → wait → click play = **no sound** (manual path, wrong order)
- ✅ Skip to next track = **works** (automatic path, correct order)

## Fix

Swap the order in the manual path so `resumeAudioAnalysis()` is called before `audio.play()`, matching the automatic path:

```diff
 if (opts.manual) {
-    var manualPlay = audio.play();
+    await resumeAudioAnalysis();
-    await resumeAudioAnalysis();
+    var manualPlay = audio.play();
     await manualPlay;
 }
```

## Testing

The change is minimal (1 line swap) and makes the manual path identical in ordering to the already-working automatic path. Both paths now follow the same pattern: resume context → play audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)