### PR TITLE
修复 Linux 环境渲染启动兜底

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -48,8 +48,10 @@ const CHROMIUM_PERFORMANCE_SWITCHES = [
   ['disable-renderer-backgrounding'],
   ['disable-backgrounding-occluded-windows'],
   ['force_high_performance_gpu'],
-  ['use-angle', 'd3d11'],
 ];
+if (process.platform === 'win32') {
+  CHROMIUM_PERFORMANCE_SWITCHES.push(['use-angle', 'd3d11']);
+}
 for (const [name, value] of CHROMIUM_PERFORMANCE_SWITCHES) {
   if (value == null) app.commandLine.appendSwitch(name);
   else app.commandLine.appendSwitch(name, value);
@@ -1370,6 +1372,10 @@ async function createWindow() {
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     shell.openExternal(url);
     return { action: 'deny' };
+  });
+
+  mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
+    console.warn(`Main window load failed: ${errorCode} ${errorDescription} ${validatedURL}`);
   });
 
   mainWindow.webContents.once('did-finish-load', () => {

--- a/public/index.html
+++ b/public/index.html
@@ -3770,7 +3770,32 @@ function getRenderLoadTier() {
   if (cssPixels >= 3200000 || renderPixels >= 3600000) return 1;
   return 0;
 }
-var renderer = new THREE.WebGLRenderer({ antialias: false, alpha: true, powerPreference: 'high-performance' });
+function createRendererFallback(reason) {
+  var canvas = document.createElement('canvas');
+  canvas.className = 'webgl-fallback-canvas';
+  canvas.setAttribute('aria-hidden', 'true');
+  console.warn('WebGL renderer unavailable, continuing with UI-only fallback:', reason && (reason.message || reason));
+  return {
+    domElement: canvas,
+    info: { memory: { geometries: 0, textures: 0 }, render: { calls: 0, triangles: 0 } },
+    capabilities: { getMaxAnisotropy: function(){ return 1; } },
+    renderLists: { dispose: function(){} },
+    setClearColor: function(){},
+    setPixelRatio: function(v){ this._pixelRatio = v || 1; },
+    getPixelRatio: function(){ return this._pixelRatio || 1; },
+    setSize: function(w, h){ canvas.width = Math.max(1, Math.floor(w || 1)); canvas.height = Math.max(1, Math.floor(h || 1)); },
+    render: function(){},
+    compile: function(){},
+    initTexture: function(){},
+    dispose: function(){}
+  };
+}
+var renderer;
+try {
+  renderer = new THREE.WebGLRenderer({ antialias: false, alpha: true, powerPreference: 'high-performance' });
+} catch (e) {
+  renderer = createRendererFallback(e);
+}
 renderer.setClearColor(0x000000, 0);
 renderer.setPixelRatio(getRenderPixelRatio());
 renderer.setSize(innerWidth, innerHeight);
@@ -26108,6 +26133,12 @@ function markSplashReadyToEnter() {
   s.setAttribute('role', 'button');
   s.setAttribute('tabindex', '0');
   s.setAttribute('aria-label', '点击进入 Mineradio');
+  if (!splashTimer) {
+    splashTimer = setTimeout(function(){
+      splashTimer = null;
+      if (document.body.classList.contains('splash-active')) dismissSplash();
+    }, 1200);
+  }
 }
 
 document.addEventListener('DOMContentLoaded', function(){


### PR DESCRIPTION
## 修复内容  
  
- 仅在 Windows 下启用 D3D11 ANGLE 参数，避免 Linux/Wayland 环境被错误强制使用 Windows 专用后端。  
- 增加 WebGL Renderer 创建失败兜底，避免 Electron/Chromium GPU 初始化异常时前端脚本中断、卡在首页或启动页。  
- 启动页进入提示出现后自动退出，避免用户被启动遮罩层卡住。  
- 增加主窗口加载失败日志，方便后续排查 Linux 环境加载问题。  
  
## 验证  
  
- `node --check desktop/main.js`  
- `node --check server.js`  
- `git diff --check`  
  
## 说明  
  
项目本身不直接使用 Vulkan；Linux 下具体走 Vulkan、EGL 还是 OpenGL 仍交由 Electron/Chromium 和用户系统环境决定，本修复不会在 Linux 上强制禁用 Vulkan。  
