### PR TITLE
feat: add NetEase album browse and playback

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -174,6 +174,7 @@ body.empty-home-active.diy-mode #search-area:not(.has-results) #search-mode-tabs
 #search-results.show{display:block;border-color:rgba(var(--fc-accent-rgb),.16);box-shadow:0 18px 54px rgba(0,0,0,.34),0 0 0 1px rgba(var(--fc-accent-rgb),.05)}
 #search-results::-webkit-scrollbar{width:3px}
 #search-results::-webkit-scrollbar-thumb{background:rgba(255,255,255,0.1);border-radius:2px}
+.search-section-label{padding:10px 12px 6px;color:rgba(255,255,255,.42);font-size:10.5px;font-weight:760;letter-spacing:.14em;text-transform:uppercase}
 .search-empty{padding:16px;text-align:center;font-size:12px;color:rgba(255,255,255,.42);letter-spacing:.4px}
 .search-history{padding:10px}
 .search-history-head{display:flex;align-items:center;justify-content:space-between;margin-bottom:8px;padding:0 2px;color:rgba(255,255,255,.42);font-size:10.5px;letter-spacing:.8px}
@@ -2710,7 +2711,7 @@ var audioFadeTimer = null, audioElementFadeFrame = 0, audioFadeSerial = 0;
 var AUDIO_FADE_IN_MS = 460;
 var AUDIO_FADE_OUT_MS = 420;
 var AUDIO_SILENCE_GAIN = 0.0001;
-var userPlaylists = [], qqPlaylists = [], myPodcastCollections = [], myPodcastItems = {}, playlistCoverCache = {};
+var userPlaylists = [], qqPlaylists = [], userAlbums = [], myPodcastCollections = [], myPodcastItems = {}, playlistCoverCache = {};
 var CUSTOM_COVER_STORE_KEY = 'mineradio-custom-covers';
 var CUSTOM_LYRIC_STORE_KEY = 'mineradio-custom-lyrics-v1';
 var CUSTOM_LYRIC_PREF_STORE_KEY = 'mineradio-custom-lyric-prefs-v1';
@@ -2761,7 +2762,7 @@ var visualGuideState = { bottomWasVisible: false, searchWasPeek: false, manual: 
 var emptyHomeActive = false;
 var homeForcedOpen = false;
 var homeSuppressed = false;
-var homeDiscoverState = { loading: false, loaded: false, loggedIn: false, mode: 'starter', songs: [], playlists: [], podcasts: [], error: '', updatedAt: 0 };
+var homeDiscoverState = { loading: false, loaded: false, loggedIn: false, mode: 'starter', songs: [], playlists: [], albums: [], podcasts: [], error: '', updatedAt: 0 };
 var homeDiscoverToken = 0;
 var homeVisualPresetActive = false;
 var homeVisualPrevPreset = 0;
@@ -15479,6 +15480,7 @@ function homeToneForItem(item, index) {
   if (item.tone) return item.tone;
   if (item.kind === 'song') return index % 2 ? 'search' : 'daily';
   if (item.kind === 'playlist') return 'playlist';
+  if (item.kind === 'album') return 'library';
   if (item.kind === 'podcast' || item.kind === 'podcastSearch') return 'podcast';
   if (item.kind === 'local') return 'local';
   if (item.kind === 'guide') return 'guide';
@@ -15523,6 +15525,11 @@ function renderHomeTiles() {
     homeDiscoverState.playlists.slice(0, Math.max(0, 5 - tiles.length)).forEach(function(pl, i){
       tiles.push({ kind: 'playlist', index: i, title: pl.name || '推荐歌单', sub: (pl.trackCount ? pl.trackCount + ' 首' : 'Playlist') + (pl.playCount ? ' · ' + compactHomeCount(pl.playCount) + ' 播放' : ''), cover: pl.cover });
     });
+    if (tiles.length < 5) {
+      homeDiscoverState.albums.slice(0, 5 - tiles.length).forEach(function(album, i){
+        tiles.push({ kind: 'album', index: i, title: album.name || '收藏专辑', sub: (album.artist || '网易云专辑') + (album.songCount ? ' · ' + album.songCount + ' 首' : ''), cover: album.cover });
+      });
+    }
     if (tiles.length < 5) {
       homeDiscoverState.podcasts.slice(0, 5 - tiles.length).forEach(function(p, i){
         tiles.push({ kind: 'podcast', index: i, title: p.name || '热门播客', sub: p.djName || p.category || 'Podcast', cover: p.cover });
@@ -15651,6 +15658,7 @@ async function loadHomeDiscover(force) {
     homeDiscoverState.mode = data && data.mode || (homeDiscoverState.loggedIn ? 'member' : 'starter');
     homeDiscoverState.songs = homeDiscoverState.loggedIn ? (data && data.dailySongs || []).map(cloneSong) : [];
     homeDiscoverState.playlists = homeDiscoverState.loggedIn ? (data && data.playlists || []) : [];
+    homeDiscoverState.albums = homeDiscoverState.loggedIn ? (data && data.albums || []) : [];
     homeDiscoverState.podcasts = homeDiscoverState.loggedIn ? (data && data.podcasts || []) : [];
     homeDiscoverState.updatedAt = Number(data && data.updatedAt) || Date.now();
     homeDiscoverState.loaded = true;
@@ -15978,6 +15986,7 @@ function updateEmptyHomeVisibility(opts) {
       homeDiscoverState.mode = 'starter';
       homeDiscoverState.songs = [];
       homeDiscoverState.playlists = [];
+      homeDiscoverState.albums = [];
       homeDiscoverState.podcasts = [];
       renderHomeDiscover();
     } else {
@@ -16110,6 +16119,21 @@ function openHomePlaylist(index) {
     return;
   }
   loadPlaylistIntoQueueById(item.id, true, item.name || '');
+}
+function openHomeAlbum(index) {
+  homeForcedOpen = false;
+  homeSuppressed = false;
+  setHomeControlsLocked(false);
+  if (!hasAnyPlatformLogin() && !homeDiscoverState.loggedIn) {
+    runHomeSearch('');
+    return;
+  }
+  var item = homeDiscoverState.albums[index];
+  if (!item || !item.id) {
+    runHomeSearch('专辑');
+    return;
+  }
+  loadAlbumIntoQueueById(item.id, true, item.name || '');
 }
 function openHomePodcast(index) {
   homeForcedOpen = false;
@@ -16319,6 +16343,7 @@ function handleHomeTileClick(index) {
   else if (item.kind === 'local') openHomeLocalImport();
   else if (item.kind === 'guide') openHomeProductGuide();
   else if (item.kind === 'playlist') openHomePlaylist(item.index);
+  else if (item.kind === 'album') openHomeAlbum(item.index);
   else if (item.kind === 'podcast') openHomePodcast(item.index);
   else if (item.kind === 'podcastSearch') { setSearchMode('podcast'); loadPodcastHot(); }
   else if (item.kind === 'library') openHomeLibrary();
@@ -17208,6 +17233,7 @@ function clearSearchResults() {
   searchRequestSeq++;
   searchLastResultQuery = '';
   playlist = [];
+  albumResults = [];
   podcastResults = [];
   podcastPrograms = [];
   podcastCurrentRadio = null;
@@ -17505,6 +17531,8 @@ document.addEventListener('click', function(e){
 });
 updateSearchModeTabs();
 
+var albumResults = [];
+
 function songProviderKey(song) {
   if (song && (song.provider === 'qq' || song.source === 'qq' || song.type === 'qq')) return 'qq';
   return 'netease';
@@ -17663,6 +17691,43 @@ async function fetchMusicSearchResults(q, mode) {
   if (result[1].status === 'rejected') console.warn('QQ search failed:', result[1].reason);
   return mergeSongSearchResults(neteaseSongs, qqSongs, 18, q);
 }
+async function fetchAlbumSearchResults(q, mode) {
+  if (mode === 'qq') return [];
+  try {
+    var data = await apiJson('/api/album/search?keywords=' + encodeURIComponent(q) + '&limit=6');
+    return data && data.albums || [];
+  } catch (e) {
+    console.warn('Album search failed:', e);
+    return [];
+  }
+}
+function albumMetaText(album) {
+  album = album || {};
+  var bits = [];
+  if (album.artist) bits.push(album.artist);
+  if (album.songCount) bits.push(album.songCount + ' 首');
+  if (album.company) bits.push(album.company);
+  return bits.join('  ·  ') || '网易云专辑';
+}
+function renderAlbumSearchSection(albums) {
+  if (!albums || !albums.length) return '';
+  return '<div class="search-section-label">专辑</div>' + albums.map(function(a, i){
+    var thumb = a.cover ? coverUrlWithSize(a.cover, 80) : '';
+    var imgTag = thumb
+      ? '<img src="' + thumb + '" alt="" loading="lazy" onerror="this.style.opacity=0.2">'
+      : '<div style="width:40px;height:40px;border-radius:6px;background:rgba(255,255,255,0.06);flex-shrink:0"></div>';
+    return '<div class="search-result album-source">' +
+      '<div style="display:flex;align-items:center;gap:12px;flex:1;min-width:0" onclick="openAlbumSearchResult(' + i + ')">' +
+        imgTag +
+        '<div class="search-result-info">' +
+          '<div class="search-result-title">' + escHtml(a.name || '') + '<span class="tag-source netease">专辑</span></div>' +
+          '<div class="search-result-meta">' + escHtml(albumMetaText(a)) + '</div>' +
+        '</div>' +
+      '</div>' +
+      '<button class="add-btn" title="播放专辑" onclick="event.stopPropagation();openAlbumSearchResult(' + i + ')">›</button>' +
+    '</div>';
+  }).join('');
+}
 function renderSongSearchResults(songs) {
   playlist = songs || [];
   $results.innerHTML = playlist.map(function(s, i){
@@ -17690,6 +17755,36 @@ function renderSongSearchResults(songs) {
   syncLikeStatusForSongs(playlist);
   if (window.gsap) animateListItems($results, '.search-result', { x: 0, y: 6, stagger: 0.012, duration: 0.18, limit: 18 });
 }
+function renderMusicSearchResults(albums, songs) {
+  albumResults = albums || [];
+  playlist = songs || [];
+  var albumHtml = renderAlbumSearchSection(albumResults);
+  var songHtml = playlist.length ? '<div class="search-section-label">歌曲</div>' : '';
+  $results.innerHTML = albumHtml + songHtml + playlist.map(function(s, i){
+    var vipTag = (s.fee === 1) ? '<span class="tag-vip">VIP</span>' : '';
+    var sourceTag = songSourceTagHtml(s);
+    var sourceClass = songProviderKey(s) + '-source';
+    var thumb = songCoverSrc(s, 80);
+    var imgTag = thumb
+      ? '<img src="' + thumb + '" alt="" loading="lazy" onerror="this.style.opacity=0.2">'
+      : '<div style="width:40px;height:40px;border-radius:6px;background:rgba(255,255,255,0.06);flex-shrink:0"></div>';
+    return '<div class="search-result ' + sourceClass + '">' +
+      '<div style="display:flex;align-items:center;gap:12px;flex:1;min-width:0" onclick="playSearchResult(' + i + ')">' +
+        imgTag +
+        '<div class="search-result-info">' +
+          '<div class="search-result-title">' + escHtml(s.name) + sourceTag + vipTag + '</div>' +
+          '<div class="search-result-meta">' + searchResultMetaHtml(s, i) + '</div>' +
+        '</div>' +
+      '</div>' +
+      '<button class="song-action-btn' + (isSongLiked(s) ? ' liked' : '') + '" data-like-index="' + i + '" title="' + (isSongLiked(s) ? '取消红心' : '红心喜欢') + '" onclick="event.stopPropagation();toggleLikeSearchResult(' + i + ')">' + heartIconSvg() + '</button>' +
+      '<button class="song-action-btn" title="收藏到歌单" onclick="event.stopPropagation();collectSearchResult(' + i + ')">' + playlistPlusIconSvg() + '</button>' +
+      '<button class="add-btn" title="下一首播放" onclick="event.stopPropagation();queueSearchResult(' + i + ')">+</button>' +
+    '</div>';
+  }).join('');
+  $results.classList.add('show');
+  syncLikeStatusForSongs(playlist);
+  if (window.gsap) animateListItems($results, '.search-result', { x: 0, y: 6, stagger: 0.012, duration: 0.18, limit: 24 });
+}
 
 async function doSearch(q, opts) {
   opts = opts || {};
@@ -17706,18 +17801,24 @@ async function doSearch(q, opts) {
   var requestSeq = ++searchRequestSeq;
   try {
     var mode = searchMode;
-    var songs = await fetchMusicSearchResults(q, mode);
+    var result = await Promise.all([
+      fetchMusicSearchResults(q, mode),
+      fetchAlbumSearchResults(q, mode)
+    ]);
+    var songs = result[0] || [];
+    var albums = result[1] || [];
     if (requestSeq !== searchRequestSeq || $input.value.trim() !== q) return;
-    if (!songs.length) {
+    if (!songs.length && !albums.length) {
       playlist = [];
+      albumResults = [];
       searchLastResultQuery = '';
-      $results.innerHTML = '<div class="search-empty">没有找到相关歌曲</div>';
+      $results.innerHTML = '<div class="search-empty">没有找到相关歌曲或专辑</div>';
       $results.classList.add('show');
       return;
     }
     searchLastResultQuery = searchResultKey(q, mode);
     rememberSearchQuery(q);
-    renderSongSearchResults(songs);
+    renderMusicSearchResults(albums, songs);
     if (opts.autoPlayFirst) playSearchResult(0);
   } catch (err) { console.error('Search:', err); }
 }
@@ -18091,6 +18192,11 @@ function queueDetailSongNext(song) {
   if (!song || song.type === 'podcast-radio') return;
   queueSongNext(song);
   showToast('已设为下一首: ' + (song.name || ''));
+}
+function openAlbumSearchResult(i) {
+  var item = albumResults[i];
+  if (!item || !item.id) return;
+  loadAlbumIntoQueueById(item.id, true, item.name || '');
 }
 function queueIndexNext(i) {
   i = Number(i);
@@ -19445,12 +19551,15 @@ async function refreshUserPlaylists(force) {
     var result = await Promise.all([
       loginStatus.loggedIn ? apiJson('/api/user/playlists') : Promise.resolve({ playlists: [] }),
       loginStatus.loggedIn ? apiJson('/api/podcast/my') : Promise.resolve({ collections: [], loggedIn: false }),
-      qqLoginStatus.loggedIn ? apiJson('/api/qq/user/playlists') : Promise.resolve({ playlists: [] })
+      qqLoginStatus.loggedIn ? apiJson('/api/qq/user/playlists') : Promise.resolve({ playlists: [] }),
+      loginStatus.loggedIn ? apiJson('/api/user/albums') : Promise.resolve({ albums: [] })
     ]);
     var neteaseLists = (result[0].playlists || []).map(function(pl){ pl.provider = 'netease'; pl.source = 'netease'; return pl; });
     qqPlaylists = (result[2].playlists || []).map(function(pl){ pl.provider = 'qq'; pl.source = 'qq'; return pl; });
     userPlaylists = neteaseLists.concat(qqPlaylists);
     myPodcastCollections = result[1].collections || [];
+    userAlbums = result[3].albums || [];
+    if (userAlbums.length) homeDiscoverState.albums = userAlbums.slice(0, 8);
     var animatePanel = isPlaylistPanelVisibleForRender();
     renderUserPlaylistsList({ animate: animatePanel, reset: true });
     renderMyPodcastCollections({ animate: animatePanel });
@@ -19878,6 +19987,49 @@ async function loadPlaylistIntoQueueById(id, autoplay, title) {
     console.warn('[PlaylistLoadState]', id, e);
     forcePlaybackControlsInteractive();
     showToast('歌单已载入，界面刷新失败');
+  } finally {
+    hideLoading();
+  }
+}
+async function loadAlbumIntoQueueById(id, autoplay, title) {
+  if (!id) return;
+  homeForcedOpen = false;
+  homeSuppressed = false;
+  updateEmptyHomeVisibility();
+  showLoading();
+  var r = null;
+  try {
+    r = await apiJson('/api/album/tracks?id=' + encodeURIComponent(id));
+  } catch (e) {
+    console.warn('[AlbumLoadApi]', id, e);
+    showToast('专辑加载失败');
+    hideLoading();
+    return;
+  }
+  try {
+    if (r.error) { showToast('专辑加载失败: ' + r.error); return; }
+    if (!r.tracks || !r.tracks.length) { showToast('专辑暂无可播放歌曲'); return; }
+    playQueue = r.tracks.map(cloneSong);
+    syncLikeStatusForSongs(playQueue);
+    currentIdx = 0;
+    safeRenderQueuePanel('album-load');
+    safeSwitchPlaylistTab('queue', 'album-load');
+    safeShelfRebuild('album-load', true);
+    forcePlaybackControlsInteractive();
+    if (autoplay) {
+      try {
+        await playQueueAt(0);
+      } catch (playErr) {
+        console.warn('[AlbumAutoplay]', id, playErr);
+        showToast('专辑已载入，播放启动失败');
+      }
+    }
+    forcePlaybackControlsInteractive();
+    showToast('载入专辑: ' + (title || (r.album && r.album.name) || id));
+  } catch (e) {
+    console.warn('[AlbumLoadState]', id, e);
+    forcePlaybackControlsInteractive();
+    showToast('专辑已载入，界面刷新失败');
   } finally {
     hideLoading();
   }

--- a/server.js
+++ b/server.js
@@ -8,6 +8,8 @@
 const {
   search,
   cloudsearch,
+  album,
+  album_sublist,
   song_detail,
   song_url,
   song_url_v1,
@@ -1588,6 +1590,26 @@ function mapSongRecord(s) {
     fee: s.fee,
   };
 }
+function mapAlbumRecord(a) {
+  a = a || {};
+  const artists = mapArtists(a.artists || a.artist && [a.artist] || []);
+  const artistName = a.artistName || a.artist && a.artist.name || artists.map(item => item.name).join(' / ');
+  const id = a.id || a.albumId;
+  return {
+    provider: 'netease',
+    source: 'netease',
+    type: 'album',
+    id,
+    name: a.name || a.albumName || '',
+    artist: artistName || '',
+    artists,
+    artistId: artists[0] && artists[0].id || a.artist && a.artist.id,
+    cover: a.picUrl || a.coverUrl || a.blurPicUrl || '',
+    songCount: a.size || a.songCount || a.trackCount || 0,
+    publishTime: a.publishTime || a.publishTimeStr || 0,
+    company: a.company || '',
+  };
+}
 function mapDiscoverPlaylist(pl, tag) {
   pl = pl || {};
   const creator = pl.creator || pl.user || {};
@@ -1666,6 +1688,35 @@ async function handleSearch(keywords, limit) {
   return mapped;
 }
 
+async function handleAlbumSearch(keywords, limit) {
+  console.log('[AlbumSearch]', keywords, 'limit:', limit);
+  const result = await cloudsearch({ keywords, type: 10, limit, cookie: userCookie, timestamp: Date.now() });
+  const albums = result.body && result.body.result && result.body.result.albums ? result.body.result.albums : [];
+  return albums.map(mapAlbumRecord).filter(a => a.id && a.name);
+}
+
+async function handleAlbumTracks(id) {
+  const r = await album({ id, cookie: userCookie, timestamp: Date.now() });
+  const body = r.body || r || {};
+  const albumMeta = mapAlbumRecord(body.album || body.data && body.data.album || { id });
+  const rawSongs = body.songs || body.data && body.data.songs || [];
+  const tracks = (Array.isArray(rawSongs) ? rawSongs : []).map(mapSongRecord).filter(s => s.id);
+  if (!albumMeta.songCount) albumMeta.songCount = tracks.length;
+  return { album: albumMeta, tracks };
+}
+
+async function handleUserAlbums(limit, offset) {
+  const r = await album_sublist({ limit, offset, cookie: userCookie, timestamp: Date.now() });
+  const body = r.body || r || {};
+  const raw = body.data || body.albums || [];
+  const albums = (Array.isArray(raw) ? raw : []).map(mapAlbumRecord).filter(a => a.id && a.name);
+  return {
+    albums,
+    count: body.count || body.total || albums.length,
+    hasMore: !!body.hasMore,
+  };
+}
+
 async function handleDiscoverHome() {
   const info = await getLoginInfo();
   const loggedIn = !!(info && info.loggedIn);
@@ -1675,6 +1726,7 @@ async function handleDiscoverHome() {
       user: null,
       dailySongs: [],
       playlists: [],
+      albums: [],
       podcasts: [],
       mode: 'starter',
       updatedAt: Date.now(),
@@ -1685,6 +1737,7 @@ async function handleDiscoverHome() {
     dj_hot({ limit: 6, offset: 0, cookie: userCookie, timestamp: Date.now() }),
     recommend_resource({ cookie: userCookie, timestamp: Date.now() }),
     recommend_songs({ cookie: userCookie, timestamp: Date.now() }),
+    album_sublist({ limit: 8, offset: 0, cookie: userCookie, timestamp: Date.now() }),
   ];
   const result = await Promise.allSettled(tasks);
 
@@ -1721,11 +1774,22 @@ async function handleDiscoverHome() {
       .slice(0, 12);
   }
 
+  let albums = [];
+  if (result[4].status === 'fulfilled' && result[4].value) {
+    const body = result[4].value.body || {};
+    const raw = body.data || body.albums || [];
+    albums = (Array.isArray(raw) ? raw : [])
+      .map(mapAlbumRecord)
+      .filter(a => a.id && a.name)
+      .slice(0, 8);
+  }
+
   return {
     loggedIn,
     user: loggedIn ? { userId: info.userId, nickname: info.nickname || '', avatar: info.avatar || '' } : null,
     dailySongs,
     playlists: privatePlaylists.concat(publicPlaylists).slice(0, 10),
+    albums,
     podcasts,
     updatedAt: Date.now(),
   };
@@ -3423,6 +3487,19 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  if (pn === '/api/album/search') {
+    try {
+      const kw = url.searchParams.get('keywords') || '';
+      const limit = Math.max(4, Math.min(20, parseInt(url.searchParams.get('limit') || '8', 10) || 8));
+      const albums = await handleAlbumSearch(kw, limit);
+      sendJSON(res, { albums });
+    } catch (err) {
+      console.error('[AlbumSearch]', err);
+      sendJSON(res, { error: err.message, albums: [] }, 500);
+    }
+    return;
+  }
+
   if (pn === '/api/qq/search') {
     try {
       const kw = url.searchParams.get('keywords') || '';
@@ -3858,6 +3935,21 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  if (pn === '/api/user/albums') {
+    try {
+      const info = await getLoginInfo();
+      if (!info.loggedIn) { sendJSON(res, { loggedIn: false, albums: [] }); return; }
+      const limit = Math.max(12, Math.min(100, parseInt(url.searchParams.get('limit') || '60', 10) || 60));
+      const offset = Math.max(0, parseInt(url.searchParams.get('offset') || '0', 10) || 0);
+      const data = await handleUserAlbums(limit, offset);
+      sendJSON(res, { loggedIn: true, albums: data.albums, count: data.count, hasMore: data.hasMore });
+    } catch (err) {
+      console.error('[UserAlbums]', err);
+      sendJSON(res, { error: err.message, loggedIn: false, albums: [] }, 500);
+    }
+    return;
+  }
+
   // ---------- 红心状态 ----------
   if (pn === '/api/song/like/check') {
     try {
@@ -4126,6 +4218,20 @@ const server = http.createServer(async (req, res) => {
       sendJSON(res, { playlist: playlistMeta, tracks });
     } catch (err) {
       console.error('[PlaylistTracks]', err);
+      sendJSON(res, { error: err.message, tracks: [] }, 500);
+    }
+    return;
+  }
+
+  // ---------- 专辑曲目详情 ----------
+  if (pn === '/api/album/tracks') {
+    try {
+      const id = url.searchParams.get('id');
+      if (!id) { sendJSON(res, { error: 'Missing album id', tracks: [] }, 400); return; }
+      const data = await handleAlbumTracks(id);
+      sendJSON(res, data);
+    } catch (err) {
+      console.error('[AlbumTracks]', err);
       sendJSON(res, { error: err.message, tracks: [] }, 500);
     }
     return;


### PR DESCRIPTION
## 背景

目前 Mineradio 已经能很好地覆盖用户歌单、搜索单曲和播客等核心路径，但音乐产品里还有一个比较基础的内容形态没有被完整承接：**专辑**。

现在用户如果想听一整张网易云专辑，需要退回到单曲搜索或外部客户端；同时，用户收藏过的专辑也没有像收藏歌单一样出现在首页滑动列表里。这会让“我想继续听我收藏的专辑 / 搜索并播放一整张专辑”这个常见场景不够顺滑。

这个 PR 先补齐网易云专辑的最小闭环：

- 可以搜索网易云专辑
- 可以点开专辑并把整张专辑加入播放队列
- 首页发现数据里返回用户收藏专辑
- 已收藏专辑可以和歌单一样出现在首页滑动入口中

## 主要改动

### 后端

- 新增 `/api/album/search`
  - 基于 `cloudsearch` 的专辑搜索能力，搜索类型为网易云专辑
- 新增 `/api/album/tracks`
  - 根据专辑 ID 获取专辑信息和专辑曲目
- 新增 `/api/user/albums`
  - 获取当前登录用户收藏过的网易云专辑
- 扩展 `/api/discover/home`
  - 返回 `albums` 字段，让首页可以直接消费收藏专辑数据

### 前端

- 音乐搜索结果新增“专辑”分区
- 点击专辑结果后，加载整张专辑进入播放队列并开始播放
- 首页滑动列表在展示歌单后，会补充展示收藏专辑
- 收藏专辑入口使用现有首页 tile 交互，不引入新的页面结构

## 范围说明

- 这次只实现网易云专辑能力，没有接入 QQ 音乐专辑搜索和播放
- 没有修改 macOS 打包、Electron 窗口或安装包相关逻辑
- 现有歌单、单曲搜索、播放队列逻辑保持兼容

## 验证

本地已完成以下验证：

- `node --check server.js`
- 校验 `public/index.html` 内联脚本可正常解析
- `git diff --check`
- `npm start`
- API 验证：
  - `/api/album/search?keywords=叶惠美&limit=5` 可返回专辑结果
  - `/api/album/tracks?id=<albumId>` 可返回专辑曲目，测试专辑返回 11 首歌，首曲为“以父之名”
  - `/api/discover/home` 可返回收藏专辑列表，测试环境返回 8 个首页专辑入口
