### PR TITLE
feat: 接入酷我音乐作为第三音源（搜索/取链/至臻无损/歌词/登录会员/歌单）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ win-unpacked/
 # User data and private state
 .cookie
 .qq-cookie
+.kw-account
 updates/
 backups/
 *.log

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -1327,6 +1327,8 @@ async function createWindow() {
   process.env.PORT = String(port);
   process.env.COOKIE_FILE = path.join(app.getPath('userData'), '.cookie');
   process.env.QQ_COOKIE_FILE = path.join(app.getPath('userData'), '.qq-cookie');
+  // 酷我账号票据(至臻凭据)同样放 userData, 否则装在 resources/app 内, NSIS 更新会连同 app 一起被替换而丢失登录
+  process.env.KW_ACCOUNT_FILE = path.join(app.getPath('userData'), '.kw-account');
   process.env.MINERADIO_UPDATE_DIR = getUpdateDownloadDir();
   try {
     const legacyQQCookie = path.join(__dirname, '..', '.qq-cookie');
@@ -1339,9 +1341,28 @@ async function createWindow() {
   } catch (e) {
     console.warn('QQ cookie migration skipped:', e.message);
   }
+  try {
+    const legacyKwAccount = path.join(__dirname, '..', '.kw-account');
+    if (fs.existsSync(legacyKwAccount)) {
+      if (!fs.existsSync(process.env.KW_ACCOUNT_FILE)) {
+        fs.copyFileSync(legacyKwAccount, process.env.KW_ACCOUNT_FILE);
+      }
+      fs.unlinkSync(legacyKwAccount);
+    }
+  } catch (e) {
+    console.warn('Kuwo account migration skipped:', e.message);
+  }
 
-  localServer = require(path.join(__dirname, '..', 'server.js'));
-  await waitForServer(localServer);
+  try {
+    localServer = require(path.join(__dirname, '..', 'server.js'));
+    await waitForServer(localServer);
+  } catch (e) {
+    // 本地服务起不来(如缺文件/端口异常)时, 干净退出并释放单实例锁, 避免留下无窗口僵尸进程占锁
+    console.error('本地服务初始化失败:', e);
+    try { dialog.showErrorBox('Mineradio 启动失败', '本地服务初始化失败:\n' + ((e && e.stack) || (e && e.message) || String(e))); } catch (_) {}
+    app.quit();
+    return;
+  }
 
   const initialBounds = getWindowedBounds();
 
@@ -1447,6 +1468,11 @@ if (!gotSingleInstanceLock) {
     screen.on('display-added', () => scheduleWindowStateSend(mainWindow));
     screen.on('display-removed', () => scheduleWindowStateSend(mainWindow));
     await createWindow();
+  }).catch((e) => {
+    // 启动链任意环节失败都干净退出, 释放单实例锁(否则下次启动会被僵尸进程挡住)
+    console.error('启动失败:', e);
+    try { dialog.showErrorBox('Mineradio 启动失败', String((e && e.stack) || (e && e.message) || e)); } catch (_) {}
+    app.quit();
   });
 
   app.on('activate', () => {

--- a/kuwo_qmc.js
+++ b/kuwo_qmc.js
@@ -1,0 +1,184 @@
+'use strict';
+// 酷我至臻 .mflac (QMCv2) 解密器: ekey -> rawkey -> QMC 流密码, 解出标准 FLAC。
+// QmcCipher.process 按密文绝对偏移寻址, 支持按 HTTP Range 分段解密。
+
+// SimpleMakeKey('j',8): int(abs(tan(0x6a+i*0.1))*100)&0xff
+const SIMPLE_KEY = Buffer.from(Array.from({ length: 8 }, (_, i) =>
+  (Math.trunc(Math.abs(Math.tan(0x6a + i * 0.1)) * 100.0)) & 0xff));
+
+function beU32(b, o) { return (((b[o] << 24) | (b[o + 1] << 16) | (b[o + 2] << 8) | b[o + 3]) >>> 0); }
+function putBeU32(out, o, v) { out[o] = (v >>> 24) & 0xff; out[o + 1] = (v >>> 16) & 0xff; out[o + 2] = (v >>> 8) & 0xff; out[o + 3] = v & 0xff; }
+
+// TEA 单块解密 (16 轮, delta=0x9E3779B9, sum0=delta*16)
+function teaEcbDecrypt(block, boff, key16) {
+  let v0 = beU32(block, boff), v1 = beU32(block, boff + 4);
+  const k0 = beU32(key16, 0), k1 = beU32(key16, 4), k2 = beU32(key16, 8), k3 = beU32(key16, 12);
+  let s = 0xE3779B90;
+  for (let i = 0; i < 16; i++) {
+    v1 = (v1 - ((((v0 << 4) >>> 0) + k2 ^ (v0 + s) ^ ((v0 >>> 5) + k3)) >>> 0)) >>> 0;
+    v0 = (v0 - ((((v1 << 4) >>> 0) + k0 ^ (v1 + s) ^ ((v1 >>> 5) + k1)) >>> 0)) >>> 0;
+    s = (s + 0x61C88647) >>> 0;
+  }
+  const out = Buffer.alloc(8);
+  putBeU32(out, 0, v0); putBeU32(out, 4, v1);
+  return out;
+}
+
+// tc_tea CBC 变体解密。失败返回 null。
+function tcTeaDecrypt(cipher, key16) {
+  const n = cipher.length;
+  if (n % 8 !== 0 || n < 16) return null;
+  let blk = teaEcbDecrypt(cipher, 0, key16);
+  const pad = blk[0] & 7;
+  const outLen = n - pad - 10;
+  if (outLen < 0) return null;
+  const out = Buffer.alloc(outLen);
+
+  let curIdx = 0, nxtIdx = 8, consumed = 8, skip = pad + 1, prevIdx = 0, prevZero = true;
+  function advance() {
+    prevZero = false; prevIdx = curIdx; curIdx = nxtIdx;
+    for (let j = 0; j < 8; j++) { if (consumed + j >= n) return false; blk[j] ^= cipher[nxtIdx + j]; }
+    blk = teaEcbDecrypt(blk, 0, key16);
+    nxtIdx += 8; consumed += 8; skip = 0;
+    return true;
+  }
+  // Phase1: 跳过 2 个 salt 字节
+  let cnt = 1;
+  while (cnt < 3) { if (skip < 8) { skip++; cnt++; } else if (!advance()) return null; }
+  // Phase2: 输出明文
+  let rem = outLen, o = 0;
+  while (rem > 0) {
+    if (skip < 8) { const pb = prevZero ? 0 : (cipher[prevIdx + skip] & 0xff); out[o++] = (blk[skip] ^ pb) & 0xff; skip++; rem--; }
+    else if (!advance()) return null;
+  }
+  // Phase3: 校验 7 个零字节
+  cnt = 1;
+  while (cnt < 8) {
+    if (skip < 8) { const pb = prevZero ? 0 : (cipher[prevIdx + skip] & 0xff); if ((blk[skip] & 0xff) !== pb) return null; skip++; cnt++; }
+    else if (!advance()) return null;
+  }
+  return out;
+}
+
+// 宽松 base64 (容忍 url-safe / 空白 / 缺 padding)
+function qmcB64decode(s) {
+  let t = String(s).trim().replace(/-/g, '+').replace(/_/g, '/').replace(/[^A-Za-z0-9+/=]/g, '');
+  const idx = t.indexOf('='); if (idx >= 0) t = t.slice(0, idx);
+  const m = t.length % 4;
+  if (m === 2) t += '=='; else if (m === 3) t += '='; else if (m === 1) t = t.slice(0, -1);
+  return Buffer.from(t, 'base64');
+}
+
+// 明文 QMC ekey -> rawkey
+function decryptEkeyRaw(ekeyB64) {
+  const ek = qmcB64decode(ekeyB64);
+  if (ek.length < 8) throw new Error('ekey too short');
+  const teakey = Buffer.alloc(16);
+  for (let i = 0; i < 8; i++) { teakey[2 * i] = SIMPLE_KEY[i]; teakey[2 * i + 1] = ek[i]; }
+  const tail = tcTeaDecrypt(ek.slice(8), teakey);
+  if (tail === null) throw new Error('tc_tea 解密/校验失败');
+  return Buffer.concat([ek.slice(0, 8), tail]);
+}
+
+// 标准 base64 (补 padding) —— DES 包装态 ekey 用
+function stdB64decode(s) {
+  let t = String(s).replace(/\s/g, '');
+  const m = t.length % 4;
+  if (m) t += '='.repeat(4 - m);
+  return Buffer.from(t, 'base64');
+}
+
+// ekey(base64) -> rawkey。自动兼容: ① 明文 QMC ekey; ② 酷我 DES 包装态
+//   = base64(DES-ECB("<16字符设备前缀>"+明文ekey, "ylzsxkwm"))
+// desDecrypt: (buf, "ylzsxkwm") => Buffer (复用项目已有的 kwDecrypt; 小端块序 ECB)
+function decryptEkeyB64(ekeyB64, desDecrypt) {
+  const s = String(ekeyB64 || '').trim();
+  try { return decryptEkeyRaw(s); } catch (e) { /* 落到 DES 包装态 */ }
+  if (typeof desDecrypt !== 'function') throw new Error('ekey 非明文形态, 需提供 desDecrypt(ylzsxkwm)');
+  const dec = desDecrypt(stdB64decode(s), 'ylzsxkwm');
+  // dec 末尾可能有 DES 尾块填充; 按 latin-1 转字符串再 trim
+  const uw = Buffer.from(dec).toString('latin1').replace(/\x00+$/g, '').trim();
+  if (uw.length > 16) { try { return decryptEkeyRaw(uw.slice(16)); } catch (e) { /* 再试不剥前缀 */ } }
+  return decryptEkeyRaw(uw);
+}
+
+// QMC 流密码: map(<=300B) / RC4 变体(>300B)
+class QmcCipher {
+  constructor(key) {
+    this.key = Buffer.from(key);
+    this.n = this.key.length;
+    this.useRc4 = this.n > 300;
+    if (this.useRc4) this._initRc4();
+  }
+  _mapL(off) {
+    const n = this.n;
+    if (off > 0x7FFF) off %= 0x7FFF;
+    const v = (off * off + 0x1162E) % n;
+    const b = this.key[v];
+    let sh = v & 7; sh = sh < 4 ? sh + 4 : sh - 4;
+    return ((b << sh) | (b >> sh)) & 0xff;
+  }
+  _initRc4() {
+    const n = this.n;
+    const box = Buffer.alloc(n);
+    for (let i = 0; i < n; i++) box[i] = i & 0xff;
+    let j = 0;
+    for (let i = 0; i < n; i++) { j = (box[i] + j + this.key[i]) % n; const t = box[i]; box[i] = box[j]; box[j] = t; }
+    this.box = box;
+    let h = 1;
+    for (let i = 0; i < n; i++) { const v = this.key[i]; if (v !== 0) { const p = (h * v) >>> 0; if (p === 0 || p <= h) break; h = p; } }
+    this.hashBase = h;
+  }
+  _encFirstSegment(off, data, start, length) {
+    const n = this.n;
+    for (let k = 0; k < length; k++) {
+      const o = off + k;
+      const seg = this.key[o % n];
+      const x = Math.trunc(this.hashBase / ((o + 1) * seg) * 100.0);
+      data[start + k] ^= this.key[(((x % n) + n) % n)];
+    }
+  }
+  _encASegment(off, data, start, length) {
+    const n = this.n;
+    const b = Buffer.from(this.box);
+    const blk = Math.floor(off / 0x1400) & 0x1FF;
+    if (blk >= n) return;
+    const seg = this.key[blk];
+    const inner = Math.trunc(this.hashBase / ((Math.floor(off / 0x1400) + 1) * seg) * 100.0);
+    const skip = (inner & 0x1FF) + (off % 0x1400);
+    let i = 0, j = 0;
+    for (let s = 0; s < skip; s++) { i = (i + 1) % n; j = (b[i] + j) % n; const t = b[i]; b[i] = b[j]; b[j] = t; }
+    for (let d = 0; d < length; d++) {
+      i = (i + 1) % n; j = (b[i] + j) % n; const t = b[i]; b[i] = b[j]; b[j] = t;
+      const idx = (b[i] + b[j]) % n;
+      data[start + d] ^= b[idx];
+    }
+  }
+  _processRc4(off, data, start, length) {
+    let pos = 0;
+    if (off < 0x80) {
+      const first = Math.min(0x80 - off, length);
+      this._encFirstSegment(off, data, start, first);
+      pos += first; off += first; length -= first;
+      if (length <= 0) return;
+    }
+    if (off % 0x1400 !== 0) {
+      const nseg = Math.min(0x1400 - off % 0x1400, length);
+      this._encASegment(off, data, start + pos, nseg);
+      pos += nseg; off += nseg; length -= nseg;
+      if (length <= 0) return;
+    }
+    while (length > 0x1400) {
+      this._encASegment(off, data, start + pos, 0x1400);
+      pos += 0x1400; off += 0x1400; length -= 0x1400;
+    }
+    this._encASegment(off, data, start + pos, length);
+  }
+  // 原地异或解密 data[start..start+length); baseOff 为这段数据在密文里的绝对偏移
+  process(data, start, length, baseOff) {
+    if (this.useRc4) this._processRc4(baseOff, data, start, length);
+    else for (let i = 0; i < length; i++) data[start + i] ^= this._mapL(baseOff + i);
+  }
+}
+
+module.exports = { SIMPLE_KEY, decryptEkeyRaw, decryptEkeyB64, qmcB64decode, stdB64decode, QmcCipher, tcTeaDecrypt, teaEcbDecrypt };

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
       "public/**/*",
       "build/**/*",
       "server.js",
+      "kuwo_qmc.js",
       "dj-analyzer.js",
       "package.json",
       "!public/index.*.html",

--- a/public/index.html
+++ b/public/index.html
@@ -21,7 +21,7 @@ try {
 html,body{font-family:var(--font-sans);background:#000;color:#fff;overflow:hidden;height:100vh;width:100vw;user-select:none;-webkit-font-smoothing:antialiased}
 body.cursor-hidden,body.cursor-hidden *{cursor:none!important}
 html.desktop-shell-root,html.desktop-shell-root body{background:transparent}
-:root{--font-sans:"Noto Sans SC","PingFang SC","HarmonyOS Sans SC","Alibaba PuHuiTi","Inter",-apple-system,BlinkMacSystemFont,system-ui,sans-serif;--font-mono:"JetBrains Mono","Geist Mono","SF Mono",ui-monospace,monospace;--fc-bg:#08090B;--fc-paper:#0E1014;--fc-ink:#E8ECEF;--fc-ink-2:#D2D7DC;--fc-muted:#8A9099;--fc-hair:#1A1D22;--fc-hair-2:#262A31;--fc-accent:#00F5D4;--fc-accent-hov:#00E0BE;--fc-accent-rgb:0,245,212;--fc-blue:#2442ff;--fc-warm:#f8f4ee;--chill-ink:#030608;--chill-deep:#061116;--chill-cyan:#8fe9ff;--chill-blue:#73a7ff;--chill-mint:#9cffdf;--chill-soft:rgba(214,248,255,.9);--champagne:#f4d28a;--champagne-deep:#9a6f2c;--home-accent:#00f5d4;--home-accent-rgb:0,245,212;--visual-tint:#9db8cf;--source-netease:#d95b67;--source-qq:#00F5D4;--source-local:#9db8cf}
+:root{--font-sans:"Noto Sans SC","PingFang SC","HarmonyOS Sans SC","Alibaba PuHuiTi","Inter",-apple-system,BlinkMacSystemFont,system-ui,sans-serif;--font-mono:"JetBrains Mono","Geist Mono","SF Mono",ui-monospace,monospace;--fc-bg:#08090B;--fc-paper:#0E1014;--fc-ink:#E8ECEF;--fc-ink-2:#D2D7DC;--fc-muted:#8A9099;--fc-hair:#1A1D22;--fc-hair-2:#262A31;--fc-accent:#00F5D4;--fc-accent-hov:#00E0BE;--fc-accent-rgb:0,245,212;--fc-blue:#2442ff;--fc-warm:#f8f4ee;--chill-ink:#030608;--chill-deep:#061116;--chill-cyan:#8fe9ff;--chill-blue:#73a7ff;--chill-mint:#9cffdf;--chill-soft:rgba(214,248,255,.9);--champagne:#f4d28a;--champagne-deep:#9a6f2c;--home-accent:#00f5d4;--home-accent-rgb:0,245,212;--visual-tint:#9db8cf;--source-netease:#d95b67;--source-qq:#00F5D4;--source-kw:#6ca8ea;--source-local:#9db8cf}
 :root{--glass-bg:linear-gradient(112deg,rgba(72,74,76,.62),rgba(24,27,30,.70) 48%,rgba(8,12,14,.74));--glass-bg-focus:linear-gradient(112deg,rgba(88,91,92,.68),rgba(28,32,35,.76) 50%,rgba(8,13,15,.82));--glass-border:rgba(0,245,212,.30);--glass-border-soft:rgba(255,255,255,.095);--glass-shadow:0 22px 64px rgba(0,0,0,.30),0 0 34px rgba(0,245,212,.052),inset 0 1px 0 rgba(255,255,255,.16),inset 0 -24px 58px rgba(0,0,0,.16);--glass-shadow-focus:0 24px 72px rgba(0,0,0,.34),0 0 0 1px rgba(0,245,212,.13),0 0 42px rgba(0,245,212,.075),inset 0 1px 0 rgba(255,255,255,.20)}
 :root{--saved-panel-glass-bg:rgba(0,0,0,.10);--saved-panel-glass-filter:blur(12px) saturate(1.8) brightness(1.16);--saved-panel-glass-svg-filter:url(#mineradio-control-glass-filter) saturate(1);--saved-panel-glass-shadow:inset 0 0 2px 1px rgba(255,255,255,.35),inset 0 0 10px 4px rgba(255,255,255,.15),0 4px 16px rgba(17,17,26,.05),0 8px 24px rgba(17,17,26,.05),0 16px 56px rgba(17,17,26,.05),inset 0 4px 16px rgba(17,17,26,.05),inset 0 8px 24px rgba(17,17,26,.05),inset 0 16px 56px rgba(17,17,26,.05);--saved-panel-glass-radius:50px;--saved-button-glass-bg:rgba(0,0,0,.10);--saved-button-glass-filter:blur(12px) saturate(1.8) brightness(1.16);--saved-button-glass-svg-filter:url(#mineradio-control-glass-filter) saturate(1);--saved-button-glass-shadow:inset 0 0 2px 1px rgba(255,255,255,.34),inset 0 0 10px 4px rgba(255,255,255,.13),0 10px 30px rgba(0,0,0,.18);--saved-button-glass-hover-bg:rgba(255,255,255,.055);--saved-button-glass-hover-shadow:inset 0 0 2px 1px rgba(255,255,255,.42),inset 0 0 12px 5px rgba(255,255,255,.17),0 12px 34px rgba(0,0,0,.22),0 0 18px rgba(255,255,255,.06)}
 :root{--home-icon-color:#f4d28a;--home-icon-rgb:244,210,138;--visual-icon-color:#7fd8ff;--visual-icon-rgb:127,216,255}
@@ -196,7 +196,9 @@ body.empty-home-active.diy-mode #search-area:not(.has-results) #search-mode-tabs
 .tag-source{display:inline-flex;align-items:center;height:16px;padding:0 6px;border-radius:999px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.045);font-size:8.5px;font-weight:800;letter-spacing:.55px;line-height:1;flex-shrink:0}
 .tag-source.netease{color:#ffd8dd;border-color:rgba(217,91,103,.30);background:rgba(217,91,103,.075)}
 .tag-source.qq{color:#f0ffc8;border-color:rgba(191,214,107,.30);background:rgba(191,214,107,.075)}
+.tag-source.kw{color:#cfe6ff;border-color:rgba(108,168,234,.32);background:rgba(108,168,234,.085)}
 .search-result.qq-source:hover{background:rgba(191,214,107,.052)}
+.search-result.kw-source:hover{background:rgba(108,168,234,.055)}
 .search-result.netease-source:hover{background:rgba(217,91,103,.045)}
 .podcast-result-head{display:flex;align-items:center;gap:10px;padding:11px 13px 9px;border-bottom:1px solid rgba(255,255,255,.04);background:rgba(255,255,255,.025)}
 .podcast-result-head img{width:40px;height:40px;border-radius:7px;object-fit:cover;background:rgba(255,255,255,.05);flex-shrink:0}
@@ -448,17 +450,24 @@ body.desktop-shell.empty-home-active.controls-visible #empty-home{bottom:126px}
 #user-btn.multi-account{height:auto;min-width:0;padding:0;flex-direction:column;align-items:flex-end;gap:7px;border:0;background:transparent;box-shadow:none;backdrop-filter:none;-webkit-backdrop-filter:none}
 #user-btn.multi-account:hover{background:transparent;border-color:transparent;box-shadow:none;transform:none;color:#fff}
 #user-avatar{width:34px;height:34px;border-radius:50%;object-fit:cover;background:rgba(255,255,255,0.1)}
-#user-vip-tag{font-size:9px;padding:2px 6px;border-radius:3px;background:linear-gradient(135deg,#fff3c2,var(--champagne),#c9963d);color:#201303;font-weight:800;letter-spacing:.5px;box-shadow:0 0 12px rgba(244,210,138,.24)}
+#user-vip-tag{font-size:9px;padding:2px 7px;border-radius:999px;background:linear-gradient(135deg,#fff3c2,var(--champagne),#c9963d);color:#201303;font-weight:800;letter-spacing:.5px;box-shadow:0 0 12px rgba(244,210,138,.24)}
 #user-vip-tag.qq{background:linear-gradient(135deg,#e7fff9,#00f5d4,#61a8ff);color:#03100f;box-shadow:0 0 12px rgba(0,245,212,.22)}
+#user-vip-tag.kw{background:linear-gradient(135deg,#dbeafe,#6ca8ea,#3f6fc4);color:#04101f;box-shadow:0 0 12px rgba(108,168,234,.26)}
+#user-vip-tag.kw.luxury{background:linear-gradient(135deg,#fff3c2,#f4d28a,#c9963d);color:#201303;box-shadow:0 0 13px rgba(244,210,138,.30)}
+#user-vip-tag.kw.super{background:linear-gradient(135deg,#ffe3f3,#c98bff,#7b3fd0);color:#1a0a2e;box-shadow:0 0 15px rgba(201,139,255,.34)}
 .account-source-dot{width:7px;height:7px;border-radius:50%;background:var(--source-local);box-shadow:0 0 12px currentColor;flex-shrink:0}
 .account-source-dot.netease{background:var(--source-netease);color:var(--source-netease)}
 .account-source-dot.qq{background:var(--source-qq);color:var(--source-qq)}
+.account-source-dot.kw{background:var(--source-kw);color:var(--source-kw)}
 .top-account-pill{height:44px;min-width:0;display:flex;align-items:center;gap:8px;padding:0 14px 0 4px;border-radius:24px;border:1px solid rgba(244,210,138,.52);background:rgba(244,210,138,.07);box-shadow:0 0 0 1px rgba(244,210,138,.08),0 14px 42px rgba(0,0,0,.28),inset 0 1px 0 rgba(255,255,255,.08);transition:background .22s,border-color .22s,box-shadow .22s,transform .22s}
 #user-btn.multi-account:hover .top-account-pill{background:rgba(244,210,138,.10);border-color:rgba(244,210,138,.62);box-shadow:0 0 0 1px rgba(244,210,138,.10),0 16px 44px rgba(0,0,0,.32),inset 0 1px 0 rgba(255,255,255,.10)}
 .top-account-pill img{width:34px;height:34px;border-radius:50%;object-fit:cover;background:rgba(255,255,255,.08);flex-shrink:0}
 .top-account-name{max-width:96px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;font-size:12px;font-weight:650;color:rgba(255,255,255,.92)}
-.top-account-vip{font-size:9px;padding:2px 6px;border-radius:3px;background:linear-gradient(135deg,#fff3c2,var(--champagne),#c9963d);color:#201303;font-weight:800;letter-spacing:.5px;box-shadow:0 0 12px rgba(244,210,138,.24);flex-shrink:0}
+.top-account-vip{font-size:9px;padding:2px 7px;border-radius:999px;background:linear-gradient(135deg,#fff3c2,var(--champagne),#c9963d);color:#201303;font-weight:800;letter-spacing:.5px;box-shadow:0 0 12px rgba(244,210,138,.24);flex-shrink:0}
 .top-account-vip.qq{background:linear-gradient(135deg,#e7fff9,#00f5d4,#61a8ff);color:#03100f;box-shadow:0 0 12px rgba(0,245,212,.22)}
+.top-account-vip.kw{background:linear-gradient(135deg,#dbeafe,#6ca8ea,#3f6fc4);color:#04101f;box-shadow:0 0 12px rgba(108,168,234,.26)}
+.top-account-vip.kw.luxury{background:linear-gradient(135deg,#fff3c2,#f4d28a,#c9963d);color:#201303;box-shadow:0 0 13px rgba(244,210,138,.30)}
+.top-account-vip.kw.super{background:linear-gradient(135deg,#ffe3f3,#c98bff,#7b3fd0);color:#1a0a2e;box-shadow:0 0 15px rgba(201,139,255,.34)}
 .update-entry{position:relative;display:none;width:44px;height:44px;border-radius:50%;border:1px solid rgba(244,210,138,.26);background:radial-gradient(circle at 50% 36%,rgba(244,210,138,.14),rgba(255,255,255,.030) 58%,rgba(157,184,207,.020));color:rgba(255,239,190,.94);align-items:center;justify-content:center;cursor:pointer;backdrop-filter:blur(22px) saturate(1.25);-webkit-backdrop-filter:blur(22px) saturate(1.25);box-shadow:0 14px 38px rgba(0,0,0,.30),0 0 22px rgba(244,210,138,.08),0 0 0 1px rgba(255,255,255,.026),inset 0 1px 0 rgba(255,255,255,.09);transition:border-color .22s,background .22s,color .22s,box-shadow .22s,transform .22s;overflow:visible}
 .update-entry.available{display:flex}
 .update-entry:hover{color:#fff8df;border-color:rgba(244,210,138,.58);background:radial-gradient(circle at 50% 34%,rgba(244,210,138,.22),rgba(255,255,255,.045) 58%,rgba(157,184,207,.028));box-shadow:0 16px 44px rgba(0,0,0,.34),0 0 26px rgba(244,210,138,.18),0 0 18px rgba(157,184,207,.08),inset 0 1px 0 rgba(255,255,255,.13)}
@@ -587,7 +596,7 @@ body.home-controls-locked #bottom-bar{opacity:0!important;pointer-events:none!im
 .quality-option:hover{transform:translateY(-1px);color:#fff;background:rgba(255,255,255,.09)}
 .quality-option.active{color:#eaf2ff;border-color:rgba(157,184,207,.46);background:rgba(157,184,207,.16);box-shadow:inset 0 1px 0 rgba(255,255,255,.08)}
 .quality-option.locked{opacity:.42;cursor:not-allowed;transform:none!important}
-.quality-option.locked small::after{content:' · 需网易云SVIP';color:rgba(244,210,138,.88)}
+.quality-option.locked small::after{content:' · 需网易云SVIP或登录酷我';color:rgba(244,210,138,.88)}
 #volume-slider{width:92px;accent-color:var(--fc-accent);cursor:pointer}
 #volume-value{width:34px;text-align:right;font-size:10px;color:rgba(255,255,255,.52);font-variant-numeric:tabular-nums}
 .mini-queue-popover{position:absolute;left:50%;bottom:calc(100% + 14px);width:min(420px,calc(100vw - 32px));max-height:min(420px,calc(100vh - 170px));padding:14px;border-radius:16px;border:1px solid rgba(255,255,255,.075);background:linear-gradient(145deg,rgba(18,18,23,.82),rgba(8,8,12,.88));backdrop-filter:blur(30px) saturate(1.08);-webkit-backdrop-filter:blur(30px) saturate(1.08);box-shadow:0 22px 70px rgba(0,0,0,.46),inset 0 1px 0 rgba(255,255,255,.065);opacity:0;pointer-events:none;transform:translateX(-50%) translateY(12px) scale(.98);transition:opacity .22s,transform .22s;z-index:7;overflow:hidden}
@@ -802,6 +811,7 @@ body.login-guide-active #login-guide-canvas{opacity:1}
 .login-platform-tabs button.active,.user-platform-tabs button.active{color:#fff;box-shadow:inset 0 0 0 1px rgba(255,255,255,.08),0 10px 26px rgba(0,0,0,.20)}
 .login-platform-tabs button.netease.active,.user-platform-tabs button.netease.active{background:rgba(217,91,103,.16);color:#ffd7dc}
 .login-platform-tabs button.qq.active,.user-platform-tabs button.qq.active{background:rgba(191,214,107,.16);color:#f3ffd1}
+.login-platform-tabs button.kw.active,.user-platform-tabs button.kw.active{background:rgba(108,168,234,.18);color:#d4e8ff}
 .user-platform-tabs button.both.active{background:rgba(244,210,138,.14);color:#fff0bf}
 .qr-shell{position:relative;width:200px;height:200px;margin:0 auto 16px;border-radius:16px}
 #qr-img{width:200px;height:200px;background:#fff;border-radius:14px;margin:0 auto 16px;display:block;padding:10px;box-shadow:0 16px 42px rgba(0,0,0,.32),0 0 0 1px rgba(244,210,138,.18)}
@@ -821,6 +831,9 @@ body.login-guide-active #login-guide-canvas{opacity:1}
 .qq-cookie-panel.show{display:block}
 .qq-cookie-input{width:100%;height:74px;resize:none;border:1px solid rgba(255,255,255,.08);border-radius:10px;background:rgba(0,0,0,.22);color:rgba(255,255,255,.82);padding:10px 11px;font-family:inherit;font-size:11px;line-height:1.45;outline:none}
 .qq-cookie-input:focus{border-color:rgba(191,214,107,.42);box-shadow:0 0 0 1px rgba(191,214,107,.10)}
+.kw-login-panel.show{display:flex;flex-direction:column;gap:9px}
+.kw-login-input{width:100%;height:38px;border:1px solid rgba(255,255,255,.08);border-radius:10px;background:rgba(0,0,0,.22);color:rgba(255,255,255,.86);padding:0 12px;font-family:inherit;font-size:12.5px;outline:none;transition:border-color .2s,box-shadow .2s}
+.kw-login-input:focus{border-color:rgba(108,168,234,.46);box-shadow:0 0 0 1px rgba(108,168,234,.12)}
 .qq-cookie-actions{display:flex;align-items:center;justify-content:space-between;gap:10px;margin-top:9px}
 .qq-cookie-note{font-size:10.5px;color:rgba(255,255,255,.36);line-height:1.45;text-align:left}
 .qq-cookie-panel .modal-btn{padding:8px 12px;white-space:nowrap}
@@ -833,6 +846,7 @@ body.login-guide-active #login-guide-canvas{opacity:1}
 .account-provider-chip{display:inline-flex;align-items:center;gap:6px;height:24px;padding:0 9px;margin-bottom:10px;border-radius:999px;border:1px solid rgba(255,255,255,.08);background:rgba(255,255,255,.035);font-size:10.5px;letter-spacing:.5px;color:rgba(255,255,255,.58)}
 .account-provider-chip.netease{border-color:rgba(217,91,103,.26);color:#ffd7dc;background:rgba(217,91,103,.08)}
 .account-provider-chip.qq{border-color:rgba(191,214,107,.26);color:#f3ffd1;background:rgba(191,214,107,.08)}
+.account-provider-chip.kw{border-color:rgba(108,168,234,.28);color:#d4e8ff;background:rgba(108,168,234,.09)}
 .account-modal-actions{display:grid;grid-template-columns:1fr 1fr;gap:8px;margin-top:14px}
 .account-modal-actions .modal-btn{padding:8px 10px}
 .account-hint{margin-top:10px;font-size:11px;line-height:1.45;color:rgba(255,255,255,.38)}
@@ -1332,6 +1346,8 @@ body.desktop-shell.diy-mode #bottom-bar.stage-mode{left:50%;width:min(1080px,cal
 .pl-detail-row-title{font-size:11.5px;font-weight:650;color:rgba(255,255,255,.86);white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .pl-detail-row-artist{display:inline-flex;max-width:100%;border:0;background:transparent;color:rgba(var(--fc-accent-rgb),.68);font:500 10.5px var(--font-sans);padding:0;margin-top:2px;cursor:pointer;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 .pl-detail-row-artist:hover{color:#fff;text-decoration:underline;text-underline-offset:3px}
+.pl-detail-row.is-offline{opacity:.5}
+.pl-detail-offline-tag{display:inline-block;margin-left:6px;padding:0 5px;border-radius:5px;font-size:9px;font-weight:600;line-height:15px;color:rgba(255,255,255,.55);background:rgba(255,255,255,.08);vertical-align:middle}
 .pl-card.expanded{border-color:rgba(var(--fc-accent-rgb),.32);background:rgba(var(--fc-accent-rgb),.060)}
 .pl-card.podcast-card{border-color:rgba(0,245,212,.075);background:rgba(0,245,212,.030)}
 .pl-card.podcast-card:hover{border-color:rgba(0,245,212,.20);background:rgba(0,245,212,.070)}
@@ -1910,6 +1926,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
       <button id="search-mode-song" class="active" type="button" onclick="setSearchMode('song')" aria-selected="true">All</button>
       <button id="search-mode-netease" type="button" onclick="setSearchMode('netease')" aria-selected="false">NE</button>
       <button id="search-mode-qq" type="button" onclick="setSearchMode('qq')" aria-selected="false">QQ</button>
+      <button id="search-mode-kw" type="button" onclick="setSearchMode('kw')" aria-selected="false">KW</button>
       <button id="search-mode-podcast" type="button" onclick="setSearchMode('podcast')" aria-selected="false">Podcast</button>
     </div>
     <div id="search-results"></div>
@@ -2287,7 +2304,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
   </div>
   <div id="pl-pane" style="display:none">
     <div class="queue-toolbar">
-      <div class="queue-chip">登录后显示网易云 / QQ 歌单</div>
+      <div class="queue-chip">登录后显示网易云 / QQ / 酷我歌单</div>
       <button class="fx-mini-btn ghost" onclick="refreshUserPlaylists(true)" style="height:26px;padding:0 10px;font-size:11px">刷新</button>
     </div>
     <div id="pl-list" style="margin-top:6px"></div>
@@ -2420,7 +2437,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
       <div id="quality-control" class="quality-control">
         <button id="quality-btn" class="ctrl-btn quality-pill" onclick="toggleQualityPanel(event)" title="音质"><span id="quality-btn-label">臻音</span></button>
         <div class="quality-popover" onclick="event.stopPropagation()">
-          <button class="quality-option svip-only" data-quality="jymaster" data-svip="1" onclick="setPlaybackQuality('jymaster')"><span>超清母带</span><small>SVIP / 最高规格</small></button>
+          <button class="quality-option svip-only" data-quality="jymaster" data-svip="1" onclick="setPlaybackQuality('jymaster')"><span>超清母带 / 至臻</span><small>网易云 SVIP · 酷我至臻</small></button>
           <button class="quality-option" data-quality="hires" onclick="setPlaybackQuality('hires')"><span>高清臻音</span><small>默认 / 细节优先</small></button>
           <button class="quality-option" data-quality="lossless" onclick="setPlaybackQuality('lossless')"><span>无损 SQ</span><small>FLAC 优先</small></button>
           <button class="quality-option" data-quality="exhigh" onclick="setPlaybackQuality('exhigh')"><span>极高 HQ</span><small>320kbps</small></button>
@@ -2468,6 +2485,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
     <div class="login-platform-tabs" id="login-platform-tabs">
       <button id="login-provider-netease" class="netease active" type="button" onclick="setLoginProvider('netease')">网易云</button>
       <button id="login-provider-qq" class="qq" type="button" onclick="setLoginProvider('qq')">QQ 音乐</button>
+      <button id="login-provider-kw" class="kw" type="button" onclick="setLoginProvider('kw')">酷我</button>
     </div>
     <div class="login-intro">
       <div class="login-intro-kicker">Mineradio</div>
@@ -2486,6 +2504,14 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
       <div class="qq-cookie-actions">
         <div class="qq-cookie-note">从 y.qq.com 的登录会话导入。</div>
         <button id="qq-cookie-save-btn" class="modal-btn primary" type="button" onclick="submitQQCookieLogin()">保存</button>
+      </div>
+    </div>
+    <div id="kw-login-panel" class="qq-cookie-panel kw-login-panel">
+      <input id="kw-login-username" class="kw-login-input" type="text" spellcheck="false" autocomplete="off" placeholder="酷我账号（手机号）">
+      <input id="kw-login-password" class="kw-login-input" type="password" autocomplete="off" placeholder="密码" onkeydown="if(event.key==='Enter')submitKwLogin()">
+      <div class="qq-cookie-actions">
+        <div class="qq-cookie-note">登录后解锁会员无损/24bit；留空仍可游客试听。</div>
+        <button id="kw-login-save-btn" class="modal-btn primary" type="button" onclick="submitKwLogin()">登录</button>
       </div>
     </div>
     <div class="btn-row">
@@ -2509,11 +2535,13 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
     <div class="user-platform-tabs" id="user-platform-tabs">
       <button id="user-provider-netease" class="netease active" type="button" onclick="setActiveAccountProvider('netease')">网易云</button>
       <button id="user-provider-qq" class="qq" type="button" onclick="setActiveAccountProvider('qq')">QQ 音乐</button>
+      <button id="user-provider-kw" class="kw" type="button" onclick="setActiveAccountProvider('kw')">酷我</button>
       <button id="user-provider-both" class="both" type="button" onclick="enableDualAccountView()">我两个都要</button>
     </div>
     <div class="account-modal-actions">
       <button id="account-add-netease" class="modal-btn" onclick="openProviderLogin('netease')">补登网易云</button>
       <button id="account-add-qq" class="modal-btn" onclick="openProviderLogin('qq')">补登 QQ 音乐</button>
+      <button id="account-add-kw" class="modal-btn" onclick="openProviderLogin('kw')">补登酷我</button>
     </div>
     <div id="account-hint" class="account-hint">QQ 音乐真实登录暂未接入，当前先预览双平台账号交互。</div>
     <div class="btn-row">
@@ -2694,6 +2722,8 @@ var playlist = [], playQueue = [], currentIdx = -1, playing = false, playToggleB
 var searchMode = 'song', podcastResults = [], podcastPrograms = [], podcastCurrentRadio = null;
 var loginStatus = { loggedIn: false, vipType: 0, vipLevel: 'none', isVip: false, isSvip: false, vipLabel: '无VIP' };
 var qqLoginStatus = { provider: 'qq', loggedIn: false, preview: false, nickname: 'QQ 音乐', userId: '', avatar: '', vipType: 0 };
+var kwLoginStatus = { provider: 'kw', loggedIn: false, nickname: '酷我音乐', userId: '', avatar: '', vipType: 0, vipTier: 'none', vipLabel: '', vipExpire: 0, isVip: false, hasAccount: false };
+var kwLoginBusy = false;
 var qqLoginAutoRefreshTimer = null;
 var qqLoginWasLoggedIn = false;
 var loginProvider = 'netease';
@@ -2710,7 +2740,7 @@ var audioFadeTimer = null, audioElementFadeFrame = 0, audioFadeSerial = 0;
 var AUDIO_FADE_IN_MS = 460;
 var AUDIO_FADE_OUT_MS = 420;
 var AUDIO_SILENCE_GAIN = 0.0001;
-var userPlaylists = [], qqPlaylists = [], myPodcastCollections = [], myPodcastItems = {}, playlistCoverCache = {};
+var userPlaylists = [], qqPlaylists = [], kwPlaylists = [], myPodcastCollections = [], myPodcastItems = {}, playlistCoverCache = {};
 var CUSTOM_COVER_STORE_KEY = 'mineradio-custom-covers';
 var CUSTOM_LYRIC_STORE_KEY = 'mineradio-custom-lyrics-v1';
 var CUSTOM_LYRIC_PREF_STORE_KEY = 'mineradio-custom-lyric-prefs-v1';
@@ -10201,6 +10231,7 @@ function beatMapSongKey(song) {
   if (!song) return '';
   if (song.type === 'local' && song.localKey) return 'local:' + song.localKey;
   if (songProviderKey(song) === 'qq') return 'qq:' + (song.mid || song.songmid || song.id || (song.name + '|' + song.artist));
+  if (songProviderKey(song) === 'kw') return 'kw:' + (song.rid || song.id || (song.name + '|' + song.artist));
   if (song.id != null && song.id !== '') return 'song:' + song.id;
   return '';
 }
@@ -10308,16 +10339,20 @@ function normalizeBeatPrefetchState(state) {
 
 async function fetchBeatPrefetchAudioUrl(song) {
   if (!song) return null;
-  var isQQ = songProviderKey(song) === 'qq';
+  var providerKey = songProviderKey(song);
+  var isQQ = providerKey === 'qq';
+  var isKw = providerKey === 'kw';
   var requestedQuality = normalizePlaybackQuality(playbackQuality);
-  if (!isQQ && requestedQuality === 'jymaster' && !hasProviderSvip('netease', loginStatus)) requestedQuality = 'hires';
+  if (providerKey === 'netease' && requestedQuality === 'jymaster' && !hasProviderSvip('netease', loginStatus)) requestedQuality = 'hires';
   if (isQQ && qqPlaybackQualityCeiling && (requestedQuality === 'jymaster' || requestedQuality === 'hires' || requestedQuality === 'lossless')) requestedQuality = qqPlaybackQualityCeiling;
   var qualityParam = '&quality=' + encodeURIComponent(requestedQuality);
   var data = isQQ
     ? await apiJson('/api/qq/song/url?mid=' + encodeURIComponent(song.mid || song.songmid || song.id || '') + '&mediaMid=' + encodeURIComponent(song.mediaMid || song.media_mid || '') + qualityParam)
-    : await apiJson('/api/song/url?id=' + encodeURIComponent(song.id) + qualityParam);
+    : isKw
+      ? await apiJson('/api/kw/song/url?rid=' + encodeURIComponent(song.rid || song.id || '') + qualityParam)
+      : await apiJson('/api/song/url?id=' + encodeURIComponent(song.id) + qualityParam);
   if (!data || !data.url || data.trial) return null;
-  return '/api/audio?url=' + encodeURIComponent(data.url);
+  return '/api/audio?url=' + encodeURIComponent(data.url) + (data.ekey ? '&kwekey=' + encodeURIComponent(data.ekey) : '');
 }
 
 function scheduleQueueBeatPrefetch(fromIdx, delayMs, state) {
@@ -13020,10 +13055,10 @@ function makeShelfManager() {
     if (hasAnyPlatformLogin() && (userPlaylists.length || myPodcastCollections.length)) {
       var source = activePlaylists();
       var items = source.map(function(pl){
-        var provider = pl.provider === 'qq' ? 'qq' : 'netease';
-        var sourceLabel = provider === 'qq' ? 'QQ' : 'NE';
+        var provider = pl.provider === 'qq' ? 'qq' : (pl.provider === 'kw' ? 'kw' : 'netease');
+        var sourceLabel = provider === 'qq' ? 'QQ' : (provider === 'kw' ? 'KW' : 'NE');
         return { type:'playlist', title: pl.name, sub:sourceLabel + ' · ' + (pl.trackCount||0)+' 首 · 播放 '+compactCount(pl.playCount||0),
-          cover: pl.cover || '', tag: pl.subscribed ? '收藏歌单' : '我的歌单', playlistId: (provider === 'qq' ? 'qq:' : '') + pl.id, provider: provider };
+          cover: pl.cover || '', tag: pl.subscribed ? '收藏歌单' : '我的歌单', playlistId: (provider === 'qq' || provider === 'kw' ? provider + ':' : '') + pl.id, provider: provider };
       });
       if (shelfShowsPodcasts() && (shelfPane === 'mine' || shelfMergesCollections()) && myPodcastCollections.length) {
         myPodcastCollections.forEach(function(pc){
@@ -14410,6 +14445,7 @@ function makeContentListManager() {
       }
       var podcastCollectionKey = String(playlistId || '').indexOf('podcast:') === 0 ? String(playlistId).slice(8) : '';
       var qqPlaylistId = String(playlistId || '').indexOf('qq:') === 0 ? String(playlistId).slice(3) : '';
+      var kwPlaylistId = String(playlistId || '').indexOf('kw:') === 0 ? String(playlistId).slice(3) : '';
       contentKind = podcastCollectionKey ? 'podcast' : 'playlist';
       // 拉取歌单/播客集合
       var r = null;
@@ -14418,7 +14454,9 @@ function makeContentListManager() {
           ? await apiJson('/api/podcast/my/items?key=' + encodeURIComponent(podcastCollectionKey) + '&limit=36')
           : (qqPlaylistId
             ? await apiJson('/api/qq/playlist/tracks?id=' + encodeURIComponent(qqPlaylistId))
-            : await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(playlistId)));
+            : (kwPlaylistId
+              ? await apiJson('/api/kw/playlist/tracks?id=' + encodeURIComponent(kwPlaylistId))
+              : await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(playlistId))));
       } catch (e) {
         if (!open || token !== requestToken) return;
         console.warn('[ShelfContentLoadApi]', playlistId, e);
@@ -15098,9 +15136,17 @@ async function apiJson(url, opts) {
   }
 }
 function escHtml(s){ var d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+// 把 URL 安全嵌入双引号 HTML 属性: 合法 URL 不含裸引号/尖括号/反引号, 出现即百分号编码,
+// 防止第三方封面字段(如经明文 HTTP + 宽松正则解析的酷我数据)含 " 闭合 src 属性注入 onerror 等 (XSS)。
+// 注意 escHtml 不转义双引号, 不能用于属性值场景。
+function attrUrl(u){ return String(u == null ? '' : u).replace(/["'<>`]/g, function(c){ return encodeURIComponent(c); }); }
+// 顶档音质可选条件: 网易云 SVIP 或 酷我登录(至臻权益由后端 music.pay 判定, 无权益自动回落无损)
+function canSelectTopQuality() {
+  return hasProviderSvip('netease', loginStatus) || hasPlatformLogin('kw');
+}
 function normalizePlaybackQuality(value) {
   value = String(value || '').toLowerCase();
-  if (value === 'jymaster' || value === 'master' || value === 'svip') return 'jymaster';
+  if (value === 'jymaster' || value === 'master' || value === 'svip' || value === 'zhizhen' || value === 'zply') return 'jymaster';
   if (value === 'hires' || value === 'hi-res' || value === 'highres' || value === 'highest') return 'hires';
   if (value === 'lossless' || value === 'flac' || value === 'sq') return 'lossless';
   if (value === 'exhigh' || value === 'high' || value === '320k' || value === 'hq') return 'exhigh';
@@ -15108,6 +15154,7 @@ function normalizePlaybackQuality(value) {
   return 'hires';
 }
 function playbackQualityLabel(value) {
+  if (String(value || '').toLowerCase() === 'zhizhen') return '至臻母带';  // 酷我至臻 (实际解出的 mflac 无损)
   value = normalizePlaybackQuality(value);
   if (value === 'jymaster') return '超清母带';
   if (value === 'hires') return '高清臻音';
@@ -15117,6 +15164,7 @@ function playbackQualityLabel(value) {
   return '高清臻音';
 }
 function playbackQualityShortLabel(value) {
+  if (String(value || '').toLowerCase() === 'zhizhen') return '至臻';
   value = normalizePlaybackQuality(value);
   if (value === 'jymaster') return '母带';
   if (value === 'hires') return '臻音';
@@ -15145,8 +15193,10 @@ function playbackBitrateLabel(br) {
 }
 function playbackResolvedQualityText(data) {
   data = data || {};
+  var lv = String(data.level || data.quality || playbackQuality).toLowerCase();
   var label = playbackQualityLabel(data.level || data.quality || playbackQuality);
-  var br = playbackBitrateLabel(data.br);
+  // 至臻的 br(20900000) 是酷我档位码不是真实码率, 不显示以免误导(实际为无损 FLAC)
+  var br = lv === 'zhizhen' ? '' : playbackBitrateLabel(data.br);
   return br ? (label + ' · ' + br) : label;
 }
 function readPlaybackQualityPreference() {
@@ -15162,26 +15212,26 @@ function savePlaybackQualityPreference() {
 function updatePlaybackQualityUi() {
   var label = document.getElementById('quality-btn-label');
   var btn = document.getElementById('quality-btn');
-  var canUseSvip = hasProviderSvip('netease', loginStatus);
-  var displayQuality = playbackQuality === 'jymaster' && !canUseSvip ? 'hires' : playbackQuality;
+  var canTop = canSelectTopQuality();
+  var displayQuality = playbackQuality === 'jymaster' && !canTop ? 'hires' : playbackQuality;
   if (label) label.textContent = playbackQualityShortLabel(displayQuality);
-  if (btn) btn.title = playbackQuality === 'jymaster' && !canUseSvip
-    ? '音质: ' + playbackQualityLabel(displayQuality) + ' · 超清母带需网易云 SVIP'
+  if (btn) btn.title = playbackQuality === 'jymaster' && !canTop
+    ? '音质: ' + playbackQualityLabel(displayQuality) + ' · 顶档需网易云 SVIP 或酷我登录'
     : '音质: ' + playbackQualityLabel(displayQuality);
   document.querySelectorAll('.quality-option').forEach(function(option){
     var q = normalizePlaybackQuality(option.dataset.quality);
-    var locked = option.dataset.svip === '1' && !canUseSvip;
+    var locked = option.dataset.svip === '1' && !canTop;
     option.classList.toggle('active', q === displayQuality);
     option.classList.toggle('locked', locked);
     option.disabled = locked;
-    option.title = locked ? '需要网易云 SVIP 账号' : playbackQualityLabel(q);
+    option.title = locked ? '顶档音质: 需网易云 SVIP 或登录酷我' : playbackQualityLabel(q);
   });
 }
 function setPlaybackQuality(value) {
   var next = normalizePlaybackQuality(value);
-  if (next === 'jymaster' && !hasProviderSvip('netease', loginStatus)) {
-    showToast(hasPlatformLogin('netease') ? '超清母带需要网易云 SVIP' : '登录网易云 SVIP 后可用超清母带');
-    if (!hasPlatformLogin('netease')) openProviderLogin('netease');
+  if (next === 'jymaster' && !canSelectTopQuality()) {
+    showToast(hasPlatformLogin('netease') ? '超清母带需网易云 SVIP, 至臻母带需登录酷我' : '登录网易云 SVIP 可用超清母带, 登录酷我可用至臻母带');
+    if (!hasAnyPlatformLogin()) openProviderLogin('netease');
     return;
   }
   playbackQuality = next;
@@ -15196,7 +15246,8 @@ function canReloadCurrentTrackForQuality() {
   if (!audio || !audio.src || audio.paused || audio.ended) return false;
   var song = playQueue[currentIdx];
   if (!song || song.type === 'local' || song.source === 'local') return false;
-  return songProviderKey(song) === 'netease' || songProviderKey(song) === 'qq';
+  var key = songProviderKey(song);
+  return key === 'netease' || key === 'qq' || key === 'kw';
 }
 function applyPlaybackQualityToCurrentTrack(nextQuality) {
   var label = playbackQualityLabel(nextQuality || playbackQuality);
@@ -15270,6 +15321,12 @@ function coverProxySrc(url, cacheBust) {
 }
 function coverUrlWithSize(url, size) {
   if (!url || isInlineCoverSrc(url) || !/^https?:\/\//i.test(url)) return url || '';
+  // 酷我专辑封面/歌手头像分辨率写在路径段 /star/albumcover/<size>/ 或 /star/starheads/<size>/ 里;
+  // 网易云的 ?param=NyN 对酷我无效, 不改写就会停留在接口返回的 120px 缩略图。直接改尺寸段。
+  if (/\/star\/(?:albumcover|starheads)\/\d+\//.test(url)) {
+    var kwSize = Math.max(120, Math.min(1000, Math.round(Number(size) || 500)));
+    return url.replace(/(\/star\/(?:albumcover|starheads)\/)\d+\//, '$1' + kwSize + '/');
+  }
   if (!size) return url;
   var param = 'param=' + size + 'y' + size;
   if (/[?&]param=\d+y\d+/i.test(url)) return url.replace(/([?&])param=\d+y\d+/i, '$1' + param);
@@ -15279,6 +15336,7 @@ function songCustomCoverKey(song) {
   if (!song) return '';
   if (song.customCoverKey) return String(song.customCoverKey);
   if (song.provider === 'qq' || song.source === 'qq' || song.type === 'qq') return 'qq:' + (song.mid || song.songmid || song.id || (song.name + '|' + song.artist));
+  if (song.provider === 'kw' || song.source === 'kw' || song.type === 'kw') return 'kw:' + (song.rid || song.id || (song.name + '|' + song.artist));
   if (song.localKey) return 'local:' + song.localKey;
   if (song.type === 'podcast' && song.programId) return 'podcast:' + song.programId;
   if (song.id != null && song.id !== '') return 'id:' + song.id;
@@ -15374,13 +15432,11 @@ function beginListenSession(song, context) {
     maxProgress: 0,
   };
 }
-function updateListenStatsTick(force) {
-  if (!audio || !audio.duration || audio.paused) return;
-  var song = currentCoverSong();
-  if (!song) return;
-  var key = queueItemKey(song);
-  if (!listenSession || listenSession.key !== key) beginListenSession(song, activeRadioContext);
+// 只把时间累加进当前 session, 绝不调用 beginListenSession ——
+// finalizeListenSession 走这里, 避免 finalize→tick→begin→finalize 的无限互递归 (栈溢出, 每 200ms 抛 RangeError)。
+function accumulateListenTime(force) {
   if (!listenSession) return;
+  if (!audio || !audio.duration || audio.paused) return;
   var now = Date.now();
   var audioTime = isFinite(audio.currentTime) ? audio.currentTime : 0;
   var deltaByAudio = Math.max(0, audioTime - (listenSession.lastAudioTime || 0)) * 1000;
@@ -15392,9 +15448,17 @@ function updateListenStatsTick(force) {
   listenSession.lastAudioTime = audioTime;
   listenSession.maxProgress = Math.max(listenSession.maxProgress || 0, audio.duration ? audioTime / audio.duration : 0);
 }
+function updateListenStatsTick(force) {
+  if (!audio || !audio.duration || audio.paused) return;
+  var song = currentCoverSong();
+  if (!song) return;
+  var key = queueItemKey(song);
+  if (!listenSession || listenSession.key !== key) beginListenSession(song, activeRadioContext);
+  accumulateListenTime(force);
+}
 function finalizeListenSession(completed) {
   if (!listenSession) return;
-  updateListenStatsTick(true);
+  accumulateListenTime(true);
   var session = listenSession;
   listenSession = null;
   var effective = completed || session.listenMs >= 45000 || session.maxProgress >= 0.5 || (!audio || !audio.duration ? session.listenMs >= 30000 : false);
@@ -16243,12 +16307,14 @@ function songFromListenRecord(record) {
   if (!record) return null;
   var provider = record.sourceKey || '';
   if (!provider && record.type === 'qq') provider = 'qq';
+  if (!provider && record.type === 'kw') provider = 'kw';
   if (!provider) provider = record.mid ? 'qq' : 'netease';
   return {
     provider: provider,
     source: provider,
-    type: record.type || (provider === 'qq' ? 'qq' : 'song'),
+    type: record.type || (provider === 'qq' ? 'qq' : (provider === 'kw' ? 'kw' : 'song')),
     id: record.id || record.mid || record.key || '',
+    rid: provider === 'kw' ? (record.id || record.key || '') : undefined,
     mid: record.mid || '',
     songmid: record.mid || '',
     mediaMid: record.mediaMid || '',
@@ -16337,6 +16403,7 @@ function songDurationLabel(song) {
 function songSourceLabel(song) {
   if (!song) return '未知';
   if (song.provider === 'qq' || song.source === 'qq' || song.type === 'qq') return 'QQ 音乐';
+  if (song.provider === 'kw' || song.source === 'kw' || song.type === 'kw') return '酷我音乐';
   if (song.type === 'local') return '本地上传';
   if (song.type === 'podcast' || song.source === 'podcast') return '网易云播客';
   return '网易云音乐';
@@ -16388,6 +16455,15 @@ function currentQQArtistMid(song) {
   }
   return '';
 }
+function currentKwArtistId(song) {
+  if (!song || songProviderKey(song) !== 'kw') return '';
+  if (song.artistId && /^\d+$/.test(String(song.artistId))) return String(song.artistId);
+  var artists = song.artists || [];
+  for (var i = 0; i < artists.length; i++) {
+    if (artists[i] && artists[i].id && /^\d+$/.test(String(artists[i].id))) return String(artists[i].id);
+  }
+  return '';
+}
 function commentTimeLabel(ms) {
   var t = Number(ms) || 0;
   if (!t) return '';
@@ -16414,7 +16490,7 @@ function renderArtistSongList(songs) {
   if (!detailArtistSongs.length) return '<div class="detail-empty">暂无热门歌曲</div>';
   return '<div class="detail-scroll">' + detailArtistSongs.map(function(s, i){
     var cover = songCoverSrc(s, 80);
-    var coverHtml = cover ? '<img class="artist-song-cover" src="' + escHtml(cover) + '" alt="" onerror="this.style.opacity=0.18">' : '<div class="artist-song-cover"></div>';
+    var coverHtml = cover ? '<img class="artist-song-cover" src="' + attrUrl(cover) + '" alt="" onerror="this.style.opacity=0.18">' : '<div class="artist-song-cover"></div>';
     var actionsHtml = '<div class="artist-song-actions">' +
       '<button class="artist-song-action collect" type="button" title="收藏到歌单" aria-label="收藏到歌单" onclick="event.stopPropagation();collectArtistDetailSong(' + i + ')">' + artistCollectTrayIconSvg() + '</button>' +
       '<button class="artist-song-action next" type="button" title="下一首播放" aria-label="下一首播放" onclick="event.stopPropagation();queueArtistDetailSongNext(' + i + ')">' + artistNextPlusIconSvg() + '</button>' +
@@ -16464,16 +16540,19 @@ function openTrackDetailModal(type, songOverride) {
   var body = document.getElementById('track-detail-body');
   if (!heading || !body) return;
   var cover = songCoverSrc(song, 180);
-  var coverHtml = cover ? '<img class="detail-cover" src="' + cover + '" alt="">' : '<div class="detail-cover"></div>';
+  var coverHtml = cover ? '<img class="detail-cover" src="' + attrUrl(cover) + '" alt="">' : '<div class="detail-cover"></div>';
   var title = song.name || '当前歌曲';
   var artists = currentArtistNames(song);
   var seq = ++trackDetailSeq;
   if (type === 'artist') {
     var artistId = currentArtistId(song);
     var qqArtistMid = currentQQArtistMid(song);
+    var kwArtistId = currentKwArtistId(song);
     var artistDetailUrl = artistId
       ? ('/api/artist/detail?id=' + encodeURIComponent(artistId) + '&limit=36')
-      : (qqArtistMid ? ('/api/qq/artist/detail?mid=' + encodeURIComponent(qqArtistMid) + '&limit=36') : '');
+      : (qqArtistMid
+        ? ('/api/qq/artist/detail?mid=' + encodeURIComponent(qqArtistMid) + '&limit=36')
+        : (kwArtistId ? ('/api/kw/artist/songs?id=' + encodeURIComponent(kwArtistId) + '&limit=36') : ''));
     var artistName = artists.join(' / ') || song.artist || '未知歌手';
     var artistNamesForMatch = artists.length ? artists : (song.artist ? [song.artist] : []);
     var artistInitial = artistName && artistName !== '未知歌手' ? artistName.slice(0, 1) : '歌';
@@ -16574,7 +16653,7 @@ function openTrackDetailModal(type, songOverride) {
 }
 function openArtistDetailForSong(song) {
   if (!song) { showToast('未找到歌手信息'); return; }
-  if (currentArtistId(song) || currentQQArtistMid(song)) {
+  if (currentArtistId(song) || currentQQArtistMid(song) || currentKwArtistId(song)) {
     openTrackDetailModal('artist', song);
     return;
   }
@@ -16591,17 +16670,19 @@ function openArtistDetailForSong(song) {
   }
 }
 function resolveArtistSongForDetail(song, artist) {
-  var provider = songProviderKey(song) === 'qq' ? 'qq' : 'netease';
+  var provider = songProviderKey(song);
   var url = provider === 'qq'
     ? '/api/qq/search?keywords=' + encodeURIComponent(artist) + '&limit=8'
-    : '/api/search?keywords=' + encodeURIComponent(artist) + '&limit=10';
+    : (provider === 'kw'
+      ? '/api/kw/search?keywords=' + encodeURIComponent(artist) + '&limit=10'
+      : '/api/search?keywords=' + encodeURIComponent(artist) + '&limit=10');
   return apiJson(url).then(function(r){
     var songs = (r && r.songs) || [];
     for (var i = 0; i < songs.length; i++) {
       var candidate = songs[i];
       if (!candidate) continue;
       if (!artistNameMatches([artist], candidate.artist || '')) continue;
-      if (currentArtistId(candidate) || currentQQArtistMid(candidate)) return candidate;
+      if (currentArtistId(candidate) || currentQQArtistMid(candidate) || currentKwArtistId(candidate)) return candidate;
     }
     return null;
   });
@@ -17066,7 +17147,7 @@ function renderCollectModal() {
   if (!current || !list) return;
   var song = collectTargetSong || {};
   var cover = songCoverSrc(song, 80);
-  current.innerHTML = (cover ? '<img src="' + cover + '" alt="">' : '<div class="cover-placeholder"></div>') +
+  current.innerHTML = (cover ? '<img src="' + attrUrl(cover) + '" alt="">' : '<div class="cover-placeholder"></div>') +
     '<div style="min-width:0"><div class="collect-title">' + escHtml(song.name || '当前歌曲') + '</div><div class="collect-sub">' + escHtml(song.artist || '') + '</div></div>';
   if (!loginStatus.loggedIn) {
     list.innerHTML = '<div class="collect-empty">登录后显示你的歌单</div>';
@@ -17084,7 +17165,7 @@ function renderCollectModal() {
   list.innerHTML = mine.map(function(pl){
     var thumb = pl.cover ? coverUrlWithSize(pl.cover, 80) : '';
     return '<div class="collect-item" data-collect-pid="' + escHtml(String(pl.id || '')) + '" onclick="addCollectTargetToPlaylist(this.getAttribute(\'data-collect-pid\'))">' +
-      (thumb ? '<img src="' + thumb + '" alt="">' : '<div class="cover-placeholder"></div>') +
+      (thumb ? '<img src="' + attrUrl(thumb) + '" alt="">' : '<div class="cover-placeholder"></div>') +
       '<div style="min-width:0"><div class="collect-title">' + escHtml(pl.name || '') + '</div><div class="collect-sub">' + (pl.trackCount || 0) + ' 首</div></div>' +
     '</div>';
   }).join('');
@@ -17267,6 +17348,7 @@ function updateSearchModeTabs() {
   var songBtn = document.getElementById('search-mode-song');
   var neteaseBtn = document.getElementById('search-mode-netease');
   var qqBtn = document.getElementById('search-mode-qq');
+  var kwBtn = document.getElementById('search-mode-kw');
   var podcastBtn = document.getElementById('search-mode-podcast');
   if (songBtn) {
     songBtn.classList.toggle('active', searchMode === 'song');
@@ -17280,6 +17362,10 @@ function updateSearchModeTabs() {
     qqBtn.classList.toggle('active', searchMode === 'qq');
     qqBtn.setAttribute('aria-selected', searchMode === 'qq' ? 'true' : 'false');
   }
+  if (kwBtn) {
+    kwBtn.classList.toggle('active', searchMode === 'kw');
+    kwBtn.setAttribute('aria-selected', searchMode === 'kw' ? 'true' : 'false');
+  }
   if (podcastBtn) {
     podcastBtn.classList.toggle('active', searchMode === 'podcast');
     podcastBtn.setAttribute('aria-selected', searchMode === 'podcast' ? 'true' : 'false');
@@ -17287,12 +17373,12 @@ function updateSearchModeTabs() {
   if ($input) {
     $input.placeholder = searchMode === 'podcast'
       ? '搜索播客、电台...'
-      : (searchMode === 'qq' ? '搜索 QQ 音乐...' : (searchMode === 'netease' ? '搜索网易云音乐...' : '搜索歌曲、歌手...'));
+      : (searchMode === 'qq' ? '搜索 QQ 音乐...' : (searchMode === 'kw' ? '搜索酷我音乐...' : (searchMode === 'netease' ? '搜索网易云音乐...' : '搜索歌曲、歌手...')));
   }
   requestAnimationFrame(updateSearchPillGlassDisplacementMap);
 }
 function setSearchMode(mode) {
-  mode = (mode === 'podcast' || mode === 'netease' || mode === 'qq') ? mode : 'song';
+  mode = (mode === 'podcast' || mode === 'netease' || mode === 'qq' || mode === 'kw') ? mode : 'song';
   if (searchMode === mode) return;
   searchMode = mode;
   updateSearchModeTabs();
@@ -17507,11 +17593,12 @@ updateSearchModeTabs();
 
 function songProviderKey(song) {
   if (song && (song.provider === 'qq' || song.source === 'qq' || song.type === 'qq')) return 'qq';
+  if (song && (song.provider === 'kw' || song.source === 'kw' || song.type === 'kw')) return 'kw';
   return 'netease';
 }
 function songSourceTagHtml(song) {
   var key = songProviderKey(song);
-  var label = key === 'qq' ? 'QQ' : 'NE';
+  var label = key === 'qq' ? 'QQ' : (key === 'kw' ? 'KW' : 'NE');
   return '<span class="tag-source ' + key + '">' + label + '</span>';
 }
 function searchResultMetaText(song) {
@@ -17629,7 +17716,7 @@ function scoreSongSearchResult(song, q, sourceIndex) {
   score -= (sourceIndex || 0) * 0.75;
   return score;
 }
-function mergeSongSearchResults(neteaseSongs, qqSongs, limit, q) {
+function mergeSongSearchResults(neteaseSongs, qqSongs, kwSongs, limit, q) {
   var out = [];
   var seen = {};
   function push(song, sourceIndex) {
@@ -17642,26 +17729,34 @@ function mergeSongSearchResults(neteaseSongs, qqSongs, limit, q) {
   }
   (neteaseSongs || []).forEach(function(song, i){ push(song, i); });
   (qqSongs || []).forEach(function(song, i){ push(song, i); });
+  (kwSongs || []).forEach(function(song, i){ push(song, i); });
   out.sort(function(a, b){ return (b._searchScore || 0) - (a._searchScore || 0); });
   return out.slice(0, limit);
 }
 async function fetchMusicSearchResults(q, mode) {
   if (mode === 'qq') {
     var qqOnly = await apiJson('/api/qq/search?keywords=' + encodeURIComponent(q) + '&limit=12');
-    return mergeSongSearchResults([], qqOnly.songs || [], 18, q);
+    return mergeSongSearchResults([], qqOnly.songs || [], [], 18, q);
+  }
+  if (mode === 'kw') {
+    var kwOnly = await apiJson('/api/kw/search?keywords=' + encodeURIComponent(q) + '&limit=18');
+    return mergeSongSearchResults([], [], kwOnly.songs || [], 18, q);
   }
   if (mode === 'netease') {
     var neOnly = await apiJson('/api/search?keywords=' + encodeURIComponent(q) + '&limit=18');
-    return mergeSongSearchResults(neOnly.songs || [], [], 18, q);
+    return mergeSongSearchResults(neOnly.songs || [], [], [], 18, q);
   }
   var result = await Promise.allSettled([
     apiJson('/api/search?keywords=' + encodeURIComponent(q) + '&limit=14'),
-    apiJson('/api/qq/search?keywords=' + encodeURIComponent(q) + '&limit=12')
+    apiJson('/api/qq/search?keywords=' + encodeURIComponent(q) + '&limit=10'),
+    apiJson('/api/kw/search?keywords=' + encodeURIComponent(q) + '&limit=10')
   ]);
   var neteaseSongs = result[0].status === 'fulfilled' ? ((result[0].value && result[0].value.songs) || []) : [];
   var qqSongs = result[1].status === 'fulfilled' ? ((result[1].value && result[1].value.songs) || []) : [];
+  var kwSongs = result[2].status === 'fulfilled' ? ((result[2].value && result[2].value.songs) || []) : [];
   if (result[1].status === 'rejected') console.warn('QQ search failed:', result[1].reason);
-  return mergeSongSearchResults(neteaseSongs, qqSongs, 18, q);
+  if (result[2].status === 'rejected') console.warn('Kuwo search failed:', result[2].reason);
+  return mergeSongSearchResults(neteaseSongs, qqSongs, kwSongs, 18, q);
 }
 function renderSongSearchResults(songs) {
   playlist = songs || [];
@@ -17671,7 +17766,7 @@ function renderSongSearchResults(songs) {
     var sourceClass = songProviderKey(s) + '-source';
     var thumb = songCoverSrc(s, 80);
     var imgTag = thumb
-      ? '<img src="' + thumb + '" alt="" loading="lazy" onerror="this.style.opacity=0.2">'
+      ? '<img src="' + attrUrl(thumb) + '" alt="" loading="lazy" onerror="this.style.opacity=0.2">'
       : '<div style="width:40px;height:40px;border-radius:6px;background:rgba(255,255,255,0.06);flex-shrink:0"></div>';
     return '<div class="search-result ' + sourceClass + '">' +
       '<div style="display:flex;align-items:center;gap:12px;flex:1;min-width:0" onclick="playSearchResult(' + i + ')">' +
@@ -18045,6 +18140,7 @@ function bindVolumeControls() {
 function queueItemKey(song) {
   if (!song) return '';
   if (song.provider === 'qq' || song.source === 'qq' || song.type === 'qq') return 'qq:' + (song.mid || song.songmid || song.id || (song.name + '|' + song.artist));
+  if (song.provider === 'kw' || song.source === 'kw' || song.type === 'kw') return 'kw:' + (song.rid || song.id || (song.name + '|' + song.artist));
   if (song.type === 'podcast' && song.programId) return 'podcast:' + song.programId;
   if (song.localKey) return 'local:' + song.localKey;
   if (song.id != null && song.id !== '') return 'song:' + song.id;
@@ -18133,10 +18229,13 @@ function playSearchResult(i) {
 var firstPlayDone = false;
 
 function playbackProviderLabel(song) {
-  return songProviderKey(song) === 'qq' ? 'QQ 音乐' : '网易云';
+  var key = songProviderKey(song);
+  return key === 'qq' ? 'QQ 音乐' : (key === 'kw' ? '酷我音乐' : '网易云');
 }
 function playbackLoginProvider(song) {
-  return songProviderKey(song) === 'qq' ? 'qq' : 'netease';
+  // songProviderKey 已返回 'qq'/'kw'/'netease'; openProviderLogin 会再 normalize。
+  // 不能只判 qq 否则把酷我版权受限曲弹成"登录网易云"。
+  return songProviderKey(song);
 }
 function playbackRestrictionMessage(song, data) {
   data = data || {};
@@ -18228,21 +18327,31 @@ function isSameTitleArtist(source, candidate) {
   if (!a.length || !b.length) return false;
   return a.some(function(name){ return b.indexOf(name) >= 0; });
 }
+function alternatePlaybackProviders(song) {
+  var cur = songProviderKey(song);
+  return ['netease', 'qq', 'kw'].filter(function(p){ return p !== cur; });
+}
 function alternatePlaybackProvider(song) {
-  return songProviderKey(song) === 'qq' ? 'netease' : 'qq';
+  return alternatePlaybackProviders(song)[0] || 'netease';
+}
+function providerSearchEndpoint(provider, query) {
+  if (provider === 'qq') return '/api/qq/search?keywords=' + encodeURIComponent(query) + '&limit=8';
+  if (provider === 'kw') return '/api/kw/search?keywords=' + encodeURIComponent(query) + '&limit=10';
+  return '/api/search?keywords=' + encodeURIComponent(query) + '&limit=12';
 }
 async function searchAlternatePlatformSong(song) {
-  var target = alternatePlaybackProvider(song);
   var artist = artistNameParts(song)[0] || '';
   var query = [song.name || song.title || '', song.artist || artist].filter(Boolean).join(' ').trim();
   if (!query) return null;
-  var url = target === 'qq'
-    ? '/api/qq/search?keywords=' + encodeURIComponent(query) + '&limit=8'
-    : '/api/search?keywords=' + encodeURIComponent(query) + '&limit=12';
-  var data = await apiJson(url);
-  var list = data && (data.songs || data.result || []);
-  for (var i = 0; i < list.length; i++) {
-    if (isSameTitleArtist(song, list[i])) return cloneSong(list[i]);
+  var providers = alternatePlaybackProviders(song);
+  for (var p = 0; p < providers.length; p++) {
+    try {
+      var data = await apiJson(providerSearchEndpoint(providers[p], query));
+      var list = (data && (data.songs || data.result)) || [];
+      for (var i = 0; i < list.length; i++) {
+        if (isSameTitleArtist(song, list[i])) return cloneSong(list[i]);
+      }
+    } catch (e) { console.warn('alternate source search failed:', providers[p], e); }
   }
   return null;
 }
@@ -18285,16 +18394,16 @@ async function tryAutoPlaybackFallback(song, data, idx, token, opts) {
   var restriction = (data && data.restriction) || {};
   var category = (data && data.reason) || restriction.category || '';
   var fromLabel = playbackProviderLabel(song);
-  var targetLabel = alternatePlaybackProvider(song) === 'qq' ? 'QQ 音乐' : '网易云';
-  showSourceFallbackNotice('正在自动换源', fromLabel + ' 当前不可播，正在查找 ' + targetLabel + ' 的同名同歌手版本。');
+  showSourceFallbackNotice('正在自动换源', fromLabel + ' 当前不可播，正在查找其它平台的同名同歌手版本。');
   try {
     var alternate = await searchAlternatePlatformSong(song);
     if (token !== trackSwitchToken) return true;
     if (!alternate) {
       if (category === 'login_required') return false;
-      skipFailedQueueItem(idx, token, '没有找到同名同歌手的 ' + targetLabel + ' 版本，正在播放下一首。');
+      skipFailedQueueItem(idx, token, '没有找到其它平台的同名同歌手版本，正在播放下一首。');
       return true;
     }
+    var targetLabel = playbackProviderLabel(alternate);
     alternate.autoFallbackFrom = songProviderKey(song);
     playQueue[idx] = hydrateCustomCover(alternate);
     safeRenderQueuePanel('source-fallback', { scrollCurrent: miniQueueOpen });
@@ -18461,16 +18570,21 @@ async function playQueueAt(idx, opts) {
 
   try {
     markPlayPhase('source-url');
-    var isQQPlayback = songProviderKey(song) === 'qq';
+    var playbackProviderKey = songProviderKey(song);
+    var isQQPlayback = playbackProviderKey === 'qq';
+    var isKwPlayback = playbackProviderKey === 'kw';
+    var isNeteasePlayback = playbackProviderKey === 'netease';
     var requestedQuality = normalizePlaybackQuality(opts.qualityOverride || playbackQuality);
-    if (!isQQPlayback && requestedQuality === 'jymaster' && !hasProviderSvip('netease', loginStatus)) requestedQuality = 'hires';
+    if (isNeteasePlayback && requestedQuality === 'jymaster' && !hasProviderSvip('netease', loginStatus)) requestedQuality = 'hires';
     if (isQQPlayback && qqPlaybackQualityCeiling && (requestedQuality === 'jymaster' || requestedQuality === 'hires' || requestedQuality === 'lossless')) {
       requestedQuality = qqPlaybackQualityCeiling;
     }
     var qualityParam = '&quality=' + encodeURIComponent(requestedQuality);
     var data = isQQPlayback
       ? await apiJson('/api/qq/song/url?mid=' + encodeURIComponent(song.mid || song.songmid || song.id || '') + '&mediaMid=' + encodeURIComponent(song.mediaMid || song.media_mid || '') + qualityParam)
-      : await apiJson('/api/song/url?id=' + song.id + qualityParam);
+      : isKwPlayback
+        ? await apiJson('/api/kw/song/url?rid=' + encodeURIComponent(song.rid || song.id || '') + qualityParam)
+        : await apiJson('/api/song/url?id=' + song.id + qualityParam);
     if (token !== trackSwitchToken) return;
     if (!data.url) {
       if (isQQPlayback && await retryQQPlaybackWithCompatibleQuality(song, idx, token, opts, data, requestedQuality)) return;
@@ -18479,7 +18593,7 @@ async function playQueueAt(idx, opts) {
       return;
     }
     var resolvedQualityText = playbackResolvedQualityText(data);
-    if (!isQQPlayback && playbackQualityWasDowngraded(requestedQuality, data.level)) {
+    if (isNeteasePlayback && playbackQualityWasDowngraded(requestedQuality, data.level)) {
       showSourceFallbackNotice('网易云音质自动降级', '请求 ' + playbackQualityLabel(requestedQuality) + '，实际播放 ' + resolvedQualityText + '。');
     } else if (opts.qualitySwitch) {
       showSourceFallbackNotice('音质已切换', '实际播放: ' + resolvedQualityText + '。');
@@ -18507,7 +18621,7 @@ async function playQueueAt(idx, opts) {
     }
     bindPlaybackProgressEvents(audio);
     applyVolumeToAudio();
-    var proxyAudioUrl = '/api/audio?url=' + encodeURIComponent(data.url);
+    var proxyAudioUrl = '/api/audio?url=' + encodeURIComponent(data.url) + (data.ekey ? '&kwekey=' + encodeURIComponent(data.ekey) : '');
     audio.src = proxyAudioUrl;
     updatePlaybackProgressUi();
     audio.onended = function(){
@@ -18580,7 +18694,7 @@ async function playQueueAt(idx, opts) {
       safePlaybackStep('visual-prep-hide-chip', hideBeatChip);
     }
     markPlayPhase('audio-start');
-    var playbackStarted = await playAudio({ silent: isQQPlayback });
+    var playbackStarted = await playAudio({ silent: isQQPlayback || isKwPlayback });
     if (!playbackStarted) {
       if (isQQPlayback && await retryQQPlaybackWithCompatibleQuality(song, idx, token, opts, data, requestedQuality)) return;
       forcePlaybackControlsInteractive();
@@ -19023,6 +19137,13 @@ async function fetchLyric(songOrId, token) {
       var mid = song.mid || song.songmid || song.id || '';
       var qqId = song.qqId || (/^\d+$/.test(String(song.id || '')) ? song.id : '');
       endpoint = '/api/qq/lyric?mid=' + encodeURIComponent(mid) + '&id=' + encodeURIComponent(qqId);
+    } else if (provider === 'kw') {
+      // 传 name/artist/duration: 播放 rid 无直挂歌词时, 后端按歌名歌手搜候选歌词 id
+      var kwDurSec = Math.round((Number(song.duration) || 0) / 1000);
+      endpoint = '/api/kw/lyric?rid=' + encodeURIComponent(song.rid || song.id || '') +
+        '&name=' + encodeURIComponent(song.name || '') +
+        '&artist=' + encodeURIComponent(song.artist || (song.artists ? song.artists.map(function(a){ return a.name; }).join('&') : '')) +
+        '&duration=' + kwDurSec;
     } else {
       var songId = song ? song.id : songOrId;
       endpoint = '/api/lyric?id=' + encodeURIComponent(songId);
@@ -19103,7 +19224,8 @@ function parseYrcText(text) {
     var lineDurMs = parseInt(m[2], 10) || 0;
     var body = m[3] || '';
     var words = [], fullText = '';
-    var reg = /\((\d+),(\d+),\d+\)([^()]*)/g, wm;
+    // 逐字文本取到"下一个时间标签前"为止 (而非遇到任意括号即停), 否则歌词里的字面括号如 "(Live)" 会被吞掉
+    var reg = /\((\d+),(\d+),\d+\)((?:(?!\(\d+,\d+,\d+\))[\s\S])*)/g, wm;
     while ((wm = reg.exec(body))) {
       var txt = (wm[3] || '').replace(/\s+/g, ' ');
       if (!txt) continue;
@@ -19368,7 +19490,7 @@ function renderMiniQueuePanel(opts) {
   }
   $list.innerHTML = playQueue.map(function(song, i){
     var thumb = songCoverSrc(song, 60);
-    var imgTag = thumb ? '<img src="' + thumb + '" alt="" loading="lazy" decoding="async" onerror="this.style.opacity=0.2">' : '<div class="mini-queue-cover"></div>';
+    var imgTag = thumb ? '<img src="' + attrUrl(thumb) + '" alt="" loading="lazy" decoding="async" onerror="this.style.opacity=0.2">' : '<div class="mini-queue-cover"></div>';
     return '<div class="mini-queue-item' + (i === currentIdx ? ' now' : '') + '" onclick="playQueueAt(' + i + ')">' +
       imgTag +
       '<div class="mini-queue-info"><div class="mini-queue-name">' + escHtml(song.name) + '</div><div class="mini-queue-sub">' + escHtml(song.artist || '') + '</div></div>' +
@@ -19402,7 +19524,7 @@ function renderQueuePanel(opts) {
   }
   $ql.innerHTML = playQueue.map(function(song, i){
     var thumb = songCoverSrc(song, 60);
-    var imgTag = thumb ? '<img src="' + thumb + '" alt="" loading="lazy" decoding="async" onerror="this.style.opacity=0.2">' : '<div style="width:38px;height:38px;border-radius:6px;background:rgba(255,255,255,.06);flex-shrink:0"></div>';
+    var imgTag = thumb ? '<img src="' + attrUrl(thumb) + '" alt="" loading="lazy" decoding="async" onerror="this.style.opacity=0.2">' : '<div style="width:38px;height:38px;border-radius:6px;background:rgba(255,255,255,.06);flex-shrink:0"></div>';
     return '<div class="queue-item' + (i === currentIdx ? ' now' : '') + '" onclick="playQueueAt(' + i + ')">' +
       imgTag +
       '<div class="qi-info"><div class="qi-name">' + escHtml(song.name) + '</div><div class="qi-sub"><button class="queue-artist-link" type="button" onclick="event.stopPropagation();openQueueArtist(' + i + ')">' + escHtml(song.artist || '未知歌手') + '</button></div></div>' +
@@ -19418,7 +19540,7 @@ function renderQueuePanel(opts) {
   renderMiniQueuePanel({ scrollCurrent: miniQueueOpen });
 }
 async function refreshUserPlaylists(force) {
-  if (!loginStatus.loggedIn && !qqLoginStatus.loggedIn) {
+  if (!loginStatus.loggedIn && !qqLoginStatus.loggedIn && !kwLoginStatus.loggedIn) {
     resetPlaylistPanelRenderLimit();
     document.getElementById('pl-list').innerHTML = '<div style="text-align:center;padding:24px 0;color:rgba(255,255,255,.32);font-size:11.5px">登录后显示个人歌单</div>';
     var podcastListLoggedOut = document.getElementById('podcast-list');
@@ -19427,8 +19549,10 @@ async function refreshUserPlaylists(force) {
   }
   if (force) resetPlaylistPanelRenderLimit();
   var hasCachedQQPlaylists = userPlaylists.some(function(pl){ return pl && pl.provider === 'qq'; });
+  var hasCachedKwPlaylists = userPlaylists.some(function(pl){ return pl && pl.provider === 'kw'; });
   var needsQQRefresh = qqLoginStatus.loggedIn && !hasCachedQQPlaylists;
-  if (!force && !needsQQRefresh && (userPlaylists.length || myPodcastCollections.length)) {
+  var needsKwRefresh = kwLoginStatus.loggedIn && !hasCachedKwPlaylists;
+  if (!force && !needsQQRefresh && !needsKwRefresh && (userPlaylists.length || myPodcastCollections.length)) {
     var cachedAnimate = isPlaylistPanelVisibleForRender();
     renderUserPlaylistsList({ animate: cachedAnimate });
     renderMyPodcastCollections({ animate: cachedAnimate });
@@ -19445,11 +19569,13 @@ async function refreshUserPlaylists(force) {
     var result = await Promise.all([
       loginStatus.loggedIn ? apiJson('/api/user/playlists') : Promise.resolve({ playlists: [] }),
       loginStatus.loggedIn ? apiJson('/api/podcast/my') : Promise.resolve({ collections: [], loggedIn: false }),
-      qqLoginStatus.loggedIn ? apiJson('/api/qq/user/playlists') : Promise.resolve({ playlists: [] })
+      qqLoginStatus.loggedIn ? apiJson('/api/qq/user/playlists') : Promise.resolve({ playlists: [] }),
+      kwLoginStatus.loggedIn ? apiJson('/api/kw/user/playlists') : Promise.resolve({ playlists: [] })
     ]);
     var neteaseLists = (result[0].playlists || []).map(function(pl){ pl.provider = 'netease'; pl.source = 'netease'; return pl; });
     qqPlaylists = (result[2].playlists || []).map(function(pl){ pl.provider = 'qq'; pl.source = 'qq'; return pl; });
-    userPlaylists = neteaseLists.concat(qqPlaylists);
+    kwPlaylists = (result[3].playlists || []).map(function(pl){ pl.provider = 'kw'; pl.source = 'kw'; return pl; });
+    userPlaylists = neteaseLists.concat(qqPlaylists).concat(kwPlaylists);
     myPodcastCollections = result[1].collections || [];
     var animatePanel = isPlaylistPanelVisibleForRender();
     renderUserPlaylistsList({ animate: animatePanel, reset: true });
@@ -19460,18 +19586,19 @@ async function refreshUserPlaylists(force) {
 }
 var playlistPanelDetailState = { key: '', loading: false, playlist: null, tracks: [], token: 0, renderLimit: PLAYLIST_DETAIL_INITIAL_RENDER };
 function playlistPanelKey(provider, id) {
-  return (provider === 'qq' ? 'qq' : 'netease') + ':' + String(id || '');
+  var prefix = provider === 'qq' ? 'qq' : (provider === 'kw' ? 'kw' : 'netease');
+  return prefix + ':' + String(id || '');
 }
 function playlistPanelProviderId(provider, id) {
-  return provider === 'qq' ? ('qq:' + id) : id;
+  return (provider === 'qq' || provider === 'kw') ? (provider + ':' + id) : id;
 }
 function playlistPanelDetailHtml(pl, provider) {
   var key = playlistPanelKey(provider, pl && pl.id);
   if (playlistPanelDetailState.key !== key) return '';
   var tracks = playlistPanelDetailState.tracks || [];
   var loading = playlistPanelDetailState.loading;
-  var cover = pl && pl.cover ? (provider === 'qq' ? pl.cover : (pl.cover + '?param=96y96')) : '';
-  var img = cover ? '<img class="pl-detail-cover" src="' + escHtml(cover) + '" alt="" decoding="async" onerror="this.style.opacity=0.2">' : '<div class="pl-detail-cover"></div>';
+  var cover = pl && pl.cover ? (provider === 'netease' ? (pl.cover + '?param=96y96') : pl.cover) : '';
+  var img = cover ? '<img class="pl-detail-cover" src="' + attrUrl(cover) + '" alt="" decoding="async" onerror="this.style.opacity=0.2">' : '<div class="pl-detail-cover"></div>';
   var renderLimit = loading ? 0 : Math.max(PLAYLIST_DETAIL_INITIAL_RENDER, playlistPanelDetailState.renderLimit || PLAYLIST_DETAIL_INITIAL_RENDER);
   renderLimit = Math.min(tracks.length, renderLimit);
   var visibleTracks = loading ? [] : tracks.slice(0, renderLimit);
@@ -19479,10 +19606,11 @@ function playlistPanelDetailHtml(pl, provider) {
     ? '<div class="pl-detail-row"><div style="width:34px;height:34px;border-radius:7px;background:rgba(255,255,255,.06)"></div><div style="flex:1;min-width:0"><div class="pl-detail-row-title">正在载入歌单</div><div class="pl-detail-row-artist">请稍候</div></div></div>'
     : visibleTracks.map(function(song, i){
         var thumb = songCoverSrc(song, 60);
-        var imgTag = thumb ? '<img src="' + escHtml(thumb) + '" alt="" loading="lazy" decoding="async" onerror="this.style.opacity=0.2">' : '<div style="width:34px;height:34px;border-radius:7px;background:rgba(255,255,255,.06);flex:0 0 auto"></div>';
-        return '<div class="pl-detail-row" data-pl-detail-row="' + i + '">' +
+        var imgTag = thumb ? '<img src="' + attrUrl(thumb) + '" alt="" loading="lazy" decoding="async" onerror="this.style.opacity=0.2">' : '<div style="width:34px;height:34px;border-radius:7px;background:rgba(255,255,255,.06);flex:0 0 auto"></div>';
+        var offTag = song.offline ? '<span class="pl-detail-offline-tag">已下架</span>' : '';
+        return '<div class="pl-detail-row' + (song.offline ? ' is-offline' : '') + '" data-pl-detail-row="' + i + '">' +
           imgTag +
-          '<div style="flex:1;min-width:0"><div class="pl-detail-row-title">' + escHtml(song.name || '') + '</div>' +
+          '<div style="flex:1;min-width:0"><div class="pl-detail-row-title">' + escHtml(song.name || '') + offTag + '</div>' +
           '<button type="button" class="pl-detail-row-artist" data-pl-detail-artist="' + i + '">' + escHtml(song.artist || '未知歌手') + '</button></div>' +
         '</div>';
       }).join('');
@@ -19530,9 +19658,9 @@ function scrollPlaylistPanelDetailIntoView(key) {
 }
 async function openPlaylistPanelDetail(provider, pid, title) {
   if (!pid) return;
-  provider = provider === 'qq' ? 'qq' : 'netease';
+  provider = (provider === 'qq' || provider === 'kw') ? provider : 'netease';
   var key = playlistPanelKey(provider, pid);
-  var pl = userPlaylists.find(function(item){ return playlistPanelKey(item.provider === 'qq' ? 'qq' : 'netease', item.id) === key; }) || { id: pid, provider: provider, name: title || '歌单详情' };
+  var pl = userPlaylists.find(function(item){ return playlistPanelKey(item.provider, item.id) === key; }) || { id: pid, provider: provider, name: title || '歌单详情' };
   if (playlistPanelDetailState.key === key && !playlistPanelDetailState.loading && playlistPanelDetailState.tracks.length) {
     playlistPanelDetailState.key = '';
     playlistPanelDetailState.tracks = [];
@@ -19548,7 +19676,9 @@ async function openPlaylistPanelDetail(provider, pid, title) {
   try {
     var r = provider === 'qq'
       ? await apiJson('/api/qq/playlist/tracks?id=' + encodeURIComponent(pid))
-      : await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(pid));
+      : (provider === 'kw'
+        ? await apiJson('/api/kw/playlist/tracks?id=' + encodeURIComponent(pid))
+        : await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(pid)));
     if (playlistPanelDetailState.token !== token) return;
     playlistPanelDetailState.loading = false;
     playlistPanelDetailState.tracks = (r && r.tracks || []).map(cloneSong);
@@ -19568,7 +19698,7 @@ function playPlaylistPanelDetail() {
   var st = playlistPanelDetailState;
   if (!st || !st.key) return;
   var parts = st.key.split(':');
-  var provider = parts[0] === 'qq' ? 'qq' : 'netease';
+  var provider = parts[0] === 'qq' ? 'qq' : (parts[0] === 'kw' ? 'kw' : 'netease');
   var pid = parts.slice(1).join(':');
   loadPlaylistIntoQueueById(playlistPanelProviderId(provider, pid), true, st.playlist && st.playlist.name || '');
 }
@@ -19638,10 +19768,10 @@ function renderUserPlaylistsList(opts) {
     return;
   }
   function playlistCardHtml(pl) {
-    var provider = pl.provider === 'qq' ? 'qq' : 'netease';
-    var providerLabel = provider === 'qq' ? 'QQ' : 'NE';
-    var thumb = pl.cover ? (provider === 'qq' ? pl.cover : (pl.cover + '?param=88y88')) : '';
-    var imgTag = thumb ? '<img src="' + thumb + '" alt="" loading="lazy" decoding="async" onerror="this.style.opacity=0.2">' : '<div style="width:44px;height:44px;border-radius:8px;background:rgba(255,255,255,.06);flex-shrink:0"></div>';
+    var provider = pl.provider === 'qq' ? 'qq' : (pl.provider === 'kw' ? 'kw' : 'netease');
+    var providerLabel = provider === 'qq' ? 'QQ' : (provider === 'kw' ? 'KW' : 'NE');
+    var thumb = pl.cover ? (provider === 'netease' ? (pl.cover + '?param=88y88') : pl.cover) : '';
+    var imgTag = thumb ? '<img src="' + attrUrl(thumb) + '" alt="" loading="lazy" decoding="async" onerror="this.style.opacity=0.2">' : '<div style="width:44px;height:44px;border-radius:8px;background:rgba(255,255,255,.06);flex-shrink:0"></div>';
     var key = playlistPanelKey(provider, pl.id);
     var expanded = playlistPanelDetailState.key === key ? ' expanded' : '';
     return '<div class="pl-card' + expanded + '" data-playlist-provider="' + provider + '" data-playlist-id="' + escHtml(String(pl.id || '')) + '" data-playlist-title="' + escHtml(pl.name || '') + '">' +
@@ -19650,8 +19780,9 @@ function renderUserPlaylistsList(opts) {
     '</div>' + playlistPanelDetailHtml(pl, provider);
   }
   var groups = [
-    { key:'netease', label:'网易云歌单', items:userPlaylists.filter(function(pl){ return pl.provider !== 'qq'; }) },
-    { key:'qq', label:'QQ 音乐歌单', items:userPlaylists.filter(function(pl){ return pl.provider === 'qq'; }) }
+    { key:'netease', label:'网易云歌单', items:userPlaylists.filter(function(pl){ return pl.provider !== 'qq' && pl.provider !== 'kw'; }) },
+    { key:'qq', label:'QQ 音乐歌单', items:userPlaylists.filter(function(pl){ return pl.provider === 'qq'; }) },
+    { key:'kw', label:'酷我歌单', items:userPlaylists.filter(function(pl){ return pl.provider === 'kw'; }) }
   ];
   if (opts.reset) resetPlaylistPanelRenderLimit();
   playlistPanelRenderLimit = Math.max(PLAYLIST_PANEL_BATCH_SIZE, Math.min(userPlaylists.length, playlistPanelRenderLimit || PLAYLIST_PANEL_BATCH_SIZE));
@@ -19842,11 +19973,14 @@ async function loadPlaylistIntoQueueById(id, autoplay, title) {
   updateEmptyHomeVisibility();
   showLoading();
   var qqPlaylistId = String(id || '').indexOf('qq:') === 0 ? String(id).slice(3) : '';
+  var kwPlaylistId = String(id || '').indexOf('kw:') === 0 ? String(id).slice(3) : '';
   var r = null;
   try {
     r = qqPlaylistId
       ? await apiJson('/api/qq/playlist/tracks?id=' + encodeURIComponent(qqPlaylistId))
-      : await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(id));
+      : (kwPlaylistId
+        ? await apiJson('/api/kw/playlist/tracks?id=' + encodeURIComponent(kwPlaylistId))
+        : await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(id)));
   } catch (e) {
     console.warn('[PlaylistLoadApi]', id, e);
     showToast('歌单加载失败');
@@ -23233,10 +23367,13 @@ function onUserBtnClick() {
 }
 function platformMeta(provider) {
   if (provider === 'qq') return { key: 'qq', short: 'QQ', label: 'QQ 音乐', app: 'QQ 音乐 App', dot: 'qq' };
+  if (provider === 'kw') return { key: 'kw', short: 'KW', label: '酷我音乐', app: '酷我音乐', dot: 'kw' };
   return { key: 'netease', short: 'NE', label: '网易云音乐', app: '网易云音乐 App', dot: 'netease' };
 }
 function platformStatus(provider) {
-  return provider === 'qq' ? qqLoginStatus : loginStatus;
+  if (provider === 'qq') return qqLoginStatus;
+  if (provider === 'kw') return kwLoginStatus;
+  return loginStatus;
 }
 function providerVipType(provider, status) {
   status = status || platformStatus(provider) || {};
@@ -23260,9 +23397,35 @@ function hasProviderVip(provider, status) {
 function hasProviderSvip(provider, status) {
   return provider === 'netease' && providerVipLevel(provider, status) === 'svip';
 }
+// 酷我会员档位 -> 顶栏徽章短标签 (两档主推: 豪华会员 / 超级会员)
+function kwVipTier(status) {
+  status = status || kwLoginStatus || {};
+  var tier = String(status.vipTier || '').toLowerCase();
+  if (tier) return tier;
+  // 兜底: 仅有 vipType (4 超级 / 3 豪华 / 2 音乐包 / 1 普通) 时反推档位
+  var t = Number(status.vipType || 0) || 0;
+  return t >= 4 ? 'super' : (t === 3 ? 'luxury' : (t === 2 ? 'musicpack' : (t >= 1 ? 'vip' : 'none')));
+}
+function kwVipShortLabel(tier) {
+  return tier === 'super' ? '超级会员' : (tier === 'luxury' ? '豪华会员' : (tier === 'musicpack' ? '音乐包' : 'VIP'));
+}
+// 会员到期时间 (后端为毫秒, 兜底秒级) -> YYYY/MM/DD; 无效返回空串
+function formatKwVipExpire(expire) {
+  var ms = Number(expire) || 0;
+  if (ms <= 0) return '';
+  if (ms < 1e12) ms *= 1000;   // 容错: 若误传秒级时间戳则补齐
+  try {
+    return new Date(ms).toLocaleDateString('zh-CN', { year: 'numeric', month: '2-digit', day: '2-digit' });
+  } catch (e) { return ''; }
+}
 function providerVipBadge(provider, status, idAttr) {
   if (!hasProviderVip(provider, status)) return '';
   var id = idAttr ? ' id="' + idAttr + '"' : '';
+  if (provider === 'kw') {
+    var tier = kwVipTier(status);
+    if (tier === 'none') return '';
+    return '<span' + id + ' class="top-account-vip kw ' + tier + '">' + kwVipShortLabel(tier) + '</span>';
+  }
   var cls = 'top-account-vip' + (provider === 'qq' ? ' qq' : '');
   var level = providerVipLevel(provider, status);
   var label = provider === 'qq' ? 'QQ VIP' : (level === 'svip' ? 'SVIP' : 'VIP');
@@ -23273,20 +23436,21 @@ function hasPlatformLogin(provider) {
   return !!(st && st.loggedIn);
 }
 function hasAnyPlatformLogin() {
-  return hasPlatformLogin('netease') || hasPlatformLogin('qq');
+  return hasPlatformLogin('netease') || hasPlatformLogin('qq') || hasPlatformLogin('kw');
 }
 function firstLoggedProvider() {
   if (hasPlatformLogin(activeAccountProvider)) return activeAccountProvider;
   if (hasPlatformLogin('netease')) return 'netease';
   if (hasPlatformLogin('qq')) return 'qq';
+  if (hasPlatformLogin('kw')) return 'kw';
   return 'netease';
 }
 function providerAvatarSrc(provider, status) {
   status = status || platformStatus(provider) || {};
   if (status.avatar) return avatarSrc(status.avatar);
   var meta = platformMeta(provider);
-  var fill = provider === 'qq' ? '#bfd66b' : '#d95b67';
-  var bg = provider === 'qq' ? '#11150b' : '#180b0f';
+  var fill = provider === 'qq' ? '#bfd66b' : (provider === 'kw' ? '#6ca8ea' : '#d95b67');
+  var bg = provider === 'qq' ? '#11150b' : (provider === 'kw' ? '#0b1018' : '#180b0f');
   var svg = '<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96"><rect width="96" height="96" rx="48" fill="' + bg + '"/><circle cx="48" cy="48" r="34" fill="' + fill + '" opacity=".16"/><text x="48" y="56" text-anchor="middle" font-family="Arial, sans-serif" font-size="26" font-weight="700" fill="' + fill + '">' + meta.short + '</text></svg>';
   return 'data:image/svg+xml;charset=UTF-8,' + encodeURIComponent(svg);
 }
@@ -23317,7 +23481,7 @@ async function refreshLoginStatus(force) {
       loadHomeDiscover(true);
       syncLikeStatusForSongs(playQueue.concat(playlist || []));
     } else {
-      userPlaylists = qqPlaylists.slice();
+      userPlaylists = qqPlaylists.concat(kwPlaylists);
       myPodcastCollections = [];
       myPodcastItems = {};
       likedSongMap = {};
@@ -23389,6 +23553,64 @@ function startQQLoginStatusAutoRefresh() {
     refreshQQLoginStatus().catch(function(e){ console.warn('QQ login auto refresh failed:', e); });
   }, 45000);
 }
+async function refreshKwLoginStatus() {
+  try {
+    var info = await apiJson('/api/kw/login/status?t=' + Date.now());
+    kwLoginStatus = Object.assign({ provider: 'kw', loggedIn: false, nickname: '酷我音乐', userId: '', avatar: '', vipType: 0, vipTier: 'none', vipLabel: '', vipExpire: 0, isVip: false, hasAccount: false }, info || {});
+    if (!hasPlatformLogin(activeAccountProvider)) activeAccountProvider = firstLoggedProvider();
+    renderUserBtn();
+    return kwLoginStatus;
+  } catch (e) {
+    console.warn('Kuwo login status failed:', e);
+    return kwLoginStatus;
+  }
+}
+async function submitKwLogin() {
+  if (kwLoginBusy) return;
+  var userEl = document.getElementById('kw-login-username');
+  var pwEl = document.getElementById('kw-login-password');
+  var statusEl = document.getElementById('qr-status');
+  var username = userEl ? userEl.value.trim() : '';
+  var password = pwEl ? pwEl.value : '';
+  if (!username || !password) {
+    if (statusEl) { statusEl.textContent = '请输入酷我账号和密码'; statusEl.className = 'fail'; }
+    return;
+  }
+  kwLoginBusy = true;
+  var btn = document.getElementById('kw-login-save-btn');
+  if (btn) { btn.disabled = true; btn.textContent = '登录中…'; }
+  if (statusEl) { statusEl.textContent = '正在登录酷我…'; statusEl.className = 'preview'; }
+  try {
+    var info = await apiJson('/api/kw/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: username, password: password })
+    });
+    if (info && info.loggedIn) {
+      kwLoginStatus = Object.assign({ provider: 'kw', loggedIn: true, nickname: '酷我音乐', userId: '', vipType: 0 }, info);
+      activeAccountProvider = 'kw';
+      if (pwEl) pwEl.value = '';
+      renderUserBtn();
+      refreshUserPlaylists(true);
+      showToast('酷我音乐已登录');
+      if (statusEl) { statusEl.textContent = '已登录酷我 · ' + (kwLoginStatus.nickname || ''); statusEl.className = 'preview'; }
+      setTimeout(closeLoginModal, 600);
+    } else {
+      if (statusEl) { statusEl.textContent = '登录失败：' + ((info && info.message) || '账号或密码错误'); statusEl.className = 'fail'; }
+    }
+  } catch (e) {
+    if (statusEl) { statusEl.textContent = '登录失败：' + (e.message || '网络错误'); statusEl.className = 'fail'; }
+  } finally {
+    kwLoginBusy = false;
+    if (btn) { btn.disabled = false; btn.textContent = '登录'; }
+  }
+}
+function startKwLoginStatusAutoRefresh() {
+  setInterval(function(){
+    if (!kwLoginStatus.loggedIn) return;   // 仅在已登录时静默核对
+    refreshKwLoginStatus().catch(function(e){ console.warn('Kuwo login auto refresh failed:', e); });
+  }, 120000);
+}
 function renderUserBtn() {
   var btn = document.getElementById('user-btn');
   if (!btn) return;
@@ -23417,9 +23639,12 @@ function renderUserBtn() {
   }
   updatePlaybackQualityUi();
 }
+function normalizeLoginProvider(p) {
+  return (p === 'qq' || p === 'kw') ? p : 'netease';
+}
 async function showLoginModal(opts) {
   opts = opts || {};
-  if (opts.provider) loginProvider = opts.provider === 'qq' ? 'qq' : 'netease';
+  if (opts.provider) loginProvider = normalizeLoginProvider(opts.provider);
   var modal = document.getElementById('login-modal');
   openGsapModal(modal);
   updateLoginProviderUi();
@@ -23430,38 +23655,46 @@ function closeLoginModal() {
   closeGsapModal(document.getElementById('login-modal'));
 }
 function setLoginProvider(provider, silent) {
-  loginProvider = provider === 'qq' ? 'qq' : 'netease';
+  loginProvider = normalizeLoginProvider(provider);
   updateLoginProviderUi();
   if (!silent && document.getElementById('login-modal').classList.contains('show')) refreshQr();
 }
 function updateLoginProviderUi() {
   var meta = platformMeta(loginProvider);
   var isQQ = loginProvider === 'qq';
+  var isKw = loginProvider === 'kw';
   var title = document.getElementById('login-modal-title');
   var desc = document.getElementById('login-modal-desc');
   var shell = document.getElementById('qr-shell');
   var st = document.getElementById('qr-status');
   var refreshBtn = document.getElementById('refresh-qr-btn');
   var qqPanel = document.getElementById('qq-cookie-panel');
+  var kwPanel = document.getElementById('kw-login-panel');
   var qqCookieToggle = document.getElementById('qq-cookie-toggle-btn');
   var qqCard = document.getElementById('qq-web-login-card');
   var neteaseBtn = document.getElementById('login-provider-netease');
   var qqBtn = document.getElementById('login-provider-qq');
+  var kwBtn = document.getElementById('login-provider-kw');
   var canOpenNeteaseWeb = !!(window.desktopWindow && typeof window.desktopWindow.openNeteaseMusicLogin === 'function');
   if (neteaseBtn) neteaseBtn.classList.toggle('active', loginProvider === 'netease');
   if (qqBtn) qqBtn.classList.toggle('active', isQQ);
-  if (title) title.textContent = '扫码登录' + meta.label;
-  if (desc) desc.innerHTML = isQQ
-    ? '打开 <b>QQ 音乐官方网页登录窗口</b> 扫码，成功后会自动同步账号会话。'
-    : (canOpenNeteaseWeb
-      ? '打开 <b>网易云音乐官方网页登录窗口</b> 扫码，避开接口二维码风控；成功后会自动同步账号会话。'
-      : '使用 <b>网易云音乐 App</b> 扫码，可同步歌单、红心与播客。');
+  if (kwBtn) kwBtn.classList.toggle('active', isKw);
+  if (title) title.textContent = isKw ? '登录酷我音乐' : ('扫码登录' + meta.label);
+  if (desc) desc.innerHTML = isKw
+    ? '输入 <b>酷我账号（手机号）和密码</b> 登录，可解锁会员无损/24bit；不登录也能游客试听。'
+    : (isQQ
+      ? '打开 <b>QQ 音乐官方网页登录窗口</b> 扫码，成功后会自动同步账号会话。'
+      : (canOpenNeteaseWeb
+        ? '打开 <b>网易云音乐官方网页登录窗口</b> 扫码，避开接口二维码风控；成功后会自动同步账号会话。'
+        : '使用 <b>网易云音乐 App</b> 扫码，可同步歌单、红心与播客。'));
   if (shell) {
-    shell.classList.toggle('web-login-preview', isQQ || canOpenNeteaseWeb);
+    shell.style.display = isKw ? 'none' : '';
+    shell.classList.toggle('web-login-preview', !isKw && (isQQ || canOpenNeteaseWeb));
     shell.classList.toggle('qq-preview', isQQ);
-    shell.classList.toggle('netease-preview', !isQQ && canOpenNeteaseWeb);
+    shell.classList.toggle('netease-preview', !isQQ && !isKw && canOpenNeteaseWeb);
   }
   if (qqPanel) qqPanel.classList.toggle('show', isQQ && qqManualCookieOpen);
+  if (kwPanel) kwPanel.classList.toggle('show', isKw);
   if (qqCookieToggle) {
     qqCookieToggle.classList.toggle('show', isQQ);
     qqCookieToggle.textContent = qqManualCookieOpen ? '收起导入' : '手动导入';
@@ -23476,12 +23709,15 @@ function updateLoginProviderUi() {
       : (neteaseWebLoginBusy ? '等待扫码确认' : '打开官方登录窗口');
   }
   if (st) {
-    st.className = isQQ ? 'preview' : '';
-    st.textContent = isQQ
-      ? (qqLoginStatus.loggedIn ? ('已保存 QQ 音乐会话 · ' + (qqLoginStatus.nickname || '')) : '点击“扫码登录”打开 QQ 音乐官方窗口')
-      : (canOpenNeteaseWeb ? '点击“网页登录”打开网易云官方窗口' : '正在生成二维码…');
+    st.className = (isQQ || isKw) ? 'preview' : '';
+    st.textContent = isKw
+      ? (kwLoginStatus.loggedIn ? ('已登录酷我 · ' + (kwLoginStatus.nickname || '')) : '输入酷我账号密码后点击登录')
+      : (isQQ
+        ? (qqLoginStatus.loggedIn ? ('已保存 QQ 音乐会话 · ' + (qqLoginStatus.nickname || '')) : '点击“扫码登录”打开 QQ 音乐官方窗口')
+        : (canOpenNeteaseWeb ? '点击“网页登录”打开网易云官方窗口' : '正在生成二维码…'));
   }
   if (refreshBtn) {
+    refreshBtn.style.display = isKw ? 'none' : '';
     refreshBtn.disabled = isQQ ? !!qqWebLoginBusy : !!neteaseWebLoginBusy;
     refreshBtn.textContent = isQQ ? (qqWebLoginBusy ? '等待扫码…' : '扫码登录') : (canOpenNeteaseWeb ? (neteaseWebLoginBusy ? '等待扫码…' : '网页登录') : '刷新二维码');
     refreshBtn.onclick = isQQ ? openQQWebLogin : (canOpenNeteaseWeb ? openNeteaseWebLogin : refreshQr);
@@ -23490,6 +23726,14 @@ function updateLoginProviderUi() {
 async function refreshQr() {
   stopQrPoll();
   updateLoginProviderUi();
+  if (loginProvider === 'kw') {
+    qrKey = null;
+    var kwImg = document.getElementById('qr-img');
+    if (kwImg) kwImg.src = '';
+    await refreshKwLoginStatus();
+    updateLoginProviderUi();
+    return;
+  }
   if (loginProvider === 'qq') {
     qrKey = null;
     var qqStatus = document.getElementById('qr-status');
@@ -23710,6 +23954,7 @@ function updateUserModalUi() {
   var logoutBtn = document.getElementById('account-logout-btn');
   var addNetease = document.getElementById('account-add-netease');
   var addQQ = document.getElementById('account-add-qq');
+  var addKw = document.getElementById('account-add-kw');
   if (chip) {
     chip.className = 'account-provider-chip ' + activeAccountProvider;
     chip.innerHTML = '<span class="account-source-dot ' + meta.dot + '"></span><span>' + meta.label + '</span>';
@@ -23722,19 +23967,33 @@ function updateUserModalUi() {
       var vipLabel = neVipLevel === 'svip' ? '网易云 SVIP' : (neVipLevel === 'vip' ? '网易云 VIP' : '普通用户');
       vipEl.textContent = 'UID: ' + ((st && st.userId) || '-') + '  ·  ' + vipLabel;
       vipEl.style.color = hasProviderVip('netease', st) ? 'rgba(244,210,138,0.86)' : 'rgba(255,255,255,0.5)';
+    } else if (activeAccountProvider === 'kw') {
+      var kwTier = kwVipTier(st);
+      var uidText = 'UID: ' + ((st && st.userId) || '-');
+      if (kwTier !== 'none') {
+        var kwLabel = (st && st.vipLabel) || kwVipShortLabel(kwTier);
+        var kwExp = formatKwVipExpire(st && st.vipExpire);
+        vipEl.textContent = uidText + '  ·  ' + kwLabel + (kwExp ? ('  ·  ' + kwExp + ' 到期') : '');
+        // 超级会员紫、其余金色高亮; 普通登录蓝色
+        vipEl.style.color = kwTier === 'super' ? 'rgba(201,139,255,0.92)' : 'rgba(244,210,138,0.88)';
+      } else {
+        vipEl.textContent = uidText + '  ·  普通用户';
+        vipEl.style.color = 'rgba(108,168,234,0.82)';
+      }
     } else {
       var qqVipLabel = hasProviderVip('qq', st) ? 'QQ VIP 会员' : 'QQ 音乐会话';
       vipEl.textContent = 'UID: ' + ((st && st.userId) || '-') + '  ·  ' + qqVipLabel;
       vipEl.style.color = hasProviderVip('qq', st) ? 'rgba(0,245,212,0.82)' : 'rgba(0,245,212,0.58)';
     }
   }
-  ['netease','qq','both'].forEach(function(key){
+  ['netease','qq','kw','both'].forEach(function(key){
     var btn = document.getElementById('user-provider-' + key);
     if (btn) btn.classList.toggle('active', key === 'both' ? dualAccountMode : (!dualAccountMode && activeAccountProvider === key));
   });
   if (addNetease) addNetease.style.display = hasPlatformLogin('netease') ? 'none' : '';
   if (addQQ) addQQ.textContent = hasPlatformLogin('qq') ? '查看 QQ 音乐' : '补登 QQ 音乐';
-  if (logoutBtn) logoutBtn.textContent = activeAccountProvider === 'qq' ? '退出 QQ 音乐' : '退出网易云';
+  if (addKw) addKw.textContent = hasPlatformLogin('kw') ? '查看酷我' : '补登酷我';
+  if (logoutBtn) logoutBtn.textContent = activeAccountProvider === 'qq' ? '退出 QQ 音乐' : (activeAccountProvider === 'kw' ? '退出酷我' : '退出网易云');
   if (hint) hint.textContent = dualAccountMode
     ? '右上角已切换为双平台并排展示。'
     : '可切换右上角展示的平台；“我两个都要”会并排放两个登录状态。';
@@ -23746,7 +24005,7 @@ function showUserModal() {
 }
 function closeUserModal() { closeGsapModal(document.getElementById('user-modal')); }
 function setActiveAccountProvider(provider) {
-  provider = provider === 'qq' ? 'qq' : 'netease';
+  provider = (provider === 'qq' || provider === 'kw') ? provider : 'netease';
   if (!hasPlatformLogin(provider)) {
     openProviderLogin(provider);
     return;
@@ -23778,12 +24037,25 @@ function requestDualLoginMode() {
   enableDualAccountView();
 }
 function openProviderLogin(provider) {
-  provider = provider === 'qq' ? 'qq' : 'netease';
+  provider = normalizeLoginProvider(provider);
   closeUserModal();
   loginProvider = provider;
   showLoginModal({ provider: provider });
 }
 async function logoutActiveAccount() {
+  if (activeAccountProvider === 'kw') {
+    try { await apiJson('/api/kw/logout'); } catch (e) {}
+    kwLoginStatus = { provider: 'kw', loggedIn: false, nickname: '酷我音乐', userId: '', avatar: '', vipType: 0, vipTier: 'none', vipLabel: '', vipExpire: 0, isVip: false, hasAccount: false };
+    kwPlaylists = [];
+    userPlaylists = userPlaylists.filter(function(pl){ return pl.provider !== 'kw'; });
+    dualAccountMode = false;
+    activeAccountProvider = firstLoggedProvider();
+    renderUserBtn();
+    if (hasAnyPlatformLogin()) updateUserModalUi();
+    else closeUserModal();
+    showToast('已退出酷我音乐');
+    return;
+  }
   if (activeAccountProvider === 'qq') {
     try { await apiJson('/api/qq/logout'); } catch (e) {}
     try {
@@ -26523,8 +26795,9 @@ if (fx.floatLayer) createFloatLayer();
 if (fx.particleLyrics) createLyricsParticles();
 if (fx.backCover) createBackCoverLayer();
 initIdleGuideCanvas();
-var startupLoginStatusPromise = Promise.all([refreshLoginStatus(), refreshQQLoginStatus()]);
+var startupLoginStatusPromise = Promise.all([refreshLoginStatus(), refreshQQLoginStatus(), refreshKwLoginStatus()]);
 startQQLoginStatusAutoRefresh();
+startKwLoginStatusAutoRefresh();
 if (startupLoginStatusPromise && startupLoginStatusPromise.then) {
   startupLoginStatusPromise.then(function(){
     if (hasAnyPlatformLogin()) {

--- a/server.js
+++ b/server.js
@@ -3498,7 +3498,7 @@ async function kwPostLogin(pathSeg, plain) {
     headers: { 'User-Agent': 'okhttp/3.10.0' },
   });
   const raw = String(text || '').trim();
-  const dec = kwDecrypt(kwB64decode(raw), KW_LOGIN_SX).toString('utf8').replace(/ +$/, '').replace(/ +$/, '');
+  const dec = kwDecrypt(kwB64decode(raw), KW_LOGIN_SX).toString('utf8').replace(/ +$/, '').replace(/\x00+$/, '');
   try { return JSON.parse(dec); }
   catch (e) {
     const m = {};

--- a/server.js
+++ b/server.js
@@ -50,6 +50,8 @@ const fs   = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const tls = require('tls');
+const zlib = require('zlib');
+const kwQmc = require('./kuwo_qmc.js');   // 至臻 mflac (QMCv2) 解密
 const { once } = require('events');
 const { fileURLToPath } = require('url');
 const { analyzePodcastDjStream, analyzePodcastDjIntro } = require('./dj-analyzer');
@@ -68,7 +70,7 @@ const APP_VERSION = process.env.MINERADIO_VERSION || APP_PACKAGE.version || '0.9
 const UPDATE_CONFIG = readUpdateConfig(APP_PACKAGE);
 const PATCH_MAX_BYTES = 12 * 1024 * 1024;
 const PATCH_ALLOWED_ROOTS = new Set(['public', 'desktop', 'build']);
-const PATCH_ALLOWED_FILES = new Set(['server.js', 'dj-analyzer.js', 'package.json', 'package-lock.json']);
+const PATCH_ALLOWED_FILES = new Set(['server.js', 'kuwo_qmc.js', 'dj-analyzer.js', 'package.json', 'package-lock.json']);
 const UPDATE_FALLBACK_NOTES = [
   '电影镜头节奏更松',
   '音源失败自动换源',
@@ -1548,7 +1550,7 @@ const QQ_QUALITY_CANDIDATE_TEMPLATES = [
 ];
 function normalizeQualityPreference(value) {
   const raw = String(value || '').toLowerCase().trim();
-  if (['jymaster', 'master', 'studio', 'svip'].includes(raw)) return 'jymaster';
+  if (['jymaster', 'master', 'studio', 'svip', 'zhizhen', 'zply'].includes(raw)) return 'jymaster';
   if (['hires', 'hi-res', 'highres', 'zhenyin', 'spatial'].includes(raw)) return 'hires';
   if (['lossless', 'flac', 'sq'].includes(raw)) return 'lossless';
   if (['exhigh', 'high', '320', '320k', 'hq'].includes(raw)) return 'exhigh';
@@ -2344,6 +2346,7 @@ function audioProxyHeadersFor(audioUrl, range) {
   try {
     const host = new URL(audioUrl).hostname.toLowerCase();
     if (host.includes('qq.com') || host.includes('qpic.cn')) headers.Referer = 'https://y.qq.com/';
+    else if (host.includes('kuwo.cn') || host.includes('kwcdn.com')) { headers.Referer = 'http://www.kuwo.cn/'; headers['User-Agent'] = KW_UA_APK; }
   } catch (e) {}
   if (range) headers.Range = range;
   return headers;
@@ -3238,6 +3241,1067 @@ async function getLoginInfo() {
 }
 
 // ====================================================================
+//  酷我音乐音源 (Kuwo): 搜索 / 取链 / 歌词 / 封面 / 登录 / 会员 / 歌单
+// ====================================================================
+// —— 酷我自实现 DES(ECB) 置换表 ——
+const KW_IP = [57,49,41,33,25,17,9,1,59,51,43,35,27,19,11,3,61,53,45,37,29,21,13,5,
+  63,55,47,39,31,23,15,7,56,48,40,32,24,16,8,0,58,50,42,34,26,18,10,2,
+  60,52,44,36,28,20,12,4,62,54,46,38,30,22,14,6];
+const KW_E = [31,0,1,2,3,4,-1,-1,3,4,5,6,7,8,-1,-1,7,8,9,10,11,12,-1,-1,11,12,13,14,15,16,-1,-1,
+  15,16,17,18,19,20,-1,-1,19,20,21,22,23,24,-1,-1,23,24,25,26,27,28,-1,-1,27,28,29,30,31,30,-1,-1];
+const KW_P = [15,6,19,20,28,11,27,16,0,14,22,25,4,17,30,9,1,7,23,13,31,26,2,8,18,12,29,5,21,10,3,24];
+const KW_FP = [39,7,47,15,55,23,63,31,38,6,46,14,54,22,62,30,37,5,45,13,53,21,61,29,36,4,44,12,52,20,60,28,
+  35,3,43,11,51,19,59,27,34,2,42,10,50,18,58,26,33,1,41,9,49,17,57,25,32,0,40,8,48,16,56,24];
+const KW_PC1 = [56,48,40,32,24,16,8,0,57,49,41,33,25,17,9,1,58,50,42,34,26,18,10,2,59,51,43,35,
+  62,54,46,38,30,22,14,6,61,53,45,37,29,21,13,5,60,52,44,36,28,20,12,4,27,19,11,3];
+const KW_PC2 = [13,16,10,23,0,4,-1,-1,2,27,14,5,20,9,-1,-1,22,18,11,3,25,7,-1,-1,15,6,26,19,12,1,-1,-1,
+  40,51,30,36,46,54,-1,-1,29,39,50,44,32,47,-1,-1,43,48,38,55,33,52,-1,-1,45,41,49,35,28,31,-1,-1];
+const KW_SHIFT = [1,1,2,2,2,2,2,2,1,2,2,2,2,2,2,1];
+const KW_MROT = [0n, 1048577n, 3145731n];
+const KW_MASK64 = (1n << 64n) - 1n;
+const KW_MASK32 = 0xffffffffn;
+const KW_BIT = [];
+for (let n = 0; n < 64; n++) KW_BIT.push(1n << BigInt(n));
+const KW_G = [
+  [14,4,3,15,2,13,5,3,13,14,6,9,11,2,0,5,4,1,10,12,15,6,9,10,1,8,12,7,8,11,7,0,
+   0,15,10,5,14,4,9,10,7,8,12,3,13,1,3,6,15,12,6,11,2,9,5,0,4,2,11,14,1,7,8,13],
+  [15,0,9,5,6,10,12,9,8,7,2,12,3,13,5,2,1,14,7,8,11,4,0,3,14,11,13,6,4,1,10,15,
+   3,13,12,11,15,3,6,0,4,10,1,7,8,4,11,14,13,8,0,6,2,15,9,5,7,1,10,12,14,2,5,9],
+  [10,13,1,11,6,8,11,5,9,4,12,2,15,3,2,14,0,6,13,1,3,15,4,10,14,9,7,12,5,0,8,7,
+   13,1,2,4,3,6,12,11,0,13,5,14,6,8,15,2,7,10,8,15,4,9,11,5,9,0,14,3,10,7,1,12],
+  [7,10,1,15,0,12,11,5,14,9,8,3,9,7,4,8,13,6,2,1,6,11,12,2,3,0,5,14,10,13,15,4,
+   13,3,4,9,6,10,1,12,11,0,2,5,0,13,14,2,8,15,7,4,15,1,10,7,5,6,12,11,3,8,9,14],
+  [2,4,8,15,7,10,13,6,4,1,3,12,11,7,14,0,12,2,5,9,10,13,0,3,1,11,15,5,6,8,9,14,
+   14,11,5,6,4,1,3,10,2,12,15,0,13,2,8,5,11,8,0,15,7,14,9,4,12,7,10,9,1,13,6,3],
+  [12,9,0,7,9,2,14,1,10,15,3,4,6,12,5,11,1,14,13,0,2,8,7,13,15,5,4,10,8,3,11,6,
+   10,4,6,11,7,9,0,6,4,2,13,1,9,15,3,8,15,3,1,14,12,5,11,0,2,12,14,7,5,10,8,13],
+  [4,1,3,10,15,12,5,0,2,11,9,6,8,7,6,9,11,4,12,15,0,3,10,5,14,13,7,8,13,14,1,2,
+   13,6,14,9,4,1,2,14,11,13,5,0,1,10,8,3,0,11,3,5,9,4,15,2,7,8,12,15,10,7,6,12],
+  [13,7,10,0,6,9,5,15,8,4,3,10,11,14,12,5,2,11,9,6,15,12,0,3,4,1,14,13,1,2,7,8,
+   1,2,12,15,10,4,0,3,13,14,6,9,7,8,9,6,15,1,5,12,3,10,14,5,8,7,11,0,4,13,2,11]
+];
+function kwPermute(table, n, val) {
+  let out = 0n;
+  for (let idx = 0; idx < n; idx++) {
+    const t = table[idx];
+    if (t >= 0 && (KW_BIT[t] & val) !== 0n) out |= KW_BIT[idx];
+  }
+  return out;
+}
+function kwKeySchedule(keyBytes, decryptMode) {
+  let j2 = 0n;
+  for (let i = 0; i < 8; i++) j2 |= BigInt(keyBytes[i] & 0xff) << BigInt(i * 8);
+  const sub = new Array(16);
+  let jA = kwPermute(KW_PC1, 56, j2);
+  for (let r = 0; r < 16; r++) {
+    const m = KW_MROT[KW_SHIFT[r]];
+    const s = BigInt(KW_SHIFT[r]);
+    jA = (((jA & (~m & KW_MASK64)) >> s) | ((m & jA) << (28n - s))) & KW_MASK64;
+    sub[r] = kwPermute(KW_PC2, 64, jA);
+  }
+  if (decryptMode) for (let i = 0; i < 8; i++) { const t = sub[i]; sub[i] = sub[15 - i]; sub[15 - i] = t; }
+  return sub;
+}
+function kwDesBlock(sub, blk) {
+  let p = kwPermute(KW_IP, 64, blk);
+  let s0 = p & KW_MASK32;
+  let s1 = (p >> 32n) & KW_MASK32;
+  for (let r = 0; r < 16; r++) {
+    let rr = kwPermute(KW_E, 64, s1);
+    rr ^= sub[r];
+    let u = 0n;
+    for (let i = 7; i >= 0; i--) {
+      const t = Number((rr >> BigInt(i * 8)) & 0xffn);
+      u <<= 4n;
+      u |= BigInt(KW_G[i][t]);
+    }
+    rr = kwPermute(KW_P, 32, u);
+    const q = s0;
+    s0 = s1;
+    s1 = (q ^ rr) & KW_MASK32;
+  }
+  let out = ((s0 << 32n) & KW_MASK64) | (s1 & KW_MASK32);
+  return kwPermute(KW_FP, 64, out);
+}
+// 加密: ECB, 每块小端装配, 末尾恒追加由 len%8 字节构成的尾块
+function kwEncrypt(bytes, keyStr) {
+  const sub = kwKeySchedule(Buffer.from(keyStr || 'ylzsxkwm', 'ascii'));
+  const n = bytes.length;
+  const full = (n / 8) | 0;
+  const blocks = [];
+  for (let i = 0; i < full; i++) {
+    let v = 0n;
+    for (let j = 0; j < 8; j++) v |= BigInt(bytes[i * 8 + j] & 0xff) << BigInt(j * 8);
+    blocks.push(kwDesBlock(sub, v));
+  }
+  let v = 0n;
+  const rem = n % 8;
+  for (let j = 0; j < rem; j++) v |= BigInt(bytes[full * 8 + j] & 0xff) << BigInt(j * 8);
+  blocks.push(kwDesBlock(sub, v));
+  const out = Buffer.alloc(blocks.length * 8);
+  for (let i = 0; i < blocks.length; i++)
+    for (let j = 0; j < 8; j++) out[i * 8 + j] = Number((blocks[i] >> BigInt(j * 8)) & 0xffn);
+  return out;
+}
+const KW_B64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+function kwB64encode(buf) {
+  let out = '';
+  for (let i = 0; i < buf.length; i += 3) {
+    const n = buf.length - i;
+    const b0 = buf[i], b1 = n > 1 ? buf[i + 1] : 0, b2 = n > 2 ? buf[i + 2] : 0;
+    out += KW_B64[b0 >> 2] + KW_B64[((b0 & 3) << 4) | (b1 >> 4)];
+    out += n > 1 ? KW_B64[((b1 & 15) << 2) | (b2 >> 6)] : '=';
+    out += n > 2 ? KW_B64[b2 & 63] : '=';
+  }
+  return out;
+}
+const KW_B64REV = (() => { const m = {}; for (let i = 0; i < 64; i++) m[KW_B64[i]] = i; return m; })();
+function kwB64decode(str) {
+  const s = String(str).replace(/=+$/, '');
+  const out = [];
+  for (let i = 0; i < s.length; i += 4) {
+    const c0 = KW_B64REV[s[i]], c1 = KW_B64REV[s[i + 1]] || 0;
+    const c2 = i + 2 < s.length ? KW_B64REV[s[i + 2]] : 0;
+    const c3 = i + 3 < s.length ? KW_B64REV[s[i + 3]] : 0;
+    out.push((c0 << 2) | (c1 >> 4));
+    if (i + 2 < s.length) out.push(((c1 & 15) << 4) | (c2 >> 2));
+    if (i + 3 < s.length) out.push(((c2 & 3) << 6) | c3);
+  }
+  return Buffer.from(out);
+}
+// 解密: ECB, 反转子密钥, 仅处理整块
+function kwDecrypt(bytes, keyStr) {
+  const sub = kwKeySchedule(Buffer.from(keyStr, 'ascii'), true);
+  const full = (bytes.length / 8) | 0;
+  const out = Buffer.alloc(full * 8);
+  for (let i = 0; i < full; i++) {
+    let v = 0n;
+    for (let j = 0; j < 8; j++) v |= BigInt(bytes[i * 8 + j] & 0xff) << BigInt(j * 8);
+    const b = kwDesBlock(sub, v);
+    for (let j = 0; j < 8; j++) out[i * 8 + j] = Number((b >> BigInt(j * 8)) & 0xffn);
+  }
+  return out;
+}
+// 明文参数串 -> q 参数 (DES + Base64)
+function kwMakeQ(plain, keyStr) {
+  return kwB64encode(kwEncrypt(Buffer.from(plain, 'utf8'), keyStr || 'ylzsxkwm'));
+}
+
+// —— 酷我账号/设备配置 ——
+const KW_ACCOUNT_FILE = process.env.KW_ACCOUNT_FILE || path.join(__dirname, '.kw-account');
+// —— 版本身份参数 ——
+const KW_VER = '11.1.8.2';
+const KW_PROD = 'kwplayer_ar_' + KW_VER;
+const KW_SRC = KW_PROD + '_newpcguanwangmobile.apk';
+const KW_Q36 = 'f2ce3c2ef68ddfd1b2bea7ed00001f314716';
+const KW_OAID = crypto.randomBytes(16).toString('hex').toUpperCase() + crypto.randomBytes(16).toString('hex');
+const KW_UA_APK = 'Dalvik/2.1.0 (Linux; U; Android 15; Build/MTXC)';
+const KW_UA_WEB = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
+const KW_UA_H5 = 'Mozilla/5.0 (Linux; Android 15) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/120.0.0.0 Mobile Safari/537.36';
+// —— 会员档位 (VIP tier) RSA 解密 ——
+const KW_VIP_RSA_KEY_B64 = 'MIICeAIBADANBgkqhkiG9w0BAQEFAASCAmIwggJeAgEAAoGBAL5BzI6Peij84o1d+i+GERDNhyKrwm5/OU4ZSd7TMJ0pDbC0TTPz6GBljoFHTK093ePH3dt8k2dEPa4oT2dZ0Xc2sU2R+v65hzrGg4JbJFmRgZfT3zqxozk13U9nN7qsTR4HMXb8JOF23rXd7O/2RLKRxmzhND3GpF/SnMsvzj+NAgMBAAECgYEAtc8lDfp3z2FRkawDn5RrDHaLM4uVIoh7F3G9EK0aIKURixHRUNs87Zk+47VhxY+AUeI11T+nkKA6nQmyT14adjt8uMrAZuiPArs+8I8qepDEjcbOgG21IshAhu+Jqg40UWK+H0eRz5bpFFohO47+VTQhchUaGRomIH79On25EzUCQQD6CGi0WXaHczu9wHLVC3zppDjwzzC0DnfxH2m0IfY0HViTNOwaZa4CLS5UKiPo2TeW1ApXqRSumhnC+zJn2FpnAkEAwswvnpsrOrc6mmdbrVfI74ilmkOG0uMLZ8rhBuzeHsue0e2EHBo4lTudYLjgpTJEqkkpZKbDjfkm2unTCw7F6wJBAIXFL/elkaPARCsuJoHTJp5+DTTRNPZwcz1fGBeWv/l75eLEQrmQwvtJHutKrHGsnXAlu+7QeE8+BSBrcrlaaGsCQQCVCqMYqEJwH0cgYhp7y2G7HAMQv7/FVOAiHtEDenIMf+DZX/AnjExkqgMkwO9olciBvY6FKy8OTmZTMno9yKTXAkBZ26Uuh5Q6PwtmeOOTjvMth5btD2N/n/v8gXkqslEwL4NN/CEc0khKtv6BiVM26G1wKQipA6bvdkbhAyjSVzkj';
+let kwVipPrivKey = null;
+function kwGetVipPrivKey() {
+  if (kwVipPrivKey === null) {
+    try { kwVipPrivKey = crypto.createPrivateKey({ key: Buffer.from(KW_VIP_RSA_KEY_B64, 'base64'), format: 'der', type: 'pkcs8' }); }
+    catch (e) { kwVipPrivKey = false; console.warn('[Kuwo] VIP 私钥加载失败:', e.message); }
+  }
+  return kwVipPrivKey || null;
+}
+const KW_VIP_PART_DELIM = Buffer.from('#PART#');
+// 按 #PART# 切块, 每块 RSA 私钥解密(PKCS1) 后拼接成 JSON
+function kwVipRsaDecrypt(b64) {
+  const key = kwGetVipPrivKey();
+  if (!key) return null;
+  const cipher = Buffer.from(String(b64 || '').trim(), 'base64');
+  if (!cipher.length) return null;
+  const parts = [];
+  let start = 0, idx;
+  while ((idx = cipher.indexOf(KW_VIP_PART_DELIM, start)) >= 0) { parts.push(cipher.slice(start, idx)); start = idx + KW_VIP_PART_DELIM.length; }
+  parts.push(cipher.slice(start));
+  const out = [];
+  for (const p of parts) { if (p.length) out.push(crypto.privateDecrypt({ key, padding: crypto.constants.RSA_PKCS1_PADDING }, p)); }
+  return Buffer.concat(out).toString('utf8');
+}
+const kwAccount = (() => {
+  const acc = {
+    deviceId: crypto.randomBytes(8).toString('hex'),                 // 随机 16 位 hex 设备号
+    appuid: String(2000000000 + Math.floor(Math.random() * 900000000)), // 非零数字 appuid (游客取链必需)
+    loginUid: '0',
+    loginSid: '0',
+    username: '',   // 仅本会话内存: 显式登录后用于本次会话自愈续期
+    password: '',
+    nickname: '',
+    avatar: '',
+    vipType: 0,
+    vipTier: 'none',   // none | vip | musicpack | luxury | super
+    vipLabel: '',      // 中文档位标签 (豪华会员 / 超级会员 / ...)
+    vipExpire: 0,      // 当前档位到期时间 (ms)
+    vipTag: '',
+    userVipType: '',
+    vipFetchedAt: 0,
+  };
+  try {
+    if (fs.existsSync(KW_ACCOUNT_FILE)) {
+      const cfg = JSON.parse(fs.readFileSync(KW_ACCOUNT_FILE, 'utf8'));
+
+      ['deviceId', 'appuid', 'loginUid', 'loginSid', 'nickname', 'avatar'].forEach(k => {
+        if (cfg && cfg[k] != null && cfg[k] !== '') acc[k] = String(cfg[k]);
+      });
+    }
+  } catch (e) { console.warn('[Kuwo] 读取 .kw-account 失败:', e.message); }
+  return acc;
+})();
+function saveKwAccount() {
+  try {
+
+    fs.writeFileSync(KW_ACCOUNT_FILE, JSON.stringify({
+      deviceId: kwAccount.deviceId,
+      appuid: kwAccount.appuid,
+      loginUid: kwAccount.loginUid,
+      loginSid: kwAccount.loginSid,
+      nickname: kwAccount.nickname,
+      avatar: kwAccount.avatar,
+    }, null, 2), { mode: 0o600 });
+  } catch (e) { console.warn('[Kuwo] 写入 .kw-account 失败:', e.message); }
+}
+function kwHasAccount() { return kwAccount.loginUid && kwAccount.loginUid !== '0' && kwAccount.loginSid && kwAccount.loginSid !== '0'; }
+function kwCommonParams() {
+  const dev = kwAccount.deviceId;
+  // 取链/接口公共参数
+  return (
+    `user=${dev}&android_id=${dev}&prod=${KW_PROD}&corp=kuwo&newver=3` +
+    `&vipver=${KW_VER}&source=${KW_SRC}&p2p=1&q36=${KW_Q36}&approval=false` +
+    `&loginUid=${kwAccount.loginUid}&loginSid=${kwAccount.loginSid}` +
+    `&appuid=${kwAccount.appuid}&allpay=0&notrace=0&oaid=${KW_OAID}`
+  );
+}
+function kwParseKv(text) {
+  const o = {};
+  String(text).split('\n').forEach(line => {
+    const i = line.indexOf('=');
+    if (i > 0) o[line.slice(0, i).trim()] = line.slice(i + 1).trim();
+  });
+  return o;
+}
+
+// —— 账号密码登录 ——
+const KW_LOGIN_KEY = 'kwks&@69';
+const KW_LOGIN_SX = 'mr8kw3sx';          // 仅用于解密登录回包
+const KW_LOGIN_BASE = 'http://ar.i.kuwo.cn/US_NEW/kuwo/';
+const KW_LOGIN_COOLDOWN = 60 * 1000;     // 最短重登间隔, 避免登录风控
+let kwLastLogin = 0;
+let kwLoginInflight = null;
+async function kwPostLogin(pathSeg, plain) {
+  const q = kwMakeQ(plain, KW_LOGIN_KEY);
+  const text = await requestText(KW_LOGIN_BASE + pathSeg + '?f=ar&q=' + encodeURIComponent(q), {
+    headers: { 'User-Agent': 'okhttp/3.10.0' },
+  });
+  const raw = String(text || '').trim();
+  const dec = kwDecrypt(kwB64decode(raw), KW_LOGIN_SX).toString('utf8').replace(/ +$/, '').replace(/ +$/, '');
+  try { return JSON.parse(dec); }
+  catch (e) {
+    const m = {};
+    dec.replace(/"?(\w+)"?\s*[:=]\s*"?([^",&}]+)"?/g, (_, k, v) => (m[k] = v));
+    return m;
+  }
+}
+// 账号密码登录 -> { ok, uid, sid }; 成功后写回 kwAccount 并持久化。
+// explicit(显式凭据) 不复用自愈 inflight, 避免换号时新凭据被旧 Promise 覆盖。
+async function kwDoLogin(username, password) {
+  const explicit = !!(username || password);
+  const user = String(username || kwAccount.username || '').trim();
+  const pass = String(password || kwAccount.password || '');
+  if (!user || !pass) return { ok: false, error: 'MISSING_CREDENTIALS' };
+  if (!explicit && kwLoginInflight) return kwLoginInflight;     // 仅自愈登录做并发合并
+  const run = (async () => {
+    const pw = kwB64encode(Buffer.from(pass, 'utf8'));
+    const plain =
+      'username=' + encodeURIComponent(user) +
+      '&password=' + encodeURIComponent(pw) +
+      '&dev_id=' + (kwAccount.appuid || '0') + '&user=' + kwAccount.deviceId +
+      '&dev_name=' + KW_PROD + '&urlencode=0&src=' + KW_SRC +
+      '&devResolution=1080*2400&from=android&devType=PJZ110&sx=' + KW_LOGIN_SX + '&version=' + KW_VER;
+    let r;
+    try { r = await kwPostLogin('login_kw', plain); }
+    catch (e) { return { ok: false, error: 'LOGIN_REQUEST_FAILED', message: e.message }; }
+    kwLastLogin = Date.now();
+    const ok = r && (r.result === 'succ' || r.ret === 'succ');
+    if (ok && (r.sid || r.userid || r.uid)) {
+      const ui = (r && r.userInfo) || {};
+      kwAccount.username = user;
+      kwAccount.password = pass;
+      kwAccount.loginUid = String(r.uid || r.userid || ui.uid || kwAccount.loginUid);
+      kwAccount.loginSid = String(r.sid || kwAccount.loginSid);
+      kwAccount.nickname = String(ui.nickName || r.nick || ui.name || r.name || '').trim();
+      kwAccount.avatar = String(r.head || ui.pic120 || ui.pic || ui.pic300 || '').trim();
+      kwAccount.vipType = Number(r.vip_type || r.vip_lev || ui.vipType || 0) || 0;
+      KW_URL_CACHE.clear();
+      saveKwAccount();
+      await kwRefreshVipInfo(true);   // 登录后拉取会员档位 (豪华/超级), 失败不影响登录
+      return { ok: true, uid: kwAccount.loginUid, sid: kwAccount.loginSid, nickname: kwAccount.nickname, avatar: kwAccount.avatar, vipTier: kwAccount.vipTier, vipLabel: kwAccount.vipLabel };
+    }
+    return { ok: false, error: 'LOGIN_FAILED', message: (r && (r.msg || r.tips || r.result || r.ret)) || '账号或密码错误', raw: r };
+  })();
+  if (!explicit) { kwLoginInflight = run; run.finally(() => { if (kwLoginInflight === run) kwLoginInflight = null; }); }
+  return run;
+}
+// 自愈: 取链命中试听替换且配了账号密码时, 冷却外自动重登换新 sid
+async function kwTryRelogin() {
+  if (!kwAccount.username || !kwAccount.password) return false;
+  if (Date.now() - kwLastLogin < KW_LOGIN_COOLDOWN) return false;
+  const r = await kwDoLogin();
+  return !!(r && r.ok);
+}
+function kwLoginStatus() {
+  const on = kwHasAccount();
+  const tier = on ? (kwAccount.vipTier || 'none') : 'none';
+  return {
+    provider: 'kw',
+    loggedIn: on,
+    userId: on ? kwAccount.loginUid : '',
+    nickname: on ? (kwAccount.nickname || ('酷我用户 ' + kwAccount.loginUid)) : '酷我音乐',
+    avatar: on ? (kwAccount.avatar || '') : '',
+    vipType: on ? (Number(kwAccount.vipType) || 0) : 0,
+    vipTier: tier,                                  // none | vip | musicpack | luxury | super
+    vipLabel: on ? (kwAccount.vipLabel || '') : '', // 豪华会员 / 超级会员 / 音乐包 / VIP会员
+    vipExpire: on ? (Number(kwAccount.vipExpire) || 0) : 0,
+    isVip: tier !== 'none',
+    isSvip: tier === 'super',                        // 超级会员
+    isLuxury: tier === 'luxury',                     // 豪华会员
+    vipTag: on ? (kwAccount.vipTag || '') : '',
+    hasAccount: !!(kwAccount.username && kwAccount.password),
+    username: kwAccount.username || '',
+  };
+}
+// 从解密后的 VIP data 判定档位 (超级 > 豪华 > 音乐包 > 普通VIP; 到期 > now 即生效)
+function kwTierFromVipData(data) {
+  const now = Date.now();
+  const exp = k => Number(data && data[k]) || 0;
+  if (exp('svipExpire') > now)       return { vipTier: 'super',     vipLabel: '超级会员', vipExpire: exp('svipExpire') };
+  if (exp('vipLuxuryExpire') > now)  return { vipTier: 'luxury',    vipLabel: '豪华会员', vipExpire: exp('vipLuxuryExpire') };
+  if (exp('vipmExpire') > now)       return { vipTier: 'musicpack', vipLabel: '音乐包',   vipExpire: exp('vipmExpire') };
+  if (exp('vipExpire') > now)        return { vipTier: 'vip',       vipLabel: 'VIP会员',  vipExpire: exp('vipExpire') };
+  return { vipTier: 'none', vipLabel: '', vipExpire: 0 };
+}
+// 拉取并解密会员信息 (vip/enc/user/vip?op=ui), 写回 kwAccount.vip*; 失败保持原值。带 5 分钟缓存。
+const KW_VIP_TTL = 5 * 60 * 1000;
+async function kwRefreshVipInfo(force) {
+  if (!kwHasAccount()) {
+    kwAccount.vipTier = 'none'; kwAccount.vipLabel = ''; kwAccount.vipExpire = 0;
+    kwAccount.vipTag = ''; kwAccount.userVipType = ''; kwAccount.vipFetchedAt = 0;
+    return;
+  }
+  if (!force && kwAccount.vipFetchedAt && (Date.now() - kwAccount.vipFetchedAt) < KW_VIP_TTL) return;
+  const url = 'http://vip1.kuwo.cn/vip/enc/user/vip?op=ui&uid=' + encodeURIComponent(kwAccount.loginUid) +
+    '&sid=' + encodeURIComponent(kwAccount.loginSid) + '&extend=1&showChezai=1&showLinqi=1&apiVersion=3' +
+    '&devid=' + encodeURIComponent(kwAccount.appuid) + '&user=' + encodeURIComponent(kwAccount.deviceId) +
+    '&source=' + encodeURIComponent(KW_SRC) + '&platform=ar';
+  try {
+    const body = await requestText(url, { headers: { 'User-Agent': KW_UA_APK, Accept: '*/*' } });
+    const dec = kwVipRsaDecrypt(body);
+    if (!dec) return;
+    const j = JSON.parse(dec);
+    const data = (j && j.data) || null;
+    if (!data) return;
+    const t = kwTierFromVipData(data);
+    kwAccount.vipTier = t.vipTier;
+    kwAccount.vipLabel = t.vipLabel;
+    kwAccount.vipExpire = t.vipExpire;
+    kwAccount.vipTag = String(data.vipTag || '');
+    kwAccount.userVipType = String(data.userVipType || '');
+    kwAccount.vipType = t.vipTier === 'super' ? 4 : (t.vipTier === 'luxury' ? 3 : (t.vipTier === 'musicpack' ? 2 : (t.vipTier === 'vip' ? 1 : 0)));
+    kwAccount.vipFetchedAt = Date.now();
+  } catch (e) { console.warn('[Kuwo] 拉取会员信息失败:', e.message); }
+}
+
+// —— 取链音质候选: 逐个尝试取第一个未降级结果 ——
+const KW_QUALITY_CANDIDATES = [
+  { level: 'hires',    br: '4000kflac', format: 'flac', label: 'Hi-Res', bitrate: 4000000 },
+  { level: 'lossless', br: '2000kflac', format: 'flac', label: '无损',   bitrate: 2000000 },
+  { level: 'exhigh',   br: '320kmp3',   format: 'mp3',  label: '320k',   bitrate: 320000 },
+  { level: 'standard', br: '128kmp3',   format: 'mp3',  label: '128k',   bitrate: 128000 },
+];
+function kwResolveLevel(kv) {
+  const b = Number(kv.bitrate) || 0;
+  const f = String(kv.format || '').toLowerCase();
+  if (f === 'flac') return b >= 2800 ? 'hires' : 'lossless';
+  if (b >= 320) return 'exhigh';
+  return 'standard';
+}
+
+// —— 搜索: search.kuwo.cn/r.s (返回单引号伪 JSON, 用括号配对切块 + regex 取字段) ——
+function kwDecodeText(value) {
+  let s = String(value || '');
+  s = s.replace(/\\u([0-9a-fA-F]{4})/g, (_, h) => String.fromCharCode(parseInt(h, 16)));
+  return decodeHtmlEntities(s).replace(/\s+/g, ' ').trim();
+}
+// 从 r.s 的单引号伪 JSON 里按 'listKey':[ {..},{..} ] 用括号配对切出每个对象块 (支持嵌套对象)。
+function kwSplitListItems(body, listKey) {
+  const at = body.indexOf("'" + listKey + "':[");
+  if (at < 0) return [];
+  const items = [];
+  let i = body.indexOf('{', at);
+  while (i >= 0 && i < body.length) {
+    let depth = 0, end = -1;
+    for (let k = i; k < body.length; k++) {
+      if (body[k] === '{') depth++;
+      else if (body[k] === '}') { depth--; if (depth === 0) { end = k; break; } }
+    }
+    if (end < 0) break;
+    items.push(body.slice(i, end + 1));
+    // 下一个 item 在 '},{' 之后; 遇到 ']' 收尾则停止
+    const nextBrace = body.indexOf('{', end + 1);
+    const listEnd = body.indexOf(']', end + 1);
+    if (nextBrace < 0 || (listEnd >= 0 && listEnd < nextBrace)) break;
+    i = nextBrace;
+  }
+  return items;
+}
+function kwSplitAbslistItems(body) { return kwSplitListItems(body, 'abslist'); }
+function kwField(raw, key) {
+  const m = new RegExp("'" + key + "':'([^']*)'").exec(raw);
+  return m ? m[1] : '';
+}
+function kwSongCover(webAlbumpicShort) {
+  const short = String(webAlbumpicShort || '').trim();
+  if (!short) return '';
+  return 'https://img1.kuwo.cn/star/albumcover/' + short.replace(/^\d+\//, '500/');
+}
+// 专辑封面路径里的尺寸段升到 500 (非专辑图原样保留)。
+function kwUpsizeCover(url) {
+  const u = String(url || '').trim();
+  if (!u) return '';
+  return u.replace(/(\/star\/albumcover\/)\d+\//, '$1500/');
+}
+// 歌手头像: 尺寸段升到 500。
+function kwArtistHead(webArtistpicShort) {
+  const short = String(webArtistpicShort || '').trim();
+  if (!short) return '';
+  return 'https://img1.kuwo.cn/star/starheads/' + short.replace(/^\d+\//, '500/');
+}
+function kwMapSearchSong(raw) {
+  const rid = (kwField(raw, 'DC_TARGETID') || kwField(raw, 'MUSICRID').replace(/^MUSIC_/, '')).trim();
+  if (!rid || !/^\d+$/.test(rid)) return null;
+  const name = kwDecodeText(kwField(raw, 'NAME') || kwField(raw, 'SONGNAME'));
+  if (!name) return null;
+  const artist = kwDecodeText(kwField(raw, 'ARTIST'));
+  const album = kwDecodeText(kwField(raw, 'ALBUM'));
+  const durationSec = Number(kwField(raw, 'DURATION')) || 0;
+  const formats = kwField(raw, 'FORMATS') || '';
+  const hasFlac = /FLAC|ALFLAC/i.test(formats);
+  const artists = artist
+    ? artist.split(/\s*&\s*|\s*、\s*|\s*\/\s*|\s*,\s*/).map(n => ({ name: n.trim() })).filter(a => a.name)
+    : [];
+  return {
+    provider: 'kw',
+    source: 'kw',
+    type: 'kw',
+    id: rid,
+    rid,
+    name,
+    artist: artist || (artists.map(a => a.name).join(' / ')),
+    artists: artists.length ? artists : (artist ? [{ name: artist }] : []),
+    artistId: kwField(raw, 'ARTISTID') || '',
+    album,
+    albumId: kwField(raw, 'ALBUMID') || '',
+    cover: kwSongCover(kwField(raw, 'web_albumpic_short')),
+    duration: durationSec * 1000,
+    fee: 0,
+    formats,
+    hasFlac,
+    playable: false,
+  };
+}
+// 歌手热门歌 (stype=artist2music) 的 musiclist 项, 字段小写。
+function kwMapArtistSong(raw) {
+  const rid = (kwField(raw, 'musicrid') || kwField(raw, 'MUSICRID')).replace(/^MUSIC_/, '').trim();
+  if (!rid || !/^\d+$/.test(rid)) return null;
+  const name = kwDecodeText(kwField(raw, 'name') || kwField(raw, 'SONGNAME') || kwField(raw, 'NAME'));
+  if (!name) return null;
+  const artist = kwDecodeText(kwField(raw, 'artist') || kwField(raw, 'ARTIST'));
+  const album = kwDecodeText(kwField(raw, 'album') || kwField(raw, 'ALBUM'));
+  const durationSec = Number(kwField(raw, 'duration') || kwField(raw, 'DURATION')) || 0;
+  const formats = kwField(raw, 'formats') || kwField(raw, 'FORMATS') || '';
+  const artists = artist
+    ? artist.split(/\s*&\s*|\s*、\s*|\s*\/\s*|\s*,\s*/).map(n => ({ name: n.trim() })).filter(a => a.name)
+    : [];
+  return {
+    provider: 'kw', source: 'kw', type: 'kw',
+    id: rid, rid, name,
+    artist: artist || (artists.map(a => a.name).join(' / ')),
+    artists: artists.length ? artists : (artist ? [{ name: artist }] : []),
+    artistId: kwField(raw, 'artistid') || kwField(raw, 'ARTISTID') || '',
+    album, albumId: kwField(raw, 'albumid') || kwField(raw, 'ALBUMID') || '',
+    cover: kwSongCover(kwField(raw, 'web_albumpic_short')),
+    duration: durationSec * 1000,
+    fee: 0, formats, hasFlac: /FLAC|ALFLAC/i.test(formats), playable: false,
+  };
+}
+async function handleKwArtistSongs(artistId, limit) {
+  const id = String(artistId || '').trim();
+  if (!/^\d+$/.test(id)) return { provider: 'kw', error: 'MISSING_ARTIST_ID', artist: { id: '', name: '' }, songs: [] };
+  const rn = Math.max(1, Math.min(50, Number(limit) || 30));
+  const url = 'http://search.kuwo.cn/r.s?stype=artist2music&sortby=0&alflac=1&pn=0&rn=' + rn +
+    '&artistid=' + encodeURIComponent(id) + '&encoding=utf8&rformat=json&vipver=1';
+  let body = '';
+  let lastErr;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try { body = await requestText(url, { headers: { 'User-Agent': KW_UA_WEB, Referer: 'http://www.kuwo.cn/' } }); break; }
+    catch (e) { lastErr = e; await new Promise(r => setTimeout(r, 400 * (attempt + 1))); }
+  }
+  if (!body) throw lastErr || new Error('KW_ARTIST_EMPTY');
+  const nameMatch = /'artist':'([^']*)'/.exec(body);
+  const artistName = kwDecodeText(nameMatch ? nameMatch[1] : '');
+  const picMatch = /'web_artistpic_short':'([^']*)'/.exec(body);
+  const avatar = kwArtistHead(picMatch ? picMatch[1] : '');
+  const seen = new Set();
+  const songs = kwSplitListItems(body, 'musiclist')
+    .map(kwMapArtistSong)
+    .filter(Boolean)
+    .filter(s => { if (seen.has(s.rid)) return false; seen.add(s.rid); return true; });
+  return { provider: 'kw', artist: { id, name: artistName, avatar }, songs };
+}
+async function handleKwSearch(keywords, limit) {
+  const kw = String(keywords || '').trim();
+  if (!kw) return [];
+  const rn = Math.max(1, Math.min(30, Number(limit) || 15));
+  const url = 'http://search.kuwo.cn/r.s?all=' + encodeURIComponent(kw) +
+    '&ft=music&itemset=web_2013&client=kt&pn=0&rn=' + rn +
+    '&rformat=json&encoding=utf8&vipver=1&show_copyright_off=0&pcmp4=1&newver=1&audiotype=0';
+  let body = '';
+  let lastErr;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try { body = await requestText(url, { headers: { 'User-Agent': KW_UA_WEB, Referer: 'http://www.kuwo.cn/' } }); break; }
+    catch (e) { lastErr = e; await new Promise(r => setTimeout(r, 400 * (attempt + 1))); }
+  }
+  if (!body) throw lastErr || new Error('KW_SEARCH_EMPTY');
+  const seen = new Set();
+  return kwSplitAbslistItems(body)
+    .filter(raw => /'DC_TARGETTYPE':'music'/.test(raw) || /'MUSICRID':'MUSIC_/.test(raw))
+    .map(kwMapSearchSong)
+    .filter(song => {
+      if (!song) return false;
+      if (seen.has(song.rid)) return false;
+      seen.add(song.rid);
+      return true;
+    });
+}
+
+// —— 取链: nmobi.kuwo.cn/mobi.s, 带 URL 缓存 + 限速 + 试听检测 + 降级回退 ——
+const KW_URL_CACHE = new Map(); // key: rid|quality -> { url, level, br, exp }
+const KW_URL_TTL = 4 * 60 * 1000;
+let kwLastReq = 0;
+const KW_MIN_GAP = 300;
+// 全酷我上游请求(取链/music.pay/至臻取链)共享 300ms 最短间隔, 防风控
+async function kwRateGate() {
+  const gap = KW_MIN_GAP - (Date.now() - kwLastReq);
+  if (gap > 0) await new Promise(r => setTimeout(r, gap));
+  kwLastReq = Date.now();
+}
+async function kwFetchOnce(rid, candidate) {
+  await kwRateGate();
+  const plain =
+    kwCommonParams() +
+    `&type=convert_url2&br=${candidate.br}&format=${candidate.format}&sig=0&rid=${rid}` +
+    `&priority=bitrate&loginUid=${kwAccount.loginUid}&network=WIFI` +
+    `&loginSid=${kwAccount.loginSid}&mode=audition&uid=${kwAccount.appuid}`;
+  const url = 'http://nmobi.kuwo.cn/mobi.s?f=kuwo&q=' + kwMakeQ(plain);
+  let body = '';
+  let lastErr;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try { body = await requestText(url, { headers: { 'User-Agent': KW_UA_APK, Accept: '*/*' } }); break; }
+    catch (e) { lastErr = e; await new Promise(r => setTimeout(r, 400 * (attempt + 1))); }
+  }
+  if (!body) throw lastErr || new Error('KW_URL_HTTP_FAIL');
+  return kwParseKv(body);
+}
+async function kwFetchMusicUrl(rid, quality) {
+  const candidates = qualityCandidatesFrom(quality, KW_QUALITY_CANDIDATES);
+  const wantFlac = candidates[0] && candidates[0].format === 'flac';
+  let throttled = false;
+  let lastReason = '未获取到播放地址';
+  const triedBr = new Set();
+  for (const c of candidates) {
+    if (triedBr.has(c.br)) continue;
+    triedBr.add(c.br);
+    const kv = await kwFetchOnce(rid, c);
+    if (!kv.url) { lastReason = '酷我接口未返回 url'; continue; }
+    // ① 试听替换: 无有效会话或版权受限时返回 6kbps 占位
+    if ((kv.rid && kv.rid !== String(rid)) || /\/lx\/resource\//.test(kv.url) || kv.bitrate === '6') {
+      lastReason = '版权受限或会话无效, 酷我仅返回试听替换';
+      throttled = true;
+      continue;
+    }
+    // ② 音质降级: 请求无损却返回非 flac (该档不存在), 尝试下一个候选
+    if (c.format === 'flac' && String(kv.format || '').toLowerCase() !== 'flac') {
+      lastReason = `该曲无 ${c.br} 档, 返回 ${kv.bitrate}k ${kv.format}`;
+      continue;
+    }
+    const level = kwResolveLevel(kv);
+    return { url: kv.url, level, br: (Number(kv.bitrate) || c.bitrate / 1000) * 1000, format: kv.format || c.format, bitrate: Number(kv.bitrate) || 0 };
+  }
+  const err = new Error(lastReason);
+  err.throttled = throttled;
+  err.wantFlac = wantFlac;
+  throw err;
+}
+function classifyKwRestriction(throttled) {
+  if (throttled) {
+    return playbackRestriction('kw', 'vip_required',
+      kwHasAccount() ? '酷我会员会话可能失效, 该曲仅返回试听片段' : '酷我该曲版权受限, 游客仅可试听 · 可换其它平台版本',
+      'switch_source', { missingPlaybackKey: !kwHasAccount() });
+  }
+  return playbackRestriction('kw', 'url_unavailable', '酷我没有返回可播放地址, 可能受版权或地区限制', 'switch_source');
+}
+// —— 至臻音质 (ZPLY mflac): music.pay 取分级 token -> convert_url_with_sign 取 .mflac + ekey ——
+const KW_UA_PAY = KW_UA_APK;
+// 限速 + 3 次退避重试 GET; 全失败抛错。
+async function kwGetWithRetry(u, headers) {
+  let lastErr;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await kwRateGate();
+    try { return await requestText(u, { headers }); }
+    catch (e) { lastErr = e; if (attempt < 2) await new Promise(r => setTimeout(r, 400 * (attempt + 1))); }
+  }
+  throw lastErr || new Error('KW_HTTP_FAIL');
+}
+// music.pay 取某 rid 的分级 token + 权益位 -> {token,payInfo}; 无账号 -> null; 失败抛错。
+async function kwMusicPay(rid, quality) {
+  if (!kwHasAccount()) return null;
+  const dev = kwAccount.deviceId;
+  // 设备参数明文直传
+  const u = 'http://musicpay.kuwo.cn/music.pay?newver=2' +
+    '&clienttimestamp=' + Date.now() +
+    '&uid=' + encodeURIComponent(kwAccount.loginUid) +
+    '&sid=' + encodeURIComponent(kwAccount.loginSid) +
+    '&android_id=' + encodeURIComponent(dev) + '&from=ar&deviceid=' + encodeURIComponent(dev) +
+    '&ver=' + KW_VER + '&src=' + encodeURIComponent(KW_SRC) + '&appuid=' + encodeURIComponent(kwAccount.appuid) +
+    '&allpay=0&notrace=0&oaid=' + encodeURIComponent(KW_OAID) +
+    '&op=query&action=play&signver=new&filter=no&apiversion=2&local=0' +
+    '&quality=' + encodeURIComponent(quality || 'ZPLY') + '&preload=0' +
+    '&ids=' + encodeURIComponent(rid);
+  const body = await kwGetWithRetry(u, { 'User-Agent': KW_UA_PAY, Accept: '*/*' });
+  let j; try { j = JSON.parse(body); } catch (e) { throw new Error('music.pay 非 JSON'); }
+  const ok = j && (String(j.result).toLowerCase() === 'ok' || j.errorcode === 0);
+  const song = (j && Array.isArray(j.songs) && j.songs[0]) || (j && j.songs && j.songs[String(rid)]) || null;
+  if (!ok || !song) throw new Error('music.pay result=' + (j && (j.result != null ? j.result : j.errorcode)));
+  // token 为按音质名键控的对象; 兼容字符串-JSON 形态
+  let token = song.token;
+  if (typeof token === 'string') { try { token = JSON.parse(token); } catch (e) { token = {}; } }
+  return { token: token || {}, payInfo: song.payInfo || {} };
+}
+// 至臻取链 (ZPLY 20900kmflac)。返回 对象=成功; 'no-zhizhen'=无权益(可负缓存); null=瞬时失败(勿负缓存)。
+async function kwFetchZhizhen(rid) {
+  let pay;
+  try { pay = await kwMusicPay(rid, 'ZPLY'); }
+  catch (e) { return null; }                 // 瞬时失败(网络/会话) → 不负缓存, 下次再试
+  if (!pay) return 'no-zhizhen';             // 未登录 → 当作无至臻
+  if (!pay.token || !pay.token.ZPLY) return 'no-zhizhen';  // 会话有效但无 ZPLY 至臻 token → 确定
+  // convert_url_with_sign: token=token.ZPLY + bc_token=token.BCMS + 权益位
+  const plain = kwCommonParams() +
+    '&type=convert_url_with_sign&br=20900kmflac&format=mp3|aac&sig=0&rid=' + rid +
+    '&priority=bitrate&network=WIFI&localUid=-1&mode=audition' +
+    '&token=' + pay.token.ZPLY + '&bc_token=' + (pay.token.BCMS || '') +
+    '&timestamp=' + Math.floor(Date.now() / 1000) + '&uid=' + kwAccount.appuid +
+    '&downloadPay=' + (pay.payInfo.ndown || '111111111111') +
+    '&playPay=' + (pay.payInfo.nplay || '111111111111') +
+    '&payUid=' + kwAccount.loginUid + '&isstar=false&surl=1';
+  const url = 'http://nmobi.kuwo.cn/mobi.s?f=kuwo&q=' + kwMakeQ(plain);
+  let body;
+  try { body = await kwGetWithRetry(url, { 'User-Agent': KW_UA_APK, Accept: '*/*' }); }
+  catch (e) { return null; }                 // 取链瞬时失败 → 不负缓存
+  let j; try { j = JSON.parse(body); } catch (e) { return null; }
+  const d = j && j.data;
+  if (d && d.url && d.ekey && String(d.format).toLowerCase() === 'mflac' && String(d.rid || rid) === String(rid)) {
+    return { url: d.url, ekey: d.ekey, level: 'zhizhen', br: (Number(d.bitrate) || 20900) * 1000, format: 'mflac', bitrate: Number(d.bitrate) || 20900 };
+  }
+  // 回包为试听替换 = 无 ZPLY 权益 -> 'no-zhizhen' 负缓存; 无 data 才当瞬时失败。
+  return (d && (d.url || d.rid)) ? 'no-zhizhen' : null;
+}
+
+async function handleKwSongUrl(rid, qualityPreference) {
+  const songRid = String(rid || '').replace(/^MUSIC_/, '').trim();
+  if (!songRid) return { provider: 'kw', url: '', playable: false, error: 'MISSING_RID', message: '缺少酷我歌曲 id' };
+  const requestedQuality = normalizeQualityPreference(qualityPreference);
+  // 至臻 (jymaster 顶档 + 已登录): 先试 ZPLY 无损, 拿不到回落普通取链; 负缓存"无至臻"避免每次白打 music.pay。
+  if (requestedQuality === 'jymaster' && kwHasAccount()) {
+    const zzKey = songRid + '|zhizhen';
+    const zc = KW_URL_CACHE.get(zzKey);
+    if (zc && zc.exp > Date.now()) {
+      if (!zc.empty) {
+        return { provider: 'kw', url: zc.url, ekey: zc.ekey, mflac: true, trial: false, playable: true, level: 'zhizhen', quality: 'zhizhen', br: zc.br, format: 'mflac', requestedQuality };
+      }
+      // zc.empty: 已知该曲无至臻, 跳过, 直接走下面普通取链
+    } else {
+      let zz = null;
+      try { zz = await kwFetchZhizhen(songRid); } catch (e) { /* 回落普通取链 */ }
+      if (zz && typeof zz === 'object') {
+        KW_URL_CACHE.set(zzKey, { url: zz.url, ekey: zz.ekey, br: zz.br, exp: Date.now() + KW_URL_TTL });
+        return { provider: 'kw', url: zz.url, ekey: zz.ekey, mflac: true, trial: false, playable: true, level: 'zhizhen', quality: 'zhizhen', br: zz.br, format: 'mflac', requestedQuality };
+      }
+      // 仅"确定无权益"才负缓存; 瞬时失败(null)不缓存, 下次再试。
+      if (zz === 'no-zhizhen') KW_URL_CACHE.set(zzKey, { empty: true, exp: Date.now() + KW_URL_TTL });
+    }
+  }
+  const cacheKey = songRid + '|' + requestedQuality;
+  const cached = KW_URL_CACHE.get(cacheKey);
+  if (cached && cached.exp > Date.now()) {
+    return { provider: 'kw', url: cached.url, trial: false, playable: true, level: cached.level, quality: cached.level, br: cached.br, format: cached.format, requestedQuality };
+  }
+  let lastErr;
+  let relogged = false;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const r = await kwFetchMusicUrl(songRid, requestedQuality);
+      KW_URL_CACHE.set(cacheKey, { url: r.url, level: r.level, br: r.br, format: r.format, exp: Date.now() + KW_URL_TTL });
+      return { provider: 'kw', url: r.url, trial: false, playable: true, level: r.level, quality: r.level, br: r.br, format: r.format, requestedQuality };
+    } catch (e) {
+      lastErr = e;
+      if (!e.throttled) break;           // 纯降级/无地址不重试
+      // 试听替换多为 sid 失效; 配了账号密码则自愈一次, 拿到新 sid 立即重试 (不计入退避)
+      if (!relogged && attempt >= 1 && kwAccount.username && kwAccount.password) {
+        relogged = true;
+        if (await kwTryRelogin()) continue;
+      }
+      await new Promise(r => setTimeout(r, 600 * (attempt + 1)));
+    }
+  }
+  const restriction = classifyKwRestriction(!!(lastErr && lastErr.throttled));
+  return {
+    provider: 'kw',
+    url: '',
+    playable: false,
+    error: 'KW_URL_UNAVAILABLE',
+    restriction,
+    reason: restriction.category,
+    message: restriction.message,
+    requestedQuality,
+  };
+}
+
+// —— 歌词 ——
+// 主源 mlyric.kuwo.cn/mobi.s: rid 直取, 无词则按 歌名+歌手 搜候选 PATH 重取; 兜底 H5 songinfoandlrc。
+function kwFmtLrcTime(sec) {
+  const s = parseFloat(sec) || 0;
+  const m = Math.floor(s / 60);
+  const r = (s - m * 60).toFixed(2);
+  return `[${String(m).padStart(2, '0')}:${r.padStart(5, '0')}]`;
+}
+const KW_LRC_BASE = 'http://mlyric.kuwo.cn/mobi.s?f=kuwo&q=';
+// 歌词回包是二进制 (zlib), 走 Buffer 版避免 utf8 破坏。
+function kwRequestBuffer(targetUrl, opts) {
+  opts = opts || {};
+  return new Promise((resolve, reject) => {
+    const u = new URL(targetUrl);
+    const lib = u.protocol === 'https:' ? https : http;
+    const req = lib.request(u, { method: opts.method || 'GET', headers: opts.headers || {} }, response => {
+      const chunks = [];
+      response.on('data', c => chunks.push(c));
+      response.on('end', () => {
+        const buf = Buffer.concat(chunks);
+        if (response.statusCode >= 400) { const e = new Error('HTTP ' + response.statusCode); e.statusCode = response.statusCode; reject(e); return; }
+        resolve(buf);
+      });
+    });
+    req.setTimeout(10000, () => req.destroy(new Error('Request timeout')));
+    req.on('error', reject);
+    req.end();
+  });
+}
+function kwXorYeelion(buf) {
+  const key = Buffer.from('yeelion', 'utf8');
+  const out = Buffer.alloc(buf.length);
+  for (let i = 0; i < buf.length; i++) out[i] = buf[i] ^ key[i % key.length];
+  return out;
+}
+// 解出 TP=content 正文; 返回 { kind:'content'|'list'|'none', text|ids }
+function kwParseLyricResponse(buf) {
+  const sep = buf.indexOf('\r\n\r\n');
+  const head = (sep >= 0 ? buf.slice(0, sep) : buf).toString('utf8');
+  if (/^TP=none/.test(head)) return { kind: 'none' };
+  if (/^TP=list/.test(head)) {
+    const ids = [];
+    const txt = buf.toString('utf8');
+    const re = /PATH=(\d+)/g; let m;
+    while ((m = re.exec(txt))) ids.push(m[1]);
+    return { kind: 'list', ids };
+  }
+  if (!/^TP=content/.test(head) || sep < 0) return { kind: 'other' };
+  const isLrcx = /lrcx=1/.test(head);
+  const payload = buf.slice(sep + 4);
+  let inflated;
+  try { inflated = zlib.inflateSync(payload); }
+  catch (e) { try { inflated = zlib.gunzipSync(payload); } catch (e2) { return { kind: 'other' }; } }
+  let text = inflated.toString('utf8');
+  if (isLrcx) {
+    try { text = kwXorYeelion(Buffer.from(text.replace(/\s/g, ''), 'base64')).toString('utf8'); }
+    catch (e) { return { kind: 'other' }; }
+  }
+  return { kind: 'content', text };
+}
+// kuwo LRCX 逐字 -> { lyric:行级LRC, yrc:逐字 }。
+//   头部 [kuwo:XXX](八进制) 给缩放因子 c=⌊v/10⌋, d=v%10 (缺省 1)。
+//   每字 <g1,g2>: 字起点 = (g1+g2)/(2c), 字时长 = (g1-g2)/(2d) (ms)。
+function kwLrcxToLyric(raw) {
+  const text = String(raw || '');
+  // [kuwo:XXX] 缩放头 (八进制): c=⌊v/10⌋, d=v%10; 解析失败或为 0 时回落 1 (避免除零)
+  let c = 1, d = 1;
+  const km = text.match(/\[kuwo:\s*([^\]\s]+)/);
+  if (km) {
+    const v = parseInt(km[1], 8);
+    if (Number.isFinite(v)) { const cc = Math.floor(v / 10), dd = v % 10; if (cc > 0) c = cc; if (dd > 0) d = dd; }
+  }
+  const lrc = [], yrc = []; let anyWords = false;
+  for (const line of text.split(/\r?\n/)) {
+    const tm = line.match(/^\[(\d{1,2}):(\d{1,2})(?:\.(\d{1,3}))?\](.*)$/);
+    if (!tm) continue; // 跳过 [ti:]/[ar:]/[kuwo:]/[ver:] 等头部标签
+    const stamp = `[${tm[1]}:${tm[2]}${tm[3] ? '.' + tm[3] : ''}]`;
+    const lineStart = ((+tm[1]) * 60 + (+tm[2])) * 1000 + (tm[3] ? parseInt((tm[3] + '00').slice(0, 3), 10) : 0);
+    const body = tm[4] || '';
+    const wre = /<(-?\d+),(-?\d+)(?:,-?\d+)?>([^<]*)/g; let wm;
+    const words = []; let plain = '', lineEnd = 0;
+    while ((wm = wre.exec(body))) {
+      const g1 = +wm[1], g2 = +wm[2], ch = wm[3];
+      if (!ch) continue;
+      let st = Math.round((g1 + g2) / (2 * c)); // 相对行首的字起点
+      let du = Math.round((g1 - g2) / (2 * d)); // 字时长
+      if (st < 0) st = 0;
+      if (du < 0) du = 0;
+      words.push({ st, du, ch });
+      plain += ch; lineEnd = Math.max(lineEnd, st + du);
+    }
+    if (!words.length) {
+      // 无逐字标签的时间行 → 行级形式进 lrc/yrc
+      const t = body.replace(/<-?\d+,-?\d+(?:,-?\d+)?>/g, '').trim();
+      if (t) { lrc.push(stamp + t); yrc.push(`[${lineStart},0]${t}`); }
+      continue;
+    }
+    // 单调收尾: 字尾不越过下一字字头, 防高亮重叠
+    for (let i = 0; i < words.length - 1; i++) {
+      const gap = words[i + 1].st - words[i].st;
+      if (gap >= 0 && words[i].du > gap) words[i].du = gap;
+    }
+    anyWords = true;
+    lrc.push(stamp + plain);
+    let y = `[${lineStart},${Math.max(1, lineEnd)}]`;
+    for (const w of words) y += `(${lineStart + w.st},${w.du},0)${w.ch}`;
+    yrc.push(y);
+  }
+  // 整首都无逐字 (lrcx=0 纯 LRC) → 不发 yrc, 让前端走完整的行级 lyric
+  return { lyric: lrc.join('\n'), yrc: anyWords ? yrc.join('\n') : '' };
+}
+async function kwLyricCall(plain) {
+  let lastErr;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try { return await kwRequestBuffer(KW_LRC_BASE + encodeURIComponent(kwMakeQ(plain)), { headers: { 'User-Agent': KW_UA_APK } }); }
+    catch (e) { lastErr = e; if (attempt < 2) await new Promise(r => setTimeout(r, 300 * (attempt + 1))); }
+  }
+  throw lastErr || new Error('KW_LYRIC_HTTP_FAIL');
+}
+async function handleKwLyric(rid, name, artist, duration) {
+  const songRid = String(rid || '').replace(/^MUSIC_/, '').trim();
+  if (!songRid && !name) return { provider: 'kw', error: 'MISSING_RID', lyric: '' };
+  const base = kwCommonParams();
+  const dur = Math.max(0, Math.round(Number(duration) || 0));
+  // 单次取词: 失败/非歌词响应都吞掉返回 null, 任一阶段出错都不阻断后续阶段
+  const tryLyric = async (plain, id) => {
+    try {
+      const r = kwParseLyricResponse(await kwLyricCall(plain));
+      if (r.kind !== 'content') return null;
+      const out = kwLrcxToLyric(r.text);
+      return out.lyric ? out : null;
+    } catch (e) { console.warn('[KwLyric] mlyric 取词失败:', e.message); return null; }
+  };
+  // 1) 用播放 rid 直取
+  if (/^\d+$/.test(songRid)) {
+    const out = await tryLyric(`${base}&type=lyric&req=2&lrcx=1&rid=${songRid}&encode=utf8`);
+    if (out) return { provider: 'kw', id: songRid, lyric: out.lyric, tlyric: '', yrc: out.yrc, source: 'kw-mobi-rid' };
+  }
+  // 2) rid 无词 → 按 歌名+歌手 搜候选 PATH 重取 (逐个候选独立容错)
+  if (name) {
+    let list = { kind: 'none' };
+    try {
+      const q = `${base}&type=lyric&songname=${encodeURIComponent(name)}&artist=${encodeURIComponent(artist || '')}` +
+        `&filename=&duration=${dur}&req=1&lrcx=1&encode=utf8`;
+      list = kwParseLyricResponse(await kwLyricCall(q));
+    } catch (e) { console.warn('[KwLyric] mlyric 搜词失败:', e.message); }
+    if (list.kind === 'list') {
+      for (const pid of list.ids.slice(0, 3)) {
+        const out = await tryLyric(`${base}&type=lyric&req=2&lrcx=1&rid=${pid}&encode=utf8`);
+        if (out) return { provider: 'kw', id: songRid, lyric: out.lyric, tlyric: '', yrc: out.yrc, source: 'kw-mobi-search', lyricId: pid };
+      }
+    }
+  }
+  // 3) 兜底: 旧的 H5 songinfoandlrc
+  if (/^\d+$/.test(songRid)) {
+    const h5 = await handleKwLyricH5(songRid);
+    if (h5 && h5.lyric) return h5;
+  }
+  return { provider: 'kw', id: songRid, lyric: '', tlyric: '', yrc: '', source: 'kw-empty' };
+}
+// 兜底歌词源: m.kuwo.cn H5 单曲歌词 (节点偶发 status=301, 需重试; 仅行级)
+async function handleKwLyricH5(rid) {
+  const songRid = String(rid || '').replace(/^MUSIC_/, '').trim();
+  if (!songRid) return { provider: 'kw', error: 'MISSING_RID', lyric: '' };
+  const url = `https://m.kuwo.cn/newh5/singles/songinfoandlrc?musicId=${songRid}&httpsStatus=1`;
+  let lastErr;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const text = await requestText(url, {
+        headers: { 'User-Agent': KW_UA_H5, Referer: 'https://m.kuwo.cn/', csrf: 'kw', Cookie: 'kw_token=kw' },
+      });
+      const data = JSON.parse(text);
+      const list = data && data.data && data.data.lrclist;
+      if (data && data.status === 200 && Array.isArray(list) && list.length) {
+        const lyric = list.map(it => kwFmtLrcTime(it.time) + (it.lineLyric || '')).join('\n');
+        return { provider: 'kw', id: songRid, lyric, tlyric: '', yrc: '', source: 'kw-h5' };
+      }
+      lastErr = new Error('酷我歌词接口 status=' + (data && data.status));
+    } catch (e) { lastErr = e; }
+    if (attempt < 4) await new Promise(r => setTimeout(r, 250 * (attempt + 1)));
+  }
+  return { provider: 'kw', id: songRid, lyric: '', tlyric: '', yrc: '', source: 'kw-empty', error: lastErr && lastErr.message };
+}
+
+// —— 封面兜底: 按 rid 取专辑封面 (搜索结果一般已带 cover) ——
+async function handleKwPic(rid) {
+  const songRid = String(rid || '').replace(/^MUSIC_/, '').trim();
+  if (!songRid) return { provider: 'kw', cover: '' };
+  const url = 'http://artistpicserver.kuwo.cn/pic.web?type=rid_pic&pictype=url&content=list&size=500' +
+    `&rid=${songRid}&user=${kwAccount.deviceId}&prod=${KW_PROD}&corp=kuwo&source=${KW_SRC}`;
+  try {
+    const body = await requestText(url, { headers: { 'User-Agent': KW_UA_APK } });
+    const first = String(body || '').trim().split('\n')[0].trim();
+    if (/^https?:\/\//.test(first)) return { provider: 'kw', cover: first };
+  } catch (e) {}
+  return { provider: 'kw', cover: '' };
+}
+
+// —— 我的歌单: nplserver.kuwo.cn/pl.svc ——
+const KW_PL_BASE = 'http://nplserver.kuwo.cn/pl.svc';
+async function kwGetJSON(url) {
+  let lastErr;
+  for (let attempt = 0; attempt < 3; attempt++) {
+    try {
+      const body = await requestText(url, { headers: { 'User-Agent': KW_UA_APK } });
+      return JSON.parse(body);
+    } catch (e) { lastErr = e; await new Promise(r => setTimeout(r, 350 * (attempt + 1))); }
+  }
+  throw lastErr || new Error('KW_PL_HTTP_FAIL');
+}
+async function handleKwUserPlaylists() {
+  if (!kwHasAccount()) return { provider: 'kw', loggedIn: false, playlists: [] };
+  const uid = kwAccount.loginUid;
+  const url = `${KW_PL_BASE}?op=getlistbyuid&uid=${encodeURIComponent(uid)}&pn=0&rn=100&encode=utf-8&keyset=pl2012&vipver=1&newver=1`;
+  const data = await kwGetJSON(url);
+  const plist = (data && Array.isArray(data.plist)) ? data.plist : [];
+  const playlists = plist
+    .filter(p => p && p.id && !p.hidden)
+    .map(p => ({
+      provider: 'kw',
+      source: 'kw',
+      id: String(p.id),
+      name: p.title || '未命名歌单',
+      cover: p.pic || '',
+      trackCount: Number(p.musicnum) || 0,
+      playCount: Number(p.playnum) || 0,
+      creator: kwAccount.nickname || '酷我用户',
+      subscribed: false,
+      favorite: p.type === 'MYFAVORITE',
+    }))
+    .sort((a, b) => Number(b.favorite) - Number(a.favorite));
+  return { provider: 'kw', loggedIn: true, userId: uid, playlists };
+}
+function kwMapPlaylistTrack(m) {
+  m = m || {};
+  const rid = String(m.id || m.musicrid || '').replace(/^MUSIC_/, '').trim();
+  if (!rid || !/^\d+$/.test(rid)) return null;
+  const name = kwDecodeText(m.name || m.songname || m.FSONGNAME || '');
+  if (!name) return null;
+  const artist = kwDecodeText(m.artist || m.FARTIST || '');
+  const album = kwDecodeText(m.album || m.FALBUM || '');
+  const cover = kwUpsizeCover(m.albumpic || m.musicPic || m.web_albumpic || '') || (m.web_albumpic_short ? kwSongCover(m.web_albumpic_short) : '');
+  const artists = artist
+    ? artist.split(/\s*&\s*|\s*、\s*|\s*\/\s*|\s*,\s*/).map(n => ({ name: n.trim() })).filter(a => a.name)
+    : [];
+  // online=0 为下架/无版权曲, 保留并打标 offline。
+  const offline = m.online != null && String(m.online) === '0';
+  return {
+    provider: 'kw',
+    source: 'kw',
+    type: 'kw',
+    id: rid,
+    rid,
+    name,
+    artist: artist || (artists.map(a => a.name).join(' / ')),
+    artists: artists.length ? artists : (artist ? [{ name: artist }] : []),
+    artistId: m.artistid || '',
+    album,
+    albumId: m.albumid || '',
+    cover: cover || '',
+    duration: (Number(m.duration) || 0) * 1000,
+    fee: 0,
+    formats: m.formats || '',
+    hasFlac: /FLAC|ALFLAC/i.test(m.formats || ''),
+    offline,
+    playable: false,
+  };
+}
+// 全量歌单: pl.svc op=pl3_getlist&sig=0, 返回含下架歌的完整成员 (登录态)。
+//   未登录/失败返回 null, 由上层回退 getlistinfo。
+async function kwGetPlaylistFull(pid) {
+  if (!kwHasAccount()) return null;
+  const dev = kwAccount.deviceId;
+  const params = new URLSearchParams({
+    op: 'pl3_getlist', pid: String(pid), sig: '0',
+    uid: kwAccount.loginUid, sid: kwAccount.loginSid,
+    encode: 'utf-8', plat: 'ar',
+    devid: kwAccount.appuid, user: dev, imei: dev, oaid: KW_OAID,
+    prod: KW_PROD, source: KW_SRC, corp: 'kuwo', q36: KW_Q36,
+    locationid: '1', approval: 'false', allpay: '0', notrace: '0',
+    ttime: String(Date.now()), pn: '0',
+  });
+  try {
+    const data = await kwGetJSON(`${KW_PL_BASE}?${params.toString()}`);
+    if (data && data.errcode === 0 && data.info && Array.isArray(data.info.musiclist)) return data.info;
+  } catch (e) { console.warn('[Kuwo] pl3_getlist 失败, 回退 getlistinfo:', e.message); }
+  return null;
+}
+async function handleKwPlaylistTracks(pid, limit) {
+  const id = String(pid || '').trim();
+  if (!id) return { provider: 'kw', error: 'MISSING_PID', tracks: [] };
+  // 优先 pl3_getlist 全量 (登录态): 含下架歌
+  let list = [];
+  let title = '';
+  let cover = '';
+  let total = 0;
+  const full = await kwGetPlaylistFull(id);
+  if (full && full.musiclist.length) {
+    list = full.musiclist;
+    total = list.length;
+  } else {
+    // 回退: 游客/pl3 失败时用 getlistinfo (会过滤下架歌)
+    const rn = Math.max(1, Math.min(1000, Number(limit) || 300));
+    const url = `${KW_PL_BASE}?op=getlistinfo&pid=${encodeURIComponent(id)}&pn=0&rn=${rn}&encode=utf-8&keyset=pl2012&vipver=1&newver=1`;
+    const data = await kwGetJSON(url);
+    list = (data && Array.isArray(data.musiclist)) ? data.musiclist : [];
+    title = kwDecodeText(data && data.title) || '';
+    cover = (data && data.pic) || '';
+    total = Number(data && data.total) || list.length;
+  }
+  const tracks = list.map(kwMapPlaylistTrack).filter(Boolean);
+  const playlist = {
+    provider: 'kw',
+    id,
+    name: title || '酷我歌单',
+    cover: cover || (tracks[0] && tracks[0].cover) || '',
+    trackCount: total || tracks.length,
+  };
+  return { provider: 'kw', playlist, tracks };
+}
+
+// ====================================================================
 //  HTTP Server
 // ====================================================================
 const server = http.createServer(async (req, res) => {
@@ -3554,6 +4618,141 @@ const server = http.createServer(async (req, res) => {
       console.error('[QQSongComments]', err);
       sendJSON(res, { provider: 'qq', error: err.message, comments: [] }, 500);
     }
+    return;
+  }
+
+  // ---------- 酷我音乐 ----------
+  if (pn === '/api/kw/search') {
+    try {
+      const kw = url.searchParams.get('keywords') || '';
+      const limit = Math.max(4, Math.min(30, parseInt(url.searchParams.get('limit') || '15', 10) || 15));
+      const songs = await handleKwSearch(kw, limit);
+      sendJSON(res, { provider: 'kw', songs });
+    } catch (err) {
+      console.error('[KwSearch]', err);
+      sendJSON(res, { provider: 'kw', error: err.message, songs: [] }, 500);
+    }
+    return;
+  }
+
+  if (pn === '/api/kw/artist/songs') {
+    try {
+      const id = url.searchParams.get('id') || url.searchParams.get('artistid') || '';
+      const limit = url.searchParams.get('limit') || '';
+      sendJSON(res, await handleKwArtistSongs(id, limit));
+    } catch (err) {
+      console.error('[KwArtist]', err);
+      sendJSON(res, { provider: 'kw', error: err.message, artist: { id: '', name: '' }, songs: [] }, 500);
+    }
+    return;
+  }
+
+  if (pn === '/api/kw/song/url') {
+    try {
+      const rid = url.searchParams.get('rid') || url.searchParams.get('id') || '';
+      const quality = url.searchParams.get('quality') || '';
+      const info = await handleKwSongUrl(rid, quality);
+      sendJSON(res, info);
+    } catch (err) {
+      console.error('[KwSongUrl]', err);
+      sendJSON(res, { provider: 'kw', url: '', playable: false, error: err.message }, 500);
+    }
+    return;
+  }
+
+  if (pn === '/api/kw/lyric') {
+    try {
+      const rid = url.searchParams.get('rid') || url.searchParams.get('id') || '';
+      const name = url.searchParams.get('name') || '';
+      const artist = url.searchParams.get('artist') || '';
+      const duration = url.searchParams.get('duration') || '';
+      if (!rid && !name) { sendJSON(res, { provider: 'kw', error: 'Missing kw rid', lyric: '' }, 400); return; }
+      const data = await handleKwLyric(rid, name, artist, duration);
+      sendJSON(res, data);
+    } catch (err) {
+      console.error('[KwLyric]', err);
+      sendJSON(res, { provider: 'kw', error: err.message, lyric: '' }, 500);
+    }
+    return;
+  }
+
+  if (pn === '/api/kw/pic') {
+    try {
+      const rid = url.searchParams.get('rid') || url.searchParams.get('id') || '';
+      const data = await handleKwPic(rid);
+      sendJSON(res, data);
+    } catch (err) {
+      console.error('[KwPic]', err);
+      sendJSON(res, { provider: 'kw', cover: '', error: err.message }, 500);
+    }
+    return;
+  }
+
+  if (pn === '/api/kw/user/playlists') {
+    try {
+      const data = await handleKwUserPlaylists();
+      sendJSON(res, data);
+    } catch (err) {
+      console.error('[KwUserPlaylists]', err);
+      sendJSON(res, { provider: 'kw', loggedIn: kwHasAccount(), error: err.message, playlists: [] }, 500);
+    }
+    return;
+  }
+
+  if (pn === '/api/kw/playlist/tracks') {
+    try {
+      const id = url.searchParams.get('id') || url.searchParams.get('pid') || '';
+      const limit = parseInt(url.searchParams.get('limit') || '300', 10) || 300;
+      const data = await handleKwPlaylistTracks(id, limit);
+      sendJSON(res, data);
+    } catch (err) {
+      console.error('[KwPlaylistTracks]', err);
+      sendJSON(res, { provider: 'kw', error: err.message, tracks: [] }, 500);
+    }
+    return;
+  }
+
+  if (pn === '/api/kw/login/status') {
+    try { await kwRefreshVipInfo(false); } catch (e) { /* 会员信息拉取失败不影响登录态返回 */ }
+    sendJSON(res, kwLoginStatus());
+    return;
+  }
+
+  if (pn === '/api/kw/login') {
+    try {
+      const body = await readRequestBody(req);
+      const username = String(body.username || body.account || body.user || '').trim();
+      const password = String(body.password || body.pwd || '');
+      if (!username || !password) {
+        sendJSON(res, { provider: 'kw', loggedIn: false, error: 'MISSING_CREDENTIALS', message: '请输入酷我账号和密码' }, 400);
+        return;
+      }
+      const r = await kwDoLogin(username, password);
+      if (r && r.ok) {
+        sendJSON(res, { ...kwLoginStatus(), saved: true });
+      } else {
+        sendJSON(res, { provider: 'kw', loggedIn: false, error: (r && r.error) || 'LOGIN_FAILED', message: (r && r.message) || '登录失败，请检查账号或密码' }, 401);
+      }
+    } catch (err) {
+      console.error('[KwLogin]', err);
+      sendJSON(res, { provider: 'kw', loggedIn: false, error: err.message }, 500);
+    }
+    return;
+  }
+
+  if (pn === '/api/kw/logout') {
+    kwAccount.loginUid = '0';
+    kwAccount.loginSid = '0';
+    kwAccount.username = '';
+    kwAccount.password = '';
+    kwAccount.nickname = '';
+    kwAccount.avatar = '';
+    kwAccount.vipType = 0;
+    kwAccount.vipTier = 'none'; kwAccount.vipLabel = ''; kwAccount.vipExpire = 0;
+    kwAccount.vipTag = ''; kwAccount.userVipType = ''; kwAccount.vipFetchedAt = 0;
+    KW_URL_CACHE.clear();
+    saveKwAccount();
+    sendJSON(res, { provider: 'kw', ok: true, loggedIn: false });
     return;
   }
 
@@ -4143,18 +5342,19 @@ const server = http.createServer(async (req, res) => {
       }
       const resp = await fetch(coverUrl, { headers: { 'User-Agent': UA, 'Referer': 'https://music.163.com/' } });
       const ct  = resp.headers.get('content-type') || 'image/jpeg';
-      const cl  = resp.headers.get('content-length');
+      // 完整缓冲后按实际字节数发送: 不能转发上游 Content-Length —— 酷我等 CDN 偶发返回
+      // 偏短的 Content-Length(实际图比声明值多几十字节), Node 的 http 响应会按声明值截断输出,
+      // 导致 JPEG 尾部 (FF D9) 被砍掉 -> 解码成全黑/损坏 (粒子封面变黑、浏览器报 ERR_CONTENT_LENGTH_MISMATCH)。
+      const body = Buffer.from(await resp.arrayBuffer());
       const hdr = {
         'Content-Type': ct,
+        'Content-Length': body.length,
         'Access-Control-Allow-Origin': '*',
         'Cross-Origin-Resource-Policy': 'cross-origin',
         'Cache-Control': 'public, max-age=86400',
       };
-      if (cl) hdr['Content-Length'] = cl;
       res.writeHead(resp.status, hdr);
-      const reader = resp.body.getReader();
-      while (true) { const c = await reader.read(); if (c.done) break; res.write(c.value); }
-      res.end();
+      res.end(body);
     } catch (err) { console.error('[Cover]', err); res.writeHead(500); res.end(); }
     return;
   }
@@ -4166,17 +5366,41 @@ const server = http.createServer(async (req, res) => {
       if (!audioUrl) { res.writeHead(400); res.end('Missing url'); return; }
       const range = req.headers.range || '';
       const hdr = audioProxyHeadersFor(audioUrl, range);
+      // 至臻 mflac: 带 kwekey 则边下边解; 解密 1:1 不改长度, Content-Length/Range 原样透传。
+      const kwekey = url.searchParams.get('kwekey') || '';
+      let qmc = null;
+      if (kwekey) {
+        try { qmc = new kwQmc.QmcCipher(kwQmc.decryptEkeyB64(kwekey, (b, k) => kwDecrypt(b, k || 'ylzsxkwm'))); }
+        catch (e) { console.error('[Audio] kwekey 解析失败:', e.message); }
+      }
       const up = await fetch(audioUrl, { headers: hdr });
       const out = {
-        'Content-Type': audioContentTypeForUrl(audioUrl, up.headers.get('content-type')),
+        'Content-Type': qmc ? 'audio/flac' : audioContentTypeForUrl(audioUrl, up.headers.get('content-type')),
         'Access-Control-Allow-Origin': '*',
         'Accept-Ranges': 'bytes',
       };
       const cl = up.headers.get('content-length'); if (cl) out['Content-Length'] = cl;
       const cr = up.headers.get('content-range');  if (cr) out['Content-Range']  = cr;
       res.writeHead(up.status, out);
+      // 解密起始偏移 = 上游实际发回的起点 (仅 206 有偏移; 回 200 整文件须从 0 解)。
+      let decOff = 0;
+      if (qmc && up.status === 206) {
+        const m = /bytes\s+(\d+)-/.exec(cr || '') || /bytes=(\d+)-/.exec(range);
+        decOff = m ? parseInt(m[1], 10) : 0;
+      }
       const reader = up.body.getReader();
-      while (true) { const c = await reader.read(); if (c.done) break; res.write(c.value); }
+      while (true) {
+        const c = await reader.read();
+        if (c.done) break;
+        if (qmc) {
+          const b = Buffer.from(c.value);
+          qmc.process(b, 0, b.length, decOff);
+          decOff += b.length;
+          res.write(b);
+        } else {
+          res.write(c.value);
+        }
+      }
       res.end();
     } catch (err) { console.error('[Audio]', err); res.writeHead(500); res.end(); }
     return;


### PR DESCRIPTION
## 主要改动

**音源能力（server.js）**
- 酷我搜索 / 取链 / 歌词 / 封面接口接入，歌单获取逻辑与官方 App 对齐
- 歌词支持按「歌名 + 歌手 + 时长」匹配，修正逐字时间计算与格式解析
- 接入酷我接口签名（DES 加密 `kwMakeQ`）
- 至臻音质：`.mflac`（QMCv2）解密器，按 HTTP Range 分段解出标准 FLAC
- 账号登录 + 票据（loginUid/loginSid）持久化，支持自动重登
- 会员档位识别，通过 RSA 解密会员信息，带 5 分钟缓存

**前端（public/index.html）**
- 登录面板新增「酷我」入口（手机号登录），账号中心支持补登/切换酷我
- 音质选择联动：顶档「超清母带 / 至臻」在「网易云 SVIP 或 酷我登录」时解锁，无权益自动回落无损
- 对第三方封面字段做转义，防止明文 HTTP 数据注入导致的 XSS

**桌面端（desktop/main.js）**
- 酷我账号票据存入 `userData/.kw-account`，避免 NSIS 更新覆盖 app 目录导致登录丢失
- 兼容旧版本：自动从旧路径迁移已有票据