### PR TITLE
feat(linux): 增加 AppImage 与 Debian 打包支持

### DIFF
--- a/desktop/main.js
+++ b/desktop/main.js
@@ -3,6 +3,11 @@ const net = require('net');
 const path = require('path');
 const fs = require('fs');
 const { execFile, spawn } = require('child_process');
+const {
+  getAppIconPath,
+  getChromiumPerformanceSwitches,
+  getUpdateOpenStrategy,
+} = require('../platform-utils');
 
 let mainWindow = null;
 let localServer = null;
@@ -31,25 +36,15 @@ const MIN_WINDOWED_WIDTH = 960;
 const MIN_WINDOWED_HEIGHT = 540;
 const APP_NAME = 'Mineradio';
 const APP_USER_MODEL_ID = 'com.mineradio.desktop';
+const BUILD_DIR = path.join(__dirname, '..', 'build');
+const APP_ICON_PATH = getAppIconPath(BUILD_DIR, process.platform);
 const APP_ICON_ICO = path.join(__dirname, '..', 'build', 'icon.ico');
 const NETEASE_LOGIN_PARTITION = 'persist:mineradio-netease-login';
 const NETEASE_LOGIN_URL = 'https://music.163.com/#/login';
 const QQ_LOGIN_PARTITION = 'persist:mineradio-qqmusic-login';
 const QQ_LOGIN_URL = 'https://y.qq.com/n/ryqq/profile';
 
-const CHROMIUM_PERFORMANCE_SWITCHES = [
-  ['autoplay-policy', 'no-user-gesture-required'],
-  ['ignore-gpu-blocklist'],
-  ['enable-gpu-rasterization'],
-  ['enable-oop-rasterization'],
-  ['enable-zero-copy'],
-  ['enable-accelerated-2d-canvas'],
-  ['disable-background-timer-throttling'],
-  ['disable-renderer-backgrounding'],
-  ['disable-backgrounding-occluded-windows'],
-  ['force_high_performance_gpu'],
-  ['use-angle', 'd3d11'],
-];
+const CHROMIUM_PERFORMANCE_SWITCHES = getChromiumPerformanceSwitches(process.platform);
 for (const [name, value] of CHROMIUM_PERFORMANCE_SWITCHES) {
   if (value == null) app.commandLine.appendSwitch(name);
   else app.commandLine.appendSwitch(name, value);
@@ -272,6 +267,17 @@ function getUpdateDownloadDir() {
   return path.join(app.getPath('userData'), 'updates');
 }
 
+async function openDownloadedUpdate(target) {
+  if (getUpdateOpenStrategy(target, process.platform) === 'relaunch') {
+    fs.chmodSync(target, 0o755);
+    app.relaunch({ execPath: target });
+    app.quit();
+    return '';
+  }
+
+  return shell.openPath(target);
+}
+
 function shouldEnsureDesktopShortcut() {
   if (process.platform !== 'win32') return false;
   if (process.env.MINERADIO_NO_DESKTOP_SHORTCUT === '1') return false;
@@ -417,7 +423,7 @@ async function openNeteaseMusicLoginWindow(owner) {
       autoHideMenuBar: true,
       title: '网易云音乐登录',
       backgroundColor: '#111111',
-      icon: APP_ICON_ICO,
+      icon: APP_ICON_PATH,
       webPreferences: {
         partition: NETEASE_LOGIN_PARTITION,
         contextIsolation: true,
@@ -519,7 +525,7 @@ async function openQQMusicLoginWindow(owner) {
       autoHideMenuBar: true,
       title: 'QQ 音乐登录',
       backgroundColor: '#111111',
-      icon: APP_ICON_ICO,
+      icon: APP_ICON_PATH,
       webPreferences: {
         partition: QQ_LOGIN_PARTITION,
         contextIsolation: true,
@@ -1184,7 +1190,7 @@ ipcMain.handle('mineradio-open-update-installer', async (_event, filePath) => {
       return { ok: false, error: 'INVALID_UPDATE_PATH' };
     }
     if (!fs.existsSync(target)) return { ok: false, error: 'UPDATE_FILE_MISSING' };
-    const error = await shell.openPath(target);
+    const error = await openDownloadedUpdate(target);
     return error ? { ok: false, error } : { ok: true };
   } catch (e) {
     return { ok: false, error: e.message || 'OPEN_UPDATE_FAILED' };
@@ -1357,7 +1363,7 @@ async function createWindow() {
     hasShadow: true,
     autoHideMenuBar: true,
     title: APP_NAME,
-    icon: APP_ICON_ICO,
+    icon: APP_ICON_PATH,
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
       contextIsolation: true,

--- a/docs/superpowers/plans/2026-07-01-debian-package.md
+++ b/docs/superpowers/plans/2026-07-01-debian-package.md
@@ -16,32 +16,32 @@
 - Modify: `test/package-config.test.js`
 - Modify: `package.json`
 
-- [ ] **Step 1: Write the failing configuration test**
+- [x] **Step 1: Write the failing configuration test**
 
 Add assertions for these exact scripts and Linux fields:
 
 ```js
-assert.equal(packageJson.scripts['build:linux'], 'npm run build:linux:appimage');
-assert.equal(packageJson.scripts['build:linux:appimage'], 'electron-builder --linux AppImage');
-assert.equal(packageJson.scripts['build:linux:deb'], 'electron-builder --linux deb');
+assert.equal(packageJson.scripts['build:linux'], 'electron-builder --linux AppImage --x64');
+assert.equal(packageJson.scripts['build:linux:appimage'], 'electron-builder --linux AppImage --x64');
+assert.equal(packageJson.scripts['build:linux:deb'], 'electron-builder --linux deb --x64');
 assert.match(packageJson.build.linux.maintainer, /^.+ <[^<>\s]+@[^<>\s]+>$/);
 assert.deepEqual(packageJson.build.linux.target, [{ target: 'AppImage', arch: ['x64'] }]);
 ```
 
-- [ ] **Step 2: Run the test and verify RED**
+- [x] **Step 2: Run the test and verify RED**
 
 Run: `node --test test/package-config.test.js`
 
 Expected: FAIL because the explicit AppImage/deb scripts and maintainer are absent.
 
-- [ ] **Step 3: Add the minimal package configuration**
+- [x] **Step 3: Add the minimal package configuration**
 
 Set the Linux scripts to:
 
 ```json
-"build:linux": "npm run build:linux:appimage",
-"build:linux:appimage": "electron-builder --linux AppImage",
-"build:linux:deb": "electron-builder --linux deb"
+"build:linux": "electron-builder --linux AppImage --x64",
+"build:linux:appimage": "electron-builder --linux AppImage --x64",
+"build:linux:deb": "electron-builder --linux deb --x64"
 ```
 
 Add this field under `build.linux`:
@@ -50,7 +50,7 @@ Add this field under `build.linux`:
 "maintainer": "XxHuberrr <281847693+XxHuberrr@users.noreply.github.com>"
 ```
 
-- [ ] **Step 4: Run the full test suite and syntax checks**
+- [x] **Step 4: Run the full test suite and syntax checks**
 
 Run: `npm test && node --check server.js && node --check desktop/main.js && git diff --check`
 
@@ -61,13 +61,13 @@ Expected: all tests and checks pass.
 **Files:**
 - Generated and ignored: `dist/Mineradio-1.1.1.deb`
 
-- [ ] **Step 1: Build with Node.js 24**
+- [x] **Step 1: Build with Node.js 24**
 
-Run: `PATH="/home/user/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run build:linux:deb`
+Run: `node --version && npm run build:linux:deb`
 
-Expected: electron-builder creates `dist/Mineradio-1.1.1.deb`.
+Expected: Node.js reports v24.x and electron-builder creates `dist/Mineradio-1.1.1.deb`.
 
-- [ ] **Step 2: Validate metadata and package contents**
+- [x] **Step 2: Validate metadata and package contents**
 
 Run: `dpkg-deb -f dist/Mineradio-1.1.1.deb Package Version Architecture Maintainer`
 
@@ -83,31 +83,31 @@ Expected: package contains an application executable, `.desktop` entry, PNG icon
 - Verify unchanged: `~/.local/bin/Mineradio.AppImage`
 - Verify unchanged: `~/.local/share/applications/Mineradio.desktop`
 
-- [ ] **Step 1: Record AppImage baseline hashes**
+- [x] **Step 1: Record AppImage baseline hashes**
 
 Run: `sha256sum ~/.local/bin/Mineradio.AppImage ~/.local/share/applications/Mineradio.desktop`
 
 Expected: both files exist and produce hashes.
 
-- [ ] **Step 2: Install the Debian package**
+- [x] **Step 2: Install the Debian package**
 
 Run: `sudo apt install -y ./dist/Mineradio-1.1.1.deb`
 
 Expected: package `mineradio` is installed successfully.
 
-- [ ] **Step 3: Launch the installed executable under Xvfb**
+- [x] **Step 3: Launch the installed executable under Xvfb**
 
-Read the `Exec` value from `/usr/share/applications/Mineradio.desktop`, launch it under Xvfb, and poll `http://127.0.0.1:3000/api/app/version`.
+Read the `Exec` value from `/usr/share/applications/Mineradio.desktop`, launch it under Xvfb with an isolated `XDG_CONFIG_HOME`, and poll the first available local port. If the AppImage already uses 3000, the deb test instance uses 3001.
 
-Expected: endpoint reports Mineradio version `1.1.1`.
+Expected: the deb endpoint reports Mineradio version `1.1.1`, while the existing AppImage continues responding on its original port.
 
-- [ ] **Step 4: Remove the Debian package**
+- [x] **Step 4: Remove the Debian package**
 
 Run: `sudo apt remove -y mineradio`
 
 Expected: `dpkg-query` no longer reports the package as installed.
 
-- [ ] **Step 5: Verify the AppImage baseline is unchanged**
+- [x] **Step 5: Verify the AppImage baseline is unchanged**
 
 Run the same `sha256sum` command from Step 1 and compare exact output.
 
@@ -120,16 +120,16 @@ Expected: both hashes match the baseline.
 - Modify: `test/package-config.test.js`
 - Modify: PR #203 body
 
-- [ ] **Step 1: Review and commit the implementation**
+- [x] **Step 1: Review and commit the implementation**
 
 Run: `git diff --check && git status --short`
 
 Commit message: `build(linux): add Debian package target`
 
-- [ ] **Step 2: Push the existing feature branch**
+- [x] **Step 2: Push the existing feature branch**
 
 Run: `git push origin feat/linux-appimage-support`
 
-- [ ] **Step 3: Update the Chinese PR body**
+- [x] **Step 3: Update the Chinese PR body**
 
 Document `npm run build:linux:appimage`, `npm run build:linux:deb`, Debian metadata checks, actual installation, launch, removal, and AppImage hash preservation.

--- a/docs/superpowers/plans/2026-07-01-debian-package.md
+++ b/docs/superpowers/plans/2026-07-01-debian-package.md
@@ -1,0 +1,135 @@
+# Debian Package Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 为 Mineradio 增加独立的 x64 Debian 包构建命令，并完成不影响现有 AppImage 的真实安装验证。
+
+**Architecture:** 继续使用 electron-builder 的 Linux 配置，默认 target 保持 AppImage；通过独立 npm 脚本显式选择 deb。配置测试锁定命令和兼容边界，产物测试使用 Debian 原生工具与真实 apt 安装流程。
+
+**Tech Stack:** Node.js 24、npm、electron-builder、node:test、dpkg-deb、apt、Xvfb
+
+---
+
+### Task 1: Lock Debian Build Configuration
+
+**Files:**
+- Modify: `test/package-config.test.js`
+- Modify: `package.json`
+
+- [ ] **Step 1: Write the failing configuration test**
+
+Add assertions for these exact scripts and Linux fields:
+
+```js
+assert.equal(packageJson.scripts['build:linux'], 'npm run build:linux:appimage');
+assert.equal(packageJson.scripts['build:linux:appimage'], 'electron-builder --linux AppImage');
+assert.equal(packageJson.scripts['build:linux:deb'], 'electron-builder --linux deb');
+assert.match(packageJson.build.linux.maintainer, /^.+ <[^<>\s]+@[^<>\s]+>$/);
+assert.deepEqual(packageJson.build.linux.target, [{ target: 'AppImage', arch: ['x64'] }]);
+```
+
+- [ ] **Step 2: Run the test and verify RED**
+
+Run: `node --test test/package-config.test.js`
+
+Expected: FAIL because the explicit AppImage/deb scripts and maintainer are absent.
+
+- [ ] **Step 3: Add the minimal package configuration**
+
+Set the Linux scripts to:
+
+```json
+"build:linux": "npm run build:linux:appimage",
+"build:linux:appimage": "electron-builder --linux AppImage",
+"build:linux:deb": "electron-builder --linux deb"
+```
+
+Add this field under `build.linux`:
+
+```json
+"maintainer": "XxHuberrr <281847693+XxHuberrr@users.noreply.github.com>"
+```
+
+- [ ] **Step 4: Run the full test suite and syntax checks**
+
+Run: `npm test && node --check server.js && node --check desktop/main.js && git diff --check`
+
+Expected: all tests and checks pass.
+
+### Task 2: Build and Inspect the Debian Artifact
+
+**Files:**
+- Generated and ignored: `dist/Mineradio-1.1.1.deb`
+
+- [ ] **Step 1: Build with Node.js 24**
+
+Run: `PATH="/home/user/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin:$PATH" npm run build:linux:deb`
+
+Expected: electron-builder creates `dist/Mineradio-1.1.1.deb`.
+
+- [ ] **Step 2: Validate metadata and package contents**
+
+Run: `dpkg-deb -f dist/Mineradio-1.1.1.deb Package Version Architecture Maintainer`
+
+Expected: package `mineradio`, version `1.1.1`, architecture `amd64`, and a non-empty maintainer.
+
+Run: `dpkg-deb -c dist/Mineradio-1.1.1.deb`
+
+Expected: package contains an application executable, `.desktop` entry, PNG icon, and `resources/app/platform-utils.js`.
+
+### Task 3: Install, Launch, and Remove Without Touching AppImage
+
+**Files:**
+- Verify unchanged: `~/.local/bin/Mineradio.AppImage`
+- Verify unchanged: `~/.local/share/applications/Mineradio.desktop`
+
+- [ ] **Step 1: Record AppImage baseline hashes**
+
+Run: `sha256sum ~/.local/bin/Mineradio.AppImage ~/.local/share/applications/Mineradio.desktop`
+
+Expected: both files exist and produce hashes.
+
+- [ ] **Step 2: Install the Debian package**
+
+Run: `sudo apt install -y ./dist/Mineradio-1.1.1.deb`
+
+Expected: package `mineradio` is installed successfully.
+
+- [ ] **Step 3: Launch the installed executable under Xvfb**
+
+Read the `Exec` value from `/usr/share/applications/Mineradio.desktop`, launch it under Xvfb, and poll `http://127.0.0.1:3000/api/app/version`.
+
+Expected: endpoint reports Mineradio version `1.1.1`.
+
+- [ ] **Step 4: Remove the Debian package**
+
+Run: `sudo apt remove -y mineradio`
+
+Expected: `dpkg-query` no longer reports the package as installed.
+
+- [ ] **Step 5: Verify the AppImage baseline is unchanged**
+
+Run the same `sha256sum` command from Step 1 and compare exact output.
+
+Expected: both hashes match the baseline.
+
+### Task 4: Commit, Push, and Update PR #203
+
+**Files:**
+- Modify: `package.json`
+- Modify: `test/package-config.test.js`
+- Modify: PR #203 body
+
+- [ ] **Step 1: Review and commit the implementation**
+
+Run: `git diff --check && git status --short`
+
+Commit message: `build(linux): add Debian package target`
+
+- [ ] **Step 2: Push the existing feature branch**
+
+Run: `git push origin feat/linux-appimage-support`
+
+- [ ] **Step 3: Update the Chinese PR body**
+
+Document `npm run build:linux:appimage`, `npm run build:linux:deb`, Debian metadata checks, actual installation, launch, removal, and AppImage hash preservation.

--- a/docs/superpowers/specs/2026-07-01-debian-package-design.md
+++ b/docs/superpowers/specs/2026-07-01-debian-package-design.md
@@ -1,0 +1,42 @@
+# Debian Package Design
+
+## Goal
+
+在现有 Linux AppImage 支持上增加独立的 x64 Debian 包构建与真实安装测试，同时不改变现有 AppImage 的文件、菜单入口和默认构建行为。
+
+## Selected Approach
+
+- 保留 `npm run build:linux`，作为 AppImage 构建的兼容别名。
+- 新增 `npm run build:linux:appimage`，明确构建 AppImage。
+- 新增 `npm run build:linux:deb`，明确构建 Debian 包。
+- `build.linux.target` 继续只声明 AppImage，避免默认命令同时生成两种格式。
+- 在 Linux 构建配置中提供 Debian 必需的维护者姓名与电子邮箱。
+
+未采用通用的 `npm run build:linux -- <target>`，因为专用脚本更易发现、审阅和在 CI 中使用。未采用手写 `dpkg-deb` 或 `fpm`，因为 electron-builder 已能复用当前应用文件、图标和桌面元数据。
+
+## Automated Tests
+
+扩展 `test/package-config.test.js`，验证：
+
+- `build:linux` 仍指向 AppImage 构建。
+- `build:linux:appimage` 和 `build:linux:deb` 均存在且目标明确。
+- 默认 Linux target 仍只有 AppImage x64。
+- Debian 维护者字段包含有效的姓名和电子邮箱格式。
+
+## Package Verification
+
+使用 Node.js 24 执行 `npm run build:linux:deb`，然后通过 `dpkg-deb` 检查包名、版本、架构、维护者、桌面入口、图标和应用可执行文件。
+
+## Installation Verification
+
+1. 记录 `~/.local/bin/Mineradio.AppImage` 与 `~/.local/share/applications/Mineradio.desktop` 的 SHA-256。
+2. 使用 apt 安装新生成的 deb。
+3. 从系统安装路径启动 Mineradio，并验证本地版本接口可用。
+4. 卸载 deb，不执行 `autoremove`。
+5. 再次核对 AppImage 和用户级桌面入口 SHA-256，确认二者未被修改。
+
+## Scope
+
+- 只支持当前 Linux x64 架构。
+- 不修改应用 UI、播放逻辑或 Windows 配置。
+- 不发布 Release 资产；本轮只构建、测试、提交并更新现有 PR。

--- a/docs/superpowers/specs/2026-07-01-debian-package-design.md
+++ b/docs/superpowers/specs/2026-07-01-debian-package-design.md
@@ -6,9 +6,10 @@
 
 ## Selected Approach
 
-- 保留 `npm run build:linux`，作为 AppImage 构建的兼容别名。
-- 新增 `npm run build:linux:appimage`，明确构建 AppImage。
-- 新增 `npm run build:linux:deb`，明确构建 Debian 包。
+- 保留 `npm run build:linux`，作为 x64 AppImage 构建的兼容命令。
+- 新增 `npm run build:linux:appimage`，明确构建 x64 AppImage。
+- 新增 `npm run build:linux:deb`，明确构建 x64 Debian 包。
+- 三个命令都显式传入 `--x64`，不依赖构建机的 CPU 架构。
 - `build.linux.target` 继续只声明 AppImage，避免默认命令同时生成两种格式。
 - 在 Linux 构建配置中提供 Debian 必需的维护者姓名与电子邮箱。
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,14 @@
   "version": "1.1.1",
   "description": "沉浸式音乐播放器，融合天气电台、歌词舞台、粒子视觉和 3D 歌单架。",
   "author": "Mineradio",
+  "desktopName": "Mineradio.desktop",
   "main": "desktop/main.js",
   "private": true,
   "scripts": {
     "start": "electron .",
+    "test": "node --test test/*.test.js",
+    "build:linux": "electron-builder --linux AppImage",
+    "build:linux:dir": "electron-builder --linux dir",
     "build:win": "electron-builder --win nsis",
     "build:win:dir": "electron-builder --win dir"
   },
@@ -28,6 +32,7 @@
       "build/**/*",
       "server.js",
       "dj-analyzer.js",
+      "platform-utils.js",
       "package.json",
       "!public/index.*.html",
       "public/index.html"
@@ -40,6 +45,21 @@
       "target": [
         {
           "target": "nsis",
+          "arch": [
+            "x64"
+          ]
+        }
+      ]
+    },
+    "linux": {
+      "executableName": "Mineradio",
+      "icon": "build/icon.png",
+      "category": "AudioVideo",
+      "artifactName": "Mineradio-${version}.${ext}",
+      "syncDesktopName": true,
+      "target": [
+        {
+          "target": "AppImage",
           "arch": [
             "x64"
           ]

--- a/package.json
+++ b/package.json
@@ -4,13 +4,16 @@
   "version": "1.1.1",
   "description": "沉浸式音乐播放器，融合天气电台、歌词舞台、粒子视觉和 3D 歌单架。",
   "author": "Mineradio",
+  "homepage": "https://github.com/XxHuberrr/Mineradio",
   "desktopName": "Mineradio.desktop",
   "main": "desktop/main.js",
   "private": true,
   "scripts": {
     "start": "electron .",
     "test": "node --test test/*.test.js",
-    "build:linux": "electron-builder --linux AppImage",
+    "build:linux": "electron-builder --linux AppImage --x64",
+    "build:linux:appimage": "electron-builder --linux AppImage --x64",
+    "build:linux:deb": "electron-builder --linux deb --x64",
     "build:linux:dir": "electron-builder --linux dir",
     "build:win": "electron-builder --win nsis",
     "build:win:dir": "electron-builder --win dir"
@@ -56,6 +59,7 @@
       "icon": "build/icon.png",
       "category": "AudioVideo",
       "artifactName": "Mineradio-${version}.${ext}",
+      "maintainer": "XxHuberrr <281847693+XxHuberrr@users.noreply.github.com>",
       "syncDesktopName": true,
       "target": [
         {

--- a/platform-utils.js
+++ b/platform-utils.js
@@ -1,0 +1,88 @@
+const os = require('os');
+const path = require('path');
+
+function normalizePlatform(platform) {
+  return platform || process.platform;
+}
+
+function getReleaseAssetPatterns(platform) {
+  switch (normalizePlatform(platform)) {
+    case 'linux':
+      return [/\.(AppImage)$/i, /\.(deb)$/i, /\.(rpm)$/i, /\.(tar\.gz|zip|7z)$/i];
+    case 'win32':
+    default:
+      return [/\.(exe|msi)$/i, /\.(zip|7z)$/i];
+  }
+}
+
+function getPreferredReleaseAsset(assets, platform) {
+  const list = Array.isArray(assets) ? assets : [];
+  const patterns = getReleaseAssetPatterns(platform);
+  for (const pattern of patterns) {
+    const hit = list.find((asset) => pattern.test(asset && asset.name || ''));
+    if (hit) return hit;
+  }
+  return list[0] || null;
+}
+
+function getDefaultUpdateAssetName(version, platform) {
+  const normalized = String(version || '').trim() || '0.0.0';
+  switch (normalizePlatform(platform)) {
+    case 'linux':
+      return `Mineradio-${normalized}.AppImage`;
+    case 'win32':
+    default:
+      return `Mineradio-${normalized}-Setup.exe`;
+  }
+}
+
+function getDefaultBeatMapCacheDir(platform, homeDir = os.homedir()) {
+  switch (normalizePlatform(platform)) {
+    case 'linux':
+      return path.join(homeDir, '.cache', 'Mineradio', 'beatmaps');
+    case 'win32':
+    default:
+      return 'D:\\MineradioCache\\beatmaps';
+  }
+}
+
+function getChromiumPerformanceSwitches(platform) {
+  const base = [
+    ['autoplay-policy', 'no-user-gesture-required'],
+    ['ignore-gpu-blocklist'],
+    ['enable-gpu-rasterization'],
+    ['enable-oop-rasterization'],
+    ['enable-zero-copy'],
+    ['enable-accelerated-2d-canvas'],
+    ['disable-background-timer-throttling'],
+    ['disable-renderer-backgrounding'],
+    ['disable-backgrounding-occluded-windows'],
+  ];
+
+  if (normalizePlatform(platform) !== 'linux') {
+    base.push(['force_high_performance_gpu']);
+    base.push(['use-angle', 'd3d11']);
+  }
+
+  return base;
+}
+
+function getAppIconPath(buildDir, platform) {
+  const iconName = normalizePlatform(platform) === 'linux' ? 'icon.png' : 'icon.ico';
+  return path.join(buildDir, iconName);
+}
+
+function getUpdateOpenStrategy(target, platform) {
+  return normalizePlatform(platform) === 'linux' && /\.AppImage$/i.test(String(target || ''))
+    ? 'relaunch'
+    : 'open';
+}
+
+module.exports = {
+  getPreferredReleaseAsset,
+  getDefaultUpdateAssetName,
+  getDefaultBeatMapCacheDir,
+  getChromiumPerformanceSwitches,
+  getAppIconPath,
+  getUpdateOpenStrategy,
+};

--- a/server.js
+++ b/server.js
@@ -53,6 +53,11 @@ const tls = require('tls');
 const { once } = require('events');
 const { fileURLToPath } = require('url');
 const { analyzePodcastDjStream, analyzePodcastDjIntro } = require('./dj-analyzer');
+const {
+  getPreferredReleaseAsset,
+  getDefaultUpdateAssetName,
+  getDefaultBeatMapCacheDir,
+} = require('./platform-utils');
 
 const PORT = process.env.PORT || 3000;
 const HOST = process.env.HOST || '0.0.0.0';
@@ -62,7 +67,7 @@ const QQ_COOKIE_FILE = process.env.QQ_COOKIE_FILE || path.join(__dirname, '.qq-c
 const UPDATE_WORK_DIR = process.env.MINERADIO_UPDATE_DIR || path.join(__dirname, 'updates');
 const UPDATE_DOWNLOAD_DIR = process.env.MINERADIO_UPDATE_DOWNLOAD_DIR || path.join(UPDATE_WORK_DIR, 'downloads');
 const UPDATE_PATCH_BACKUP_DIR = process.env.MINERADIO_PATCH_BACKUP_DIR || path.join(UPDATE_WORK_DIR, 'backups', 'patches');
-const BEATMAP_CACHE_DIR = process.env.MINERADIO_BEAT_CACHE_DIR || 'D:\\MineradioCache\\beatmaps';
+const BEATMAP_CACHE_DIR = process.env.MINERADIO_BEAT_CACHE_DIR || getDefaultBeatMapCacheDir(process.platform);
 const APP_PACKAGE = readPackageInfo();
 const APP_VERSION = process.env.MINERADIO_VERSION || APP_PACKAGE.version || '0.9.11';
 const UPDATE_CONFIG = readUpdateConfig(APP_PACKAGE);
@@ -364,9 +369,7 @@ function extractReleaseNotes(body) {
 }
 function pickReleaseAsset(assets) {
   const list = Array.isArray(assets) ? assets : [];
-  const preferred = list.find(a => /\.(exe|msi)$/i.test(a && a.name || ''))
-    || list.find(a => /\.(zip|7z)$/i.test(a && a.name || ''))
-    || list[0];
+  const preferred = getPreferredReleaseAsset(list, process.platform);
   if (!preferred) return null;
   const digest = assetDigestInfo(preferred);
   const candidates = uniqueDownloadCandidates(preferred.browser_download_url || '');
@@ -453,7 +456,7 @@ function normalizeManifestUpdateInfo(data) {
     ? release.notes.slice(0, 4).map(cleanReleaseLine).filter(Boolean)
     : (extractReleaseNotes(release.body || data.body).length ? extractReleaseNotes(release.body || data.body) : UPDATE_FALLBACK_NOTES);
   const assetInfo = downloadUrl ? {
-    name: asset.name || updateAssetNameFromUrl(downloadUrl) || `Mineradio-${latestVersion}-Setup.exe`,
+    name: asset.name || updateAssetNameFromUrl(downloadUrl) || getDefaultUpdateAssetName(latestVersion, process.platform),
     size: Number(asset.size || 0) || 0,
     contentType: asset.contentType || asset.content_type || '',
     downloadUrl,
@@ -508,7 +511,9 @@ function beatCacheRootInfo() {
   const dir = path.resolve(BEATMAP_CACHE_DIR);
   const root = path.parse(dir).root;
   const drive = root ? root.replace(/[\\\/]+$/, '').toUpperCase() : '';
-  const allowed = !!root && !/^C:$/i.test(drive);
+  const allowed = process.platform === 'win32'
+    ? (!!root && !/^C:$/i.test(drive))
+    : path.isAbsolute(dir);
   const available = allowed && fs.existsSync(root);
   return { dir, root, drive, allowed, available };
 }
@@ -667,7 +672,7 @@ function githubReleaseDownloadUrl(version, fileName) {
 }
 function parseLatestYmlUpdateInfo(text, reason) {
   const latestVersion = normalizeVersion(yamlScalar(text, 'version') || APP_VERSION) || APP_VERSION;
-  const assetPath = yamlScalar(text, 'path') || yamlScalar(text, 'url') || `Mineradio-${latestVersion}-Setup.exe`;
+  const assetPath = yamlScalar(text, 'path') || yamlScalar(text, 'url') || getDefaultUpdateAssetName(latestVersion, process.platform);
   const sha512 = normalizeDigest(yamlScalar(text, 'sha512'), 'sha512');
   const size = Number(yamlScalar(text, 'size') || 0) || 0;
   const releaseDate = yamlScalar(text, 'releaseDate');
@@ -706,6 +711,7 @@ function parseLatestYmlUpdateInfo(text, reason) {
   };
 }
 async function fetchLatestYmlUpdateInfo(reason) {
+  if (process.platform !== 'win32') throw updateError('LATEST_YML_UNSUPPORTED_PLATFORM');
   if (!UPDATE_CONFIG.configured || UPDATE_CONFIG.provider !== 'github') throw updateError('UPDATE_REPOSITORY_NOT_CONFIGURED');
   const latestYmlUrl = `https://github.com/${encodeURIComponent(UPDATE_CONFIG.owner)}/${encodeURIComponent(UPDATE_CONFIG.repo)}/releases/latest/download/latest.yml`;
   const candidates = uniqueDownloadCandidates(latestYmlUrl);
@@ -764,13 +770,13 @@ async function fetchLatestUpdateInfo() {
   }
 }
 function safeUpdateFileName(name, version) {
-  const raw = String(name || '').trim() || `Mineradio-${version || APP_VERSION}.exe`;
+  const raw = String(name || '').trim() || getDefaultUpdateAssetName(version || APP_VERSION, process.platform);
   const cleaned = raw
     .replace(/[<>:"/\\|?*\x00-\x1F]/g, '-')
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, 160);
-  return cleaned || `Mineradio-${version || APP_VERSION}.exe`;
+  return cleaned || getDefaultUpdateAssetName(version || APP_VERSION, process.platform);
 }
 function publicUpdateJob(job) {
   if (!job) return { ok: false, error: 'UPDATE_JOB_NOT_FOUND' };

--- a/test/package-config.test.js
+++ b/test/package-config.test.js
@@ -9,3 +9,14 @@ test('package build files include platform utility module used at runtime', () =
 
   assert.equal(files.includes('platform-utils.js'), true);
 });
+
+test('provides explicit AppImage and Debian build commands without changing the default target', () => {
+  assert.equal(packageJson.homepage, 'https://github.com/XxHuberrr/Mineradio');
+  assert.equal(packageJson.scripts['build:linux'], 'electron-builder --linux AppImage --x64');
+  assert.equal(packageJson.scripts['build:linux:appimage'], 'electron-builder --linux AppImage --x64');
+  assert.equal(packageJson.scripts['build:linux:deb'], 'electron-builder --linux deb --x64');
+  assert.match(packageJson.build.linux.maintainer, /^.+ <[^<>\s]+@[^<>\s]+>$/);
+  assert.deepEqual(packageJson.build.linux.target, [
+    { target: 'AppImage', arch: ['x64'] },
+  ]);
+});

--- a/test/package-config.test.js
+++ b/test/package-config.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const packageJson = require('../package.json');
+
+test('package build files include platform utility module used at runtime', () => {
+  const files = Array.isArray(packageJson.build && packageJson.build.files)
+    ? packageJson.build.files
+    : [];
+
+  assert.equal(files.includes('platform-utils.js'), true);
+});

--- a/test/platform-utils.test.js
+++ b/test/platform-utils.test.js
@@ -1,0 +1,67 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  getPreferredReleaseAsset,
+  getDefaultUpdateAssetName,
+  getDefaultBeatMapCacheDir,
+  getChromiumPerformanceSwitches,
+  getAppIconPath,
+  getUpdateOpenStrategy,
+} = require('../platform-utils');
+
+test('prefers AppImage assets on Linux releases', () => {
+  const asset = getPreferredReleaseAsset([
+    { name: 'Mineradio-1.1.1-Setup.exe', browser_download_url: 'https://example.com/setup.exe' },
+    { name: 'Mineradio-1.1.1.AppImage', browser_download_url: 'https://example.com/appimage' },
+  ], 'linux');
+
+  assert.equal(asset.name, 'Mineradio-1.1.1.AppImage');
+});
+
+test('prefers Windows installer assets on Windows releases', () => {
+  const asset = getPreferredReleaseAsset([
+    { name: 'Mineradio-1.1.1.AppImage', browser_download_url: 'https://example.com/appimage' },
+    { name: 'Mineradio-1.1.1-Setup.exe', browser_download_url: 'https://example.com/setup.exe' },
+  ], 'win32');
+
+  assert.equal(asset.name, 'Mineradio-1.1.1-Setup.exe');
+});
+
+test('uses Linux-friendly default update asset names', () => {
+  assert.equal(getDefaultUpdateAssetName('1.1.1', 'linux'), 'Mineradio-1.1.1.AppImage');
+  assert.equal(getDefaultUpdateAssetName('1.1.1', 'win32'), 'Mineradio-1.1.1-Setup.exe');
+});
+
+test('limits platform behavior changes to Linux', () => {
+  assert.equal(getDefaultUpdateAssetName('1.1.1', 'darwin'), 'Mineradio-1.1.1-Setup.exe');
+  assert.equal(getDefaultBeatMapCacheDir('darwin'), 'D:\\MineradioCache\\beatmaps');
+  assert.equal(getAppIconPath('/repo/build', 'darwin'), '/repo/build/icon.ico');
+  assert.equal(
+    getChromiumPerformanceSwitches('darwin').some(([name, value]) => name === 'use-angle' && value === 'd3d11'),
+    true
+  );
+});
+
+test('uses Linux cache path under the user cache directory', () => {
+  const dir = getDefaultBeatMapCacheDir('linux', '/home/tester');
+  assert.equal(dir, '/home/tester/.cache/Mineradio/beatmaps');
+});
+
+test('uses platform-appropriate Chromium switches', () => {
+  const linuxSwitches = getChromiumPerformanceSwitches('linux');
+  const winSwitches = getChromiumPerformanceSwitches('win32');
+
+  assert.equal(linuxSwitches.some(([name, value]) => name === 'use-angle' && value === 'd3d11'), false);
+  assert.equal(winSwitches.some(([name, value]) => name === 'use-angle' && value === 'd3d11'), true);
+});
+
+test('uses PNG icon on Linux and ICO on Windows', () => {
+  assert.equal(getAppIconPath('/repo/build', 'linux'), '/repo/build/icon.png');
+  assert.equal(getAppIconPath('/repo/build', 'win32'), '/repo/build/icon.ico');
+});
+
+test('relaunches Linux AppImage updates after the current instance exits', () => {
+  assert.equal(getUpdateOpenStrategy('/tmp/Mineradio-1.2.0.AppImage', 'linux'), 'relaunch');
+  assert.equal(getUpdateOpenStrategy('/tmp/Mineradio-1.2.0.exe', 'win32'), 'open');
+});


### PR DESCRIPTION
## 合并结论

**状态：Linux x64 AppImage 与 Debian 包均已完成构建和实机测试；在本 PR 范围内功能完整、运行正常，可以直接使用。**

本 PR 以隔离的平台配置补齐 Linux 桌面发行能力，不改动主界面、视觉系统和播放逻辑，并保留原有 Windows 行为。

## 主要改动

- 新增 Linux x64 AppImage 构建配置、PNG 图标和桌面应用元数据。
- 新增 x64 Debian 包构建命令、项目主页和维护者元数据。
- 新增独立的 `platform-utils.js`，集中处理安装包选择、缓存目录、更新文件名、图标和 Chromium 参数。
- Linux 更新时优先选择 `.AppImage`，并在退出当前单实例后启动已下载的新版本。
- 新增平台行为及打包配置测试，防止 Linux 适配影响 Windows 或改变默认 AppImage target。

## 构建命令

已使用 Node.js 24.14.0 完成验证，建议使用 Node.js 24。

```bash
# 安装依赖并运行测试
npm ci
npm test

# 兼容命令：构建 x64 AppImage
npm run build:linux

# 显式构建 x64 AppImage
npm run build:linux:appimage

# 显式构建 x64 Debian 包
npm run build:linux:deb
```

生成文件：

```text
dist/Mineradio-1.1.1.AppImage
dist/Mineradio-1.1.1.deb
```

## 安装与运行

AppImage：

```bash
chmod +x dist/Mineradio-1.1.1.AppImage
./dist/Mineradio-1.1.1.AppImage
```

如果系统无法通过 FUSE 挂载 AppImage：

```bash
APPIMAGE_EXTRACT_AND_RUN=1 ./dist/Mineradio-1.1.1.AppImage
```

Debian/Ubuntu：

```bash
sudo apt install -y ./dist/Mineradio-1.1.1.deb
/usr/bin/Mineradio

# 卸载
sudo apt remove -y mineradio
```

## 验证结果

- `npm test`：10/10 通过。
- `node --check desktop/main.js`：通过。
- `node --check server.js`：通过。
- `git diff --check`：通过。
- `npm run build:linux`：成功生成 x86-64 AppImage。
- `npm run build:linux:deb`：成功生成 `mineradio 1.1.1 amd64` Debian 包。
- deb 控制字段已验证：`Package`、`Version`、`Architecture`、`Maintainer`、`Homepage` 均正确。
- deb 内容已验证：主程序、桌面入口、PNG 图标和 `resources/app/platform-utils.js` 均存在。
- deb 已通过真实 `apt install` 安装，系统正确注册 `/usr/bin/Mineradio`、`/opt/Mineradio`、菜单和图标。
- 已从 `/opt/Mineradio/Mineradio` 启动 deb 实例并验证 `/api/app/version` 正确返回 1.1.1。
- 测试时现有 AppImage 持续在原端口运行，deb 使用隔离配置和独立端口，两者互不干扰。
- deb 已成功卸载，系统安装文件已清除；现有 AppImage 与用户菜单文件前后 SHA-256 完全一致，且仍可正常运行。
- 独立代码复审未发现 blocking 或 important 问题。

## 变更边界

- 未修改 `public/index.html`，不涉及 UI、视觉效果或播放逻辑重构。
- `build.linux.target` 仍只包含 AppImage；deb 仅由 `build:linux:deb` 显式构建。
- 三个 Linux 构建命令均显式固定 `--x64`，不依赖构建机架构。
- Windows 行为由平台分支和回归测试保持不变。
- macOS 不在本 PR 范围内。
- 受当前 Linux 环境限制，本次未执行 Windows NSIS 安装包构建。

## 建议审阅重点

1. `package.json` 中 AppImage/deb 命令、Linux 元数据及默认 target 是否符合发布策略。
2. `platform-utils.js` 的 Linux/Windows 分支是否符合现有更新和缓存约束。
3. `desktop/main.js` 中 Linux AppImage 更新后的重启流程。
4. `test/` 中对 x64 构建命令、Windows 兼容和运行时文件完整性的回归保护。
