### PR TITLE
feat: Linux 适配 - AppImage + deb 构建支持

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,0 +1,76 @@
+name: Build Linux (AppImage + deb)
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
+      - 'LICENSE'
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Linux (AppImage + deb)
+        run: npm run build:linux
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload AppImage artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Mineradio-AppImage
+          path: dist/*.AppImage
+          if-no-files-found: error
+
+      - name: Upload deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Mineradio-deb
+          path: dist/*.deb
+          if-no-files-found: error
+
+  release:
+    needs: build-linux
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download AppImage
+        uses: actions/download-artifact@v4
+        with:
+          name: Mineradio-AppImage
+
+      - name: Download deb
+        uses: actions/download-artifact@v4
+        with:
+          name: Mineradio-deb
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            *.AppImage
+            *.deb
+          generate_release_notes: true

--- a/README.md
+++ b/README.md
@@ -34,6 +34,61 @@ git merge upstream/main
 git push origin main
 ```
 
+## Linux 安装
+
+有两种安装方式，按需选择：
+
+### 方式一：AppImage（免安装，推荐）
+
+AppImage 是单个可执行文件，下载后赋予执行权限即可双击运行，无需安装。
+
+```bash
+# 下载后赋予执行权限（文件名以实际 Release 为准）
+chmod +x Mineradio-1.1.1-x86_64.AppImage
+
+# 运行
+./Mineradio-1.1.1-x86_64.AppImage
+```
+
+> 如果双击无法运行，可能是文件管理器未启用「允许执行」，在文件属性里勾选「作为程序执行」即可。
+
+### 方式二：deb 包（系统安装，适合 Debian/Ubuntu 系）
+
+```bash
+# 安装
+sudo dpkg -i Mineradio-1.1.1-x64.deb
+
+# 如提示缺少依赖，补一下再安装
+sudo apt-get install -f
+
+# 安装后从应用菜单启动 Mineradio，或命令行运行
+mineradio
+```
+
+安装包会自动注册到系统应用菜单，卸载使用 `sudo apt remove mineradio`。
+
+### 系统依赖
+
+基于 Electron 的应用需要以下运行库，大多数桌面发行版已默认包含，缺失时按需安装：
+
+```bash
+sudo apt install libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 \
+  xdg-utils libatspi2.0-0 libdrm2 libgbm1
+```
+
+> AppImage 用户通常无需手动安装，AppImage 会自带大部分依赖。
+
+### 从源码构建
+
+如果 Release 里没有你需要的包，可从源码自行构建：
+
+```bash
+git clone https://github.com/jade2-fff/Mineradio-for-linux.git
+cd Mineradio-for-linux
+npm install
+npm run build:linux        # 生成 AppImage + deb，产物在 dist/
+```
+
 ## 原版 Windows 下载
 
 ## 立即下载 Windows 安装包

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@
 
 Mineradio 是一款沉浸式音乐播放器，把天气电台、搜索播放、歌词舞台、粒子视觉和 3D 歌单架组合成一个更接近现场感的私人音乐空间。本仓库是针对 Linux x86_64 平台的适配版本。
 
+## 立即下载 Linux 版
+
+| 安装方式 | 适用发行版 | 下载 |
+| --- | --- | --- |
+| AppImage（免安装，推荐） | 所有主流发行版 | [Mineradio-1.1.1-x86_64.AppImage](https://github.com/jade2-fff/Mineradio-for-linux/releases/download/v1.1.1/Mineradio-1.1.1-x86_64.AppImage) |
+| deb 包 | Debian / Ubuntu / 深度 | [Mineradio-1.1.1-amd64.deb](https://github.com/jade2-fff/Mineradio-for-linux/releases/download/v1.1.1/Mineradio-1.1.1-amd64.deb) |
+
+> [查看所有 Release](https://github.com/jade2-fff/Mineradio-for-linux/releases)
+
 ## Linux 适配说明
 
 - **构建目标**：AppImage + deb（x64）

--- a/README.md
+++ b/README.md
@@ -1,8 +1,40 @@
-# Mineradio
+# Mineradio for Linux
 
 ![Mineradio 暗场启动页](./docs/assets/readme/cinema-beat-smoke.png)
 
-Mineradio 是一款 Windows 桌面沉浸式音乐播放器，把天气电台、搜索播放、歌词舞台、粒子视觉和 3D 歌单架组合成一个更接近现场感的私人音乐空间。
+> **Linux x86 适配版** — 基于 [XxHuberrr/Mineradio](https://github.com/XxHuberrr/Mineradio)，由 [jade2-fff](https://github.com/jade2-fff) 移植，保持与上游同步更新。
+
+Mineradio 是一款沉浸式音乐播放器，把天气电台、搜索播放、歌词舞台、粒子视觉和 3D 歌单架组合成一个更接近现场感的私人音乐空间。本仓库是针对 Linux x86_64 平台的适配版本。
+
+## Linux 适配说明
+
+- **构建目标**：AppImage + deb（x64）
+- **GPU 渲染**：Windows d3d11 → Linux OpenGL + Wayland 自适应（ozone）
+- **已适配**：窗口图标、更新选包、AppImage 自动 chmod+启动、节奏缓存目录跨平台化
+- **已知降级**（不影响核心播放）：
+  - 桌面歌词中键全局解锁（依赖 Windows PowerShell，Linux 上静默跳过）
+  - 壁纸嵌入桌面图标层（依赖 Win32 WorkerW API，Linux 上静默跳过）
+
+### 推荐安装字体
+
+```bash
+sudo apt install fonts-noto-cjk fonts-inter
+```
+
+## 同步上游更新
+
+本项目保持与原作者仓库 [XxHuberrr/Mineradio](https://github.com/XxHuberrr/Mineradio) 同步。当上游有新版本发布时，执行以下命令拉取合并：
+
+```bash
+git fetch upstream
+git merge upstream/main
+# 如有冲突，手动解决后：
+# git add .
+# git commit
+git push origin main
+```
+
+## 原版 Windows 下载
 
 ## 立即下载 Windows 安装包
 
@@ -69,11 +101,21 @@ Windows 用户可以在 GitHub Releases 中下载安装包。
 
 ```bash
 npm install
+
+# 开发模式启动
 npm start
+
+# Windows 构建
 npm run build:win
+
+# Linux 构建（AppImage + deb）
+npm run build:linux
+
+# Linux 仅打包目录（调试用，更快）
+npm run build:linux:dir
 ```
 
-桌面版入口由 Electron 主进程加载本地服务。`npm run build:win` 会生成 Windows NSIS 安装包，产物位于 `dist/`。
+桌面版入口由 Electron 主进程加载本地服务。`npm run build:win` 会生成 Windows NSIS 安装包，`npm run build:linux` 会生成 AppImage 和 deb 安装包，产物均位于 `dist/`。
 
 ## 更新机制
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,21 @@ sudo apt install libgtk-3-0 libnotify4 libnss3 libxss1 libxtst6 \
 
 > AppImage 用户通常无需手动安装，AppImage 会自带大部分依赖。
 
+### 常见问题：双击没反应 / 启动秒退
+
+deb 安装后双击没反应，通常是 Electron 的 `chrome-sandbox` 权限不对。一条命令修复：
+
+```bash
+sudo chown root:root /opt/Mineradio/chrome-sandbox && sudo chmod 4755 /opt/Mineradio/chrome-sandbox
+```
+
+> AppImage 用户如果也遇到，先解包再执行相同操作：
+> ```bash
+> ./Mineradio-*.AppImage --appimage-extract
+> sudo chown root:root squashfs-root/chrome-sandbox && sudo chmod 4755 squashfs-root/chrome-sandbox
+> ./squashfs-root/AppRun
+> ```
+
 ### 从源码构建
 
 如果 Release 里没有你需要的包，可从源码自行构建：

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -31,7 +31,10 @@ const MIN_WINDOWED_WIDTH = 960;
 const MIN_WINDOWED_HEIGHT = 540;
 const APP_NAME = 'Mineradio';
 const APP_USER_MODEL_ID = 'com.mineradio.desktop';
-const APP_ICON_ICO = path.join(__dirname, '..', 'build', 'icon.ico');
+// 窗口图标按平台选择：Windows 用 .ico，其它平台（Linux/macOS）用 .png。
+const APP_ICON_ICO = process.platform === 'win32'
+  ? path.join(__dirname, '..', 'build', 'icon.ico')
+  : path.join(__dirname, '..', 'build', 'icon.png');
 const NETEASE_LOGIN_PARTITION = 'persist:mineradio-netease-login';
 const NETEASE_LOGIN_URL = 'https://music.163.com/#/login';
 const QQ_LOGIN_PARTITION = 'persist:mineradio-qqmusic-login';
@@ -48,11 +51,21 @@ const CHROMIUM_PERFORMANCE_SWITCHES = [
   ['disable-renderer-backgrounding'],
   ['disable-backgrounding-occluded-windows'],
   ['force_high_performance_gpu'],
-  ['use-angle', 'd3d11'],
+  // Angle 后端按平台选择：Windows 用 d3d11，Linux 优先 OpenGL（兼容性最稳）。
+  ['use-angle', process.platform === 'win32' ? 'd3d11' : 'gl'],
 ];
 for (const [name, value] of CHROMIUM_PERFORMANCE_SWITCHES) {
   if (value == null) app.commandLine.appendSwitch(name);
   else app.commandLine.appendSwitch(name, value);
+}
+
+// Linux 下让 Electron/X11 应用在不同会话（X11 / Wayland）下都能正常合成透明窗口。
+// 当会话是 Wayland 时用 wayland 后端，否则回落到默认 X11。
+if (process.platform === 'linux') {
+  if (process.env.XDG_SESSION_TYPE === 'wayland' || !!(process.env.WAYLAND_DISPLAY)) {
+    app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
+    app.commandLine.appendSwitch('enable-features', 'UseOzonePlatform,WaylandWindowDecorations');
+  }
 }
 const gotSingleInstanceLock = app.requestSingleInstanceLock();
 
@@ -1184,6 +1197,17 @@ ipcMain.handle('mineradio-open-update-installer', async (_event, filePath) => {
       return { ok: false, error: 'INVALID_UPDATE_PATH' };
     }
     if (!fs.existsSync(target)) return { ok: false, error: 'UPDATE_FILE_MISSING' };
+
+    // Linux 上更新产物通常是 AppImage：它是一个可执行文件，不能用 xdg-open 打开。
+    // 需要补上可执行权限后直接启动；其它格式（deb/rpm）交给系统默认程序。
+    if (process.platform === 'linux' && /\.appimage$/i.test(target)) {
+      try { fs.chmodSync(target, 0o755); } catch (_) {}
+      const child = spawn(target, { detached: true, stdio: 'ignore' });
+      child.on('error', () => {});
+      child.unref();
+      return { ok: true };
+    }
+
     const error = await shell.openPath(target);
     return error ? { ok: false, error } : { ok: true };
   } catch (e) {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "start": "electron .",
     "build:win": "electron-builder --win nsis",
-    "build:win:dir": "electron-builder --win dir"
+    "build:win:dir": "electron-builder --win dir",
+    "build:linux": "electron-builder --linux AppImage deb",
+    "build:linux:dir": "electron-builder --linux dir"
   },
   "build": {
     "appId": "com.mineradio.desktop",
@@ -60,6 +62,41 @@
       "installerHeader": "build/installerHeader.bmp",
       "include": "build/installer.nsh",
       "artifactName": "Mineradio-${version}-Setup.${ext}"
+    },
+    "linux": {
+      "executableName": "mineradio",
+      "icon": "build/icon.png",
+      "category": "AudioVideo",
+      "mimeTypes": ["audio/mpeg", "audio/mp3", "audio/flac"],
+      "maintainer": "Mineradio",
+      "desktop": {
+        "entry": {
+          "Name": "Mineradio",
+          "Comment": "沉浸式音乐播放器",
+          "StartupWMClass": "Mineradio",
+          "Categories": "AudioVideo;Audio;Player;"
+        }
+      },
+      "target": [
+        {
+          "target": "AppImage",
+          "arch": ["x64"]
+        },
+        {
+          "target": "deb",
+          "arch": ["x64"]
+        }
+      ]
+    },
+    "appImage": {
+      "artifactName": "Mineradio-${version}-${arch}.AppImage"
+    },
+    "deb": {
+      "artifactName": "Mineradio-${version}-${arch}.deb",
+      "depends": [
+        "libgtk-3-0", "libnotify4", "libnss3", "libxss1",
+        "libxtst6", "xdg-utils", "libatspi2.0-0", "libdrm2", "libgbm1"
+      ]
     },
     "publish": [
       {

--- a/server.js
+++ b/server.js
@@ -62,13 +62,36 @@ const QQ_COOKIE_FILE = process.env.QQ_COOKIE_FILE || path.join(__dirname, '.qq-c
 const UPDATE_WORK_DIR = process.env.MINERADIO_UPDATE_DIR || path.join(__dirname, 'updates');
 const UPDATE_DOWNLOAD_DIR = process.env.MINERADIO_UPDATE_DOWNLOAD_DIR || path.join(UPDATE_WORK_DIR, 'downloads');
 const UPDATE_PATCH_BACKUP_DIR = process.env.MINERADIO_PATCH_BACKUP_DIR || path.join(UPDATE_WORK_DIR, 'backups', 'patches');
-const BEATMAP_CACHE_DIR = process.env.MINERADIO_BEAT_CACHE_DIR || 'D:\\MineradioCache\\beatmaps';
+// 节奏分析缓存目录：优先用环境变量覆盖，否则按平台放在用户数据目录下，
+// 避免硬编码 Windows 盘符路径在 Linux/macOS 上失效。
+const BEATMAP_CACHE_DIR = process.env.MINERADIO_BEAT_CACHE_DIR || (
+  process.platform === 'win32'
+    ? 'D:\\MineradioCache\\beatmaps'
+    : path.join(require('os').homedir(), '.cache', 'mineradio', 'beatmaps')
+);
 const APP_PACKAGE = readPackageInfo();
 const APP_VERSION = process.env.MINERADIO_VERSION || APP_PACKAGE.version || '0.9.11';
 const UPDATE_CONFIG = readUpdateConfig(APP_PACKAGE);
 const PATCH_MAX_BYTES = 12 * 1024 * 1024;
 const PATCH_ALLOWED_ROOTS = new Set(['public', 'desktop', 'build']);
 const PATCH_ALLOWED_FILES = new Set(['server.js', 'dj-analyzer.js', 'package.json', 'package-lock.json']);
+// 不同平台更新安装包的扩展名优先级，用于从 GitHub Release 产物里挑选本平台可用的安装包。
+const PLATFORM_INSTALLER_EXT = process.platform === 'win32'
+  ? ['exe', 'msi']
+  : process.platform === 'darwin'
+    ? ['dmg', 'zip', 'pkg']
+    : ['appimage', 'deb', 'rpm', 'tar.gz'];
+// 不同平台更新安装包的默认文件名（含扩展名），用于缺失名字时的兜底。
+const PLATFORM_DEFAULT_INSTALLER = process.platform === 'win32'
+  ? `Mineradio-${APP_VERSION}-Setup.exe`
+  : process.platform === 'darwin'
+    ? `Mineradio-${APP_VERSION}.dmg`
+    : `Mineradio-${APP_VERSION}-x86_64.AppImage`;
+// 判断 Release 产物文件名是否属于本平台可安装包。
+function isPlatformInstallerName(name) {
+  const lower = String(name || '').toLowerCase();
+  return PLATFORM_INSTALLER_EXT.some((ext) => lower.endsWith('.' + ext));
+}
 const UPDATE_FALLBACK_NOTES = [
   '电影镜头节奏更松',
   '音源失败自动换源',
@@ -364,7 +387,8 @@ function extractReleaseNotes(body) {
 }
 function pickReleaseAsset(assets) {
   const list = Array.isArray(assets) ? assets : [];
-  const preferred = list.find(a => /\.(exe|msi)$/i.test(a && a.name || ''))
+  // 优先挑选本平台安装包；其次退回到任意归档包；最后取第一个资产。
+  const preferred = list.find(a => isPlatformInstallerName(a && a.name || ''))
     || list.find(a => /\.(zip|7z)$/i.test(a && a.name || ''))
     || list[0];
   if (!preferred) return null;
@@ -453,7 +477,7 @@ function normalizeManifestUpdateInfo(data) {
     ? release.notes.slice(0, 4).map(cleanReleaseLine).filter(Boolean)
     : (extractReleaseNotes(release.body || data.body).length ? extractReleaseNotes(release.body || data.body) : UPDATE_FALLBACK_NOTES);
   const assetInfo = downloadUrl ? {
-    name: asset.name || updateAssetNameFromUrl(downloadUrl) || `Mineradio-${latestVersion}-Setup.exe`,
+    name: asset.name || updateAssetNameFromUrl(downloadUrl) || PLATFORM_DEFAULT_INSTALLER.replace(/\$\{?version\}?/gi, latestVersion),
     size: Number(asset.size || 0) || 0,
     contentType: asset.contentType || asset.content_type || '',
     downloadUrl,
@@ -667,7 +691,7 @@ function githubReleaseDownloadUrl(version, fileName) {
 }
 function parseLatestYmlUpdateInfo(text, reason) {
   const latestVersion = normalizeVersion(yamlScalar(text, 'version') || APP_VERSION) || APP_VERSION;
-  const assetPath = yamlScalar(text, 'path') || yamlScalar(text, 'url') || `Mineradio-${latestVersion}-Setup.exe`;
+  const assetPath = yamlScalar(text, 'path') || yamlScalar(text, 'url') || PLATFORM_DEFAULT_INSTALLER.replace(/\$\{?version\}?/gi, latestVersion);
   const sha512 = normalizeDigest(yamlScalar(text, 'sha512'), 'sha512');
   const size = Number(yamlScalar(text, 'size') || 0) || 0;
   const releaseDate = yamlScalar(text, 'releaseDate');
@@ -764,13 +788,13 @@ async function fetchLatestUpdateInfo() {
   }
 }
 function safeUpdateFileName(name, version) {
-  const raw = String(name || '').trim() || `Mineradio-${version || APP_VERSION}.exe`;
+  const raw = String(name || '').trim() || PLATFORM_DEFAULT_INSTALLER.replace(/\$\{?version\}?/gi, version || APP_VERSION);
   const cleaned = raw
     .replace(/[<>:"/\\|?*\x00-\x1F]/g, '-')
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, 160);
-  return cleaned || `Mineradio-${version || APP_VERSION}.exe`;
+  return cleaned || PLATFORM_DEFAULT_INSTALLER.replace(/\$\{?version\}?/gi, version || APP_VERSION);
 }
 function publicUpdateJob(job) {
   if (!job) return { ok: false, error: 'UPDATE_JOB_NOT_FOUND' };
@@ -1347,7 +1371,7 @@ function startUpdatePatchJob(info) {
     received: 0,
     total: patch.size || 0,
     mode: 'patch',
-    fileName: patch.name || safeUpdateFileName('', version).replace(/\.exe$/i, '.patch.json'),
+    fileName: patch.name || safeUpdateFileName('', version).replace(/\.(exe|msi|appimage|deb|rpm|dmg|pkg)$/i, '.patch.json').replace(/\.tar\.gz$/i, '.patch.json'),
     filePath: '',
     version,
     downloadUrl,


### PR DESCRIPTION
为 Mineradio 添加 Linux x86_64 构建支持。

## 改动
- `package.json`: 添加 Linux 构建目标 (AppImage + deb)
- `desktop/main.cjs`: Linux 路径适配
- `.github/workflows/build-linux.yml`: CI 自动构建

## 产物
- `Mineradio-x.y.z-x86_64.AppImage` (~135MB)
- `Mineradio-x.y.z-amd64.deb` (~105MB)

## 测试
已在 Ubuntu 24.04 验证，Release: https://github.com/jade2-fff/Mineradio-for-linux/releases/tag/v1.1.1