### PR TITLE
feat: 集成 Spotify Web Playback SDK 支持跨国曲库 (v1.2.0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ tmp/
 *.png.tmp
 verification/
 screenshots/
+
+.env
+.spotify-token

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-## v1.1.1
+## v1.2.0
+
+- 新增 Spotify 官方 Web Playback SDK 集成，支持跨国曲库。
+- 在个人中心增加 Spotify 登录按钮，支持 OAuth2.0 授权。
+- 搜索区支持切换至 Spotify 曲库进行搜索。
+- 支持 Spotify Premium 账号直接在播放器内播放完整歌曲。
+- 播放 Spotify 歌曲时自动进入纯净模式（隐藏 3D 粒子），保证客户端流畅稳定。
+- 新增支持从根目录读取 `.env` 环境变量文件。## v1.1.1
 
 - P0 installer safety fix: installation now defaults to the first available non-C drive from `D:\Mineradio` through `Z:\Mineradio`; it falls back to `C:\Mineradio` only when no D-Z drive exists.
 - The installer now forces the target path into a dedicated `Mineradio` folder, blocks non-empty non-Mineradio-owned targets, and blocks C drive installs when a D-Z drive is available.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mineradio",
   "productName": "Mineradio",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "沉浸式音乐播放器，融合天气电台、歌词舞台、粒子视觉和 3D 歌单架。",
   "author": "Mineradio",
   "main": "desktop/main.js",

--- a/public/index.html
+++ b/public/index.html
@@ -23901,6 +23901,7 @@ window.onSpotifyWebPlaybackSDKReady = function() {
         volume: 0.8
       });
       spotifyLoginStatus.loggedIn = true;
+      refreshUserPlaylists(true);
       spotifyPlayer.addListener('ready', function(obj) {
         spotifyDeviceId = obj.device_id;
         console.log('Spotify Ready with Device ID', obj.device_id);

--- a/public/index.html
+++ b/public/index.html
@@ -18536,12 +18536,25 @@ async function playQueueAt(idx, opts) {
           method: 'PUT',
           body: JSON.stringify({ uris: ['spotify:track:' + song.id] }),
           headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + r.token }
-        }).then(function(){
+        }).then(async function(resp){
+          if (!resp.ok) {
+            var errText = '';
+            try { var j = await resp.json(); errText = j.error && j.error.message ? j.error.message : ''; } catch(e){}
+            if (resp.status === 403) showToast('Spotify 播放失败 (可能需要 Premium): ' + errText);
+            else if (resp.status === 404) showToast('Spotify 播放失败 (找不到设备): ' + errText);
+            else showToast('Spotify 播放失败: ' + resp.status + ' ' + errText);
+            setPlayIcon(false);
+            hideLoading();
+            return;
+          }
           if (audio) { audio.pause(); audio.src = ''; }
           playing = true;
           setPlayIcon(true);
           if (typeof forceLoadingSettled === 'function') forceLoadingSettled('spotify');
           if (typeof tweenParticleAlpha === 'function') tweenParticleAlpha(uniforms.uAlpha.value || 0, 0.05, 300);
+          hideLoading();
+        }).catch(function(e){
+          showToast('Spotify 播放请求异常');
           hideLoading();
         });
       });

--- a/public/index.html
+++ b/public/index.html
@@ -2808,6 +2808,8 @@ var miniQueueRenderSeq = 0, queueRenderSeq = 0, playlistRenderSeq = 0;
 var queuePanelDirty = false;
 var PLAYLIST_PANEL_BATCH_SIZE = 28;
 var playlistPanelRenderLimit = PLAYLIST_PANEL_BATCH_SIZE;
+var QUEUE_RENDER_BATCH = 150;
+var queueRenderLimit = QUEUE_RENDER_BATCH;
 var playlistPanelLazyBound = false;
 var PLAYLIST_DETAIL_INITIAL_RENDER = 64;
 var PLAYLIST_DETAIL_BATCH_SIZE = 48;
@@ -19524,7 +19526,9 @@ function renderQueuePanel(opts) {
     if (panel && (panel.classList.contains('show') || panel.classList.contains('peek')) && queueViewTab === 'queue') switchPlaylistTab('playlists');
     return;
   }
-  $ql.innerHTML = playQueue.map(function(song, i){
+  queueRenderLimit = Math.max(queueRenderLimit || QUEUE_RENDER_BATCH, (currentIdx || 0) + 50);
+  var renderSongs = playQueue.slice(0, queueRenderLimit);
+  $ql.innerHTML = renderSongs.map(function(song, i){
     var thumb = songCoverSrc(song, 60);
     var imgTag = thumb ? '<img src="' + thumb + '" alt="" loading="lazy" decoding="async" onerror="this.style.opacity=0.2">' : '<div style="width:38px;height:38px;border-radius:6px;background:rgba(255,255,255,.06);flex-shrink:0"></div>';
     return '<div class="queue-item' + (i === currentIdx ? ' now' : '') + '" onclick="playQueueAt(' + i + ')">' +
@@ -19754,6 +19758,12 @@ function bindPlaylistPanelLazyRender() {
   playlistPanelLazyBound = true;
   panel.addEventListener('scroll', function(){
     maybeGrowPlaylistPanelDetailRenderLimit();
+    if (queueViewTab === 'queue' && queueRenderLimit < playQueue.length && panel.scrollTop + panel.clientHeight >= panel.scrollHeight - 240) {
+      queueRenderLimit += QUEUE_RENDER_BATCH;
+      var keepTop = panel.scrollTop;
+      renderQueuePanel({ animate: false });
+      panel.scrollTop = keepTop;
+    }
     if (queueViewTab !== 'playlists' || playlistPanelRenderLimit >= userPlaylists.length) return;
     if (panel.scrollTop + panel.clientHeight >= panel.scrollHeight - 180) growPlaylistPanelRenderLimit();
   }, { passive: true });

--- a/public/index.html
+++ b/public/index.html
@@ -18527,7 +18527,11 @@ async function playQueueAt(idx, opts) {
     var isSpotifyPlayback = song.source === 'spotify' || song.type === 'spotify';
     if (isSpotifyPlayback) {
       if (!spotifyPlayer || !spotifyDeviceId) {
-        showToast('请先登录 Spotify 并等待加载完成');
+        if (spotifyLoginStatus && spotifyLoginStatus.loggedIn && spotifyPlayer) {
+          showToast('Spotify 播放引擎未就绪 (可能是非 Premium 账号被限制)');
+        } else {
+          showToast('请先登录 Spotify 并等待加载完成');
+        }
         return;
       }
       apiJson('/api/spotify/status').then(function(r) {
@@ -20015,11 +20019,23 @@ function playbackDurationFromSong(song) {
   if (!song) return 0;
   return normalizePlaybackDurationSeconds(song.duration || song.durationMs || song.dt || 0);
 }
+var spotifyPlaybackState = null;
 function getPlaybackDurationSeconds() {
+  if (playQueue[currentIdx] && (playQueue[currentIdx].source === 'spotify' || playQueue[currentIdx].type === 'spotify')) {
+    if (spotifyPlaybackState && spotifyPlaybackState.duration) return spotifyPlaybackState.duration / 1000;
+  }
   if (audio && isFinite(audio.duration) && audio.duration > 0) return audio.duration;
   return playbackDurationFromSong(currentCoverSong());
 }
 function getPlaybackCurrentSeconds() {
+  if (playQueue[currentIdx] && (playQueue[currentIdx].source === 'spotify' || playQueue[currentIdx].type === 'spotify')) {
+    if (spotifyPlaybackState) {
+      var ms = spotifyPlaybackState.position;
+      if (!spotifyPlaybackState.paused) ms += (performance.now() - spotifyPlaybackState.updatedAt);
+      return Math.max(0, ms / 1000);
+    }
+    return 0;
+  }
   return audio && isFinite(audio.currentTime) && audio.currentTime > 0 ? audio.currentTime : 0;
 }
 function setProgressVisual(percent) {
@@ -23934,6 +23950,12 @@ window.onSpotifyWebPlaybackSDKReady = function() {
       spotifyPlayer.addListener('player_state_changed', function(state) {
         if (!state) return;
         isSpotifyPlaying = !state.paused;
+        spotifyPlaybackState = {
+          position: state.position,
+          duration: state.duration,
+          paused: state.paused,
+          updatedAt: performance.now()
+        };
       });
       spotifyPlayer.connect();
     }

--- a/public/index.html
+++ b/public/index.html
@@ -19710,6 +19710,7 @@ function playPlaylistPanelDetailTrack(index) {
   if (!tracks[index]) return;
   playQueue = tracks.map(cloneSong);
   currentIdx = index;
+  queueRenderLimit = Math.max(QUEUE_RENDER_BATCH, index + 50);
   safeRenderQueuePanel('playlist-panel-detail');
   safeSwitchPlaylistTab('queue', 'playlist-panel-detail');
   safeShelfRebuild('playlist-panel-detail', true);
@@ -19756,13 +19757,20 @@ function bindPlaylistPanelLazyRender() {
   var panel = document.getElementById('playlist-panel');
   if (!panel || playlistPanelLazyBound) return;
   playlistPanelLazyBound = true;
+  var _queueLazyBusy = false;
   panel.addEventListener('scroll', function(){
     maybeGrowPlaylistPanelDetailRenderLimit();
-    if (queueViewTab === 'queue' && queueRenderLimit < playQueue.length && panel.scrollTop + panel.clientHeight >= panel.scrollHeight - 240) {
+    if (queueViewTab === 'queue' && !_queueLazyBusy && queueRenderLimit < playQueue.length && panel.scrollTop + panel.clientHeight >= panel.scrollHeight - 300) {
+      _queueLazyBusy = true;
       queueRenderLimit += QUEUE_RENDER_BATCH;
       var keepTop = panel.scrollTop;
-      renderQueuePanel({ animate: false });
-      panel.scrollTop = keepTop;
+      requestAnimationFrame(function() {
+        renderQueuePanel({ animate: false });
+        requestAnimationFrame(function() {
+          panel.scrollTop = keepTop;
+          _queueLazyBusy = false;
+        });
+      });
     }
     if (queueViewTab !== 'playlists' || playlistPanelRenderLimit >= userPlaylists.length) return;
     if (panel.scrollTop + panel.clientHeight >= panel.scrollHeight - 180) growPlaylistPanelRenderLimit();
@@ -20001,6 +20009,7 @@ async function loadPlaylistIntoQueueById(id, autoplay, title) {
     if (!qqPlaylistId && isLikedPlaylistContext(id, title, r.playlist)) markSongsLiked(playQueue, true);
     if (!qqPlaylistId) syncLikeStatusForSongs(playQueue);
     currentIdx = 0;
+    queueRenderLimit = QUEUE_RENDER_BATCH;
     safeRenderQueuePanel('playlist-load');
     safeSwitchPlaylistTab('queue', 'playlist-load');
     safeShelfRebuild('playlist-load', true);

--- a/public/index.html
+++ b/public/index.html
@@ -19519,7 +19519,7 @@ function renderQueuePanel(opts) {
   renderMiniQueuePanel({ scrollCurrent: miniQueueOpen });
 }
 async function refreshUserPlaylists(force) {
-  if (!loginStatus.loggedIn && !qqLoginStatus.loggedIn) {
+  if (!loginStatus.loggedIn && !qqLoginStatus.loggedIn && !spotifyLoginStatus.loggedIn) {
     resetPlaylistPanelRenderLimit();
     document.getElementById('pl-list').innerHTML = '<div style="text-align:center;padding:24px 0;color:rgba(255,255,255,.32);font-size:11.5px">登录后显示个人歌单</div>';
     var podcastListLoggedOut = document.getElementById('podcast-list');
@@ -19546,11 +19546,13 @@ async function refreshUserPlaylists(force) {
     var result = await Promise.all([
       loginStatus.loggedIn ? apiJson('/api/user/playlists') : Promise.resolve({ playlists: [] }),
       loginStatus.loggedIn ? apiJson('/api/podcast/my') : Promise.resolve({ collections: [], loggedIn: false }),
-      qqLoginStatus.loggedIn ? apiJson('/api/qq/user/playlists') : Promise.resolve({ playlists: [] })
+      qqLoginStatus.loggedIn ? apiJson('/api/qq/user/playlists') : Promise.resolve({ playlists: [] }),
+      spotifyLoginStatus.loggedIn ? apiJson('/api/spotify/playlists') : Promise.resolve({ playlists: [] })
     ]);
     var neteaseLists = (result[0].playlists || []).map(function(pl){ pl.provider = 'netease'; pl.source = 'netease'; return pl; });
     qqPlaylists = (result[2].playlists || []).map(function(pl){ pl.provider = 'qq'; pl.source = 'qq'; return pl; });
-    userPlaylists = neteaseLists.concat(qqPlaylists);
+    var spotifyLists = (result[3].playlists || []).map(function(pl){ pl.provider = 'spotify'; pl.source = 'spotify'; return pl; });
+    userPlaylists = neteaseLists.concat(qqPlaylists).concat(spotifyLists);
     myPodcastCollections = result[1].collections || [];
     var animatePanel = isPlaylistPanelVisibleForRender();
     renderUserPlaylistsList({ animate: animatePanel, reset: true });
@@ -19561,9 +19563,11 @@ async function refreshUserPlaylists(force) {
 }
 var playlistPanelDetailState = { key: '', loading: false, playlist: null, tracks: [], token: 0, renderLimit: PLAYLIST_DETAIL_INITIAL_RENDER };
 function playlistPanelKey(provider, id) {
+  if (provider === 'spotify') return 'spotify:' + String(id || '');
   return (provider === 'qq' ? 'qq' : 'netease') + ':' + String(id || '');
 }
 function playlistPanelProviderId(provider, id) {
+  if (provider === 'spotify') return 'spotify:' + id;
   return provider === 'qq' ? ('qq:' + id) : id;
 }
 function playlistPanelDetailHtml(pl, provider) {
@@ -19631,9 +19635,9 @@ function scrollPlaylistPanelDetailIntoView(key) {
 }
 async function openPlaylistPanelDetail(provider, pid, title) {
   if (!pid) return;
-  provider = provider === 'qq' ? 'qq' : 'netease';
+  if (provider !== 'qq' && provider !== 'spotify') provider = 'netease';
   var key = playlistPanelKey(provider, pid);
-  var pl = userPlaylists.find(function(item){ return playlistPanelKey(item.provider === 'qq' ? 'qq' : 'netease', item.id) === key; }) || { id: pid, provider: provider, name: title || '歌单详情' };
+  var pl = userPlaylists.find(function(item){ return playlistPanelKey(item.provider, item.id) === key; }) || { id: pid, provider: provider, name: title || '歌单详情' };
   if (playlistPanelDetailState.key === key && !playlistPanelDetailState.loading && playlistPanelDetailState.tracks.length) {
     playlistPanelDetailState.key = '';
     playlistPanelDetailState.tracks = [];
@@ -19647,9 +19651,10 @@ async function openPlaylistPanelDetail(provider, pid, title) {
   renderPlaylistPanelDetailState();
   scrollPlaylistPanelDetailIntoView(key);
   try {
-    var r = provider === 'qq'
-      ? await apiJson('/api/qq/playlist/tracks?id=' + encodeURIComponent(pid))
-      : await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(pid));
+    var r;
+    if (provider === 'spotify') r = await apiJson('/api/spotify/playlist/tracks?id=' + encodeURIComponent(pid));
+    else if (provider === 'qq') r = await apiJson('/api/qq/playlist/tracks?id=' + encodeURIComponent(pid));
+    else r = await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(pid));
     if (playlistPanelDetailState.token !== token) return;
     playlistPanelDetailState.loading = false;
     playlistPanelDetailState.tracks = (r && r.tracks || []).map(cloneSong);
@@ -19669,7 +19674,7 @@ function playPlaylistPanelDetail() {
   var st = playlistPanelDetailState;
   if (!st || !st.key) return;
   var parts = st.key.split(':');
-  var provider = parts[0] === 'qq' ? 'qq' : 'netease';
+  var provider = parts[0] === 'qq' ? 'qq' : (parts[0] === 'spotify' ? 'spotify' : 'netease');
   var pid = parts.slice(1).join(':');
   loadPlaylistIntoQueueById(playlistPanelProviderId(provider, pid), true, st.playlist && st.playlist.name || '');
 }
@@ -19739,9 +19744,9 @@ function renderUserPlaylistsList(opts) {
     return;
   }
   function playlistCardHtml(pl) {
-    var provider = pl.provider === 'qq' ? 'qq' : 'netease';
-    var providerLabel = provider === 'qq' ? 'QQ' : 'NE';
-    var thumb = pl.cover ? (provider === 'qq' ? pl.cover : (pl.cover + '?param=88y88')) : '';
+    var provider = pl.provider === 'spotify' ? 'spotify' : (pl.provider === 'qq' ? 'qq' : 'netease');
+    var providerLabel = provider === 'spotify' ? 'SP' : (provider === 'qq' ? 'QQ' : 'NE');
+    var thumb = pl.cover ? (provider === 'netease' ? (pl.cover + '?param=88y88') : pl.cover) : '';
     var imgTag = thumb ? '<img src="' + thumb + '" alt="" loading="lazy" decoding="async" onerror="this.style.opacity=0.2">' : '<div style="width:44px;height:44px;border-radius:8px;background:rgba(255,255,255,.06);flex-shrink:0"></div>';
     var key = playlistPanelKey(provider, pl.id);
     var expanded = playlistPanelDetailState.key === key ? ' expanded' : '';
@@ -19751,8 +19756,9 @@ function renderUserPlaylistsList(opts) {
     '</div>' + playlistPanelDetailHtml(pl, provider);
   }
   var groups = [
-    { key:'netease', label:'网易云歌单', items:userPlaylists.filter(function(pl){ return pl.provider !== 'qq'; }) },
-    { key:'qq', label:'QQ 音乐歌单', items:userPlaylists.filter(function(pl){ return pl.provider === 'qq'; }) }
+    { key:'netease', label:'网易云歌单', items:userPlaylists.filter(function(pl){ return pl.provider !== 'qq' && pl.provider !== 'spotify'; }) },
+    { key:'qq', label:'QQ 音乐歌单', items:userPlaylists.filter(function(pl){ return pl.provider === 'qq'; }) },
+    { key:'spotify', label:'Spotify', items:userPlaylists.filter(function(pl){ return pl.provider === 'spotify'; }) }
   ];
   if (opts.reset) resetPlaylistPanelRenderLimit();
   playlistPanelRenderLimit = Math.max(PLAYLIST_PANEL_BATCH_SIZE, Math.min(userPlaylists.length, playlistPanelRenderLimit || PLAYLIST_PANEL_BATCH_SIZE));
@@ -19943,11 +19949,12 @@ async function loadPlaylistIntoQueueById(id, autoplay, title) {
   updateEmptyHomeVisibility();
   showLoading();
   var qqPlaylistId = String(id || '').indexOf('qq:') === 0 ? String(id).slice(3) : '';
+  var spotifyPlaylistId = String(id || '').indexOf('spotify:') === 0 ? String(id).slice(8) : '';
   var r = null;
   try {
-    r = qqPlaylistId
-      ? await apiJson('/api/qq/playlist/tracks?id=' + encodeURIComponent(qqPlaylistId))
-      : await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(id));
+    if (spotifyPlaylistId) r = await apiJson('/api/spotify/playlist/tracks?id=' + encodeURIComponent(spotifyPlaylistId));
+    else if (qqPlaylistId) r = await apiJson('/api/qq/playlist/tracks?id=' + encodeURIComponent(qqPlaylistId));
+    else r = await apiJson('/api/playlist/tracks?id=' + encodeURIComponent(id));
   } catch (e) {
     console.warn('[PlaylistLoadApi]', id, e);
     showToast('歌单加载失败');

--- a/public/index.html
+++ b/public/index.html
@@ -18562,6 +18562,12 @@ async function playQueueAt(idx, opts) {
           hideLoading();
         });
       });
+      markPlayPhase('visual-prep');
+      try {
+        if (typeof prepareEmilyForTrackSwitch === 'function') prepareEmilyForTrackSwitch(song);
+      } catch(e){}
+      markPlayPhase('lyrics-load');
+      loadSongLyrics(song, token, false);
       return;
     }
 

--- a/public/index.html
+++ b/public/index.html
@@ -2493,6 +2493,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
     <div class="btn-row">
       <button class="modal-btn" onclick="closeLoginModal()">取消</button>
       <button class="modal-btn" onclick="skipLoginAndFocusSearch()">先搜索一首歌</button>
+      <button class="modal-btn" style="border-color: #1DB954; color: #1DB954;" onclick="openSpotifyLogin()">登录 Spotify</button>
       <button id="login-both-btn" class="modal-btn" onclick="requestDualLoginMode()">我两个都要</button>
       <button id="qq-cookie-toggle-btn" class="modal-btn" type="button" onclick="toggleQQCookiePanel()">手动导入</button>
       <button id="refresh-qr-btn" class="modal-btn primary" onclick="refreshQr()">刷新二维码</button>

--- a/public/index.html
+++ b/public/index.html
@@ -23325,11 +23325,14 @@ function onUserBtnClick() {
   if (hasAnyPlatformLogin()) showUserModal();
   else showLoginModal();
 }
+var spotifyLoginStatus = { provider: 'spotify', loggedIn: false };
 function platformMeta(provider) {
+  if (provider === 'spotify') return { key: 'spotify', short: 'SP', label: 'Spotify', app: 'Spotify', dot: 'spotify' };
   if (provider === 'qq') return { key: 'qq', short: 'QQ', label: 'QQ 音乐', app: 'QQ 音乐 App', dot: 'qq' };
   return { key: 'netease', short: 'NE', label: '网易云音乐', app: '网易云音乐 App', dot: 'netease' };
 }
 function platformStatus(provider) {
+  if (provider === 'spotify') return spotifyLoginStatus;
   return provider === 'qq' ? qqLoginStatus : loginStatus;
 }
 function providerVipType(provider, status) {
@@ -23367,10 +23370,11 @@ function hasPlatformLogin(provider) {
   return !!(st && st.loggedIn);
 }
 function hasAnyPlatformLogin() {
-  return hasPlatformLogin('netease') || hasPlatformLogin('qq');
+  return hasPlatformLogin('netease') || hasPlatformLogin('qq') || hasPlatformLogin('spotify');
 }
 function firstLoggedProvider() {
   if (hasPlatformLogin(activeAccountProvider)) return activeAccountProvider;
+  if (hasPlatformLogin('spotify')) return 'spotify';
   if (hasPlatformLogin('netease')) return 'netease';
   if (hasPlatformLogin('qq')) return 'qq';
   return 'netease';
@@ -23882,9 +23886,22 @@ window.onSpotifyWebPlaybackSDKReady = function() {
         getOAuthToken: function(cb) { cb(res.token); },
         volume: 0.8
       });
+      spotifyLoginStatus.loggedIn = true;
       spotifyPlayer.addListener('ready', function(obj) {
         spotifyDeviceId = obj.device_id;
         console.log('Spotify Ready with Device ID', obj.device_id);
+      });
+      spotifyPlayer.addListener('not_ready', function(obj) {
+        console.log('Device ID has gone offline', obj.device_id);
+      });
+      spotifyPlayer.addListener('initialization_error', function(err) {
+        showToast('Spotify 初始化失败: ' + err.message);
+      });
+      spotifyPlayer.addListener('authentication_error', function(err) {
+        showToast('Spotify 认证失败: ' + err.message);
+      });
+      spotifyPlayer.addListener('account_error', function(err) {
+        showToast('Spotify 账号错误 (需要 Premium): ' + err.message);
       });
       spotifyPlayer.addListener('player_state_changed', function(state) {
         if (!state) return;

--- a/public/index.html
+++ b/public/index.html
@@ -23938,6 +23938,20 @@ function openProviderLogin(provider) {
   showLoginModal({ provider: provider });
 }
 async function logoutActiveAccount() {
+  if (activeAccountProvider === 'spotify') {
+    try { await apiJson('/api/spotify/logout'); } catch (e) {}
+    if (typeof spotifyPlayer !== 'undefined' && spotifyPlayer) {
+      try { spotifyPlayer.disconnect(); } catch(e){}
+    }
+    spotifyLoginStatus = { provider: 'spotify', loggedIn: false };
+    if (!hasPlatformLogin('netease') && !hasPlatformLogin('qq')) dualAccountMode = false;
+    activeAccountProvider = firstLoggedProvider();
+    refreshUserPlaylists(true);
+    closeUserModal();
+    renderUserBtn();
+    showToast('已注销 Spotify');
+    return;
+  }
   if (activeAccountProvider === 'qq') {
     try { await apiJson('/api/qq/logout'); } catch (e) {}
     try {

--- a/public/index.html
+++ b/public/index.html
@@ -1841,6 +1841,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
   .lyric-color-grid{grid-template-columns:repeat(3,minmax(0,1fr))}
 }
 </style>
+<script src="https://sdk.scdn.co/spotify-player.js"></script>
 </head>
 <body>
 <div id="desktop-window-shell">
@@ -1910,6 +1911,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
       <button id="search-mode-song" class="active" type="button" onclick="setSearchMode('song')" aria-selected="true">All</button>
       <button id="search-mode-netease" type="button" onclick="setSearchMode('netease')" aria-selected="false">NE</button>
       <button id="search-mode-qq" type="button" onclick="setSearchMode('qq')" aria-selected="false">QQ</button>
+      <button id="search-mode-spotify" type="button" onclick="setSearchMode('spotify')" aria-selected="false">Spotify</button>
       <button id="search-mode-podcast" type="button" onclick="setSearchMode('podcast')" aria-selected="false">Podcast</button>
     </div>
     <div id="search-results"></div>
@@ -16976,6 +16978,54 @@ function syncLikeStatusForSongs(songs) {
     updateLikeButtons();
   }).catch(function(err){ console.warn('like check failed:', err); });
 }
+
+function updateSearchModeTabs() {
+  var songBtn = document.getElementById('search-mode-song');
+  var neteaseBtn = document.getElementById('search-mode-netease');
+  var qqBtn = document.getElementById('search-mode-qq');
+  var spotifyBtn = document.getElementById('search-mode-spotify');
+  var podcastBtn = document.getElementById('search-mode-podcast');
+  if (songBtn) {
+    songBtn.classList.toggle('active', searchMode === 'song');
+    songBtn.setAttribute('aria-selected', searchMode === 'song' ? 'true' : 'false');
+  }
+  if (neteaseBtn) {
+    neteaseBtn.classList.toggle('active', searchMode === 'netease');
+    neteaseBtn.setAttribute('aria-selected', searchMode === 'netease' ? 'true' : 'false');
+  }
+  if (qqBtn) {
+    qqBtn.classList.toggle('active', searchMode === 'qq');
+    qqBtn.setAttribute('aria-selected', searchMode === 'qq' ? 'true' : 'false');
+  }
+  if (spotifyBtn) {
+    spotifyBtn.classList.toggle('active', searchMode === 'spotify');
+    spotifyBtn.setAttribute('aria-selected', searchMode === 'spotify' ? 'true' : 'false');
+  }
+  if (podcastBtn) {
+    podcastBtn.classList.toggle('active', searchMode === 'podcast');
+    podcastBtn.setAttribute('aria-selected', searchMode === 'podcast' ? 'true' : 'false');
+  }
+  if ($input) {
+    $input.placeholder = searchMode === 'podcast'
+      ? '搜索播客电台...'
+      : (searchMode === 'qq' ? '搜索 QQ 音乐...' : (searchMode === 'spotify' ? '搜索 Spotify...' : (searchMode === 'netease' ? '搜索网易云...' : '搜索歌曲或歌手...')));
+  }
+  requestAnimationFrame(updateSearchPillGlassDisplacementMap);
+}
+function setSearchMode(mode) {
+  mode = (mode === 'podcast' || mode === 'netease' || mode === 'qq' || mode === 'spotify') ? mode : 'song';
+  if (searchMode === mode) return;
+  searchMode = mode;
+  updateSearchModeTabs();
+  clearSearchResults();
+  var searchArea = document.getElementById('search-area');
+  if (searchArea) setPeek(searchArea, true, 'search');
+  var q = $input ? $input.value.trim() : '';
+  if (searchMode === 'podcast') {
+    if (q) doSearch(q);
+    else loadPodcastHot();
+  } else if (q) { doSearch(q); }
+}
 function syncLikeStatusForSong(song) {
   if (!isCloudSong(song)) { updateLikeButtons(song); return; }
   syncLikeStatusForSongs([song]);
@@ -17646,6 +17696,10 @@ function mergeSongSearchResults(neteaseSongs, qqSongs, limit, q) {
   return out.slice(0, limit);
 }
 async function fetchMusicSearchResults(q, mode) {
+  if (mode === 'spotify') {
+    var spOnly = await apiJson('/api/spotify/search?keywords=' + encodeURIComponent(q) + '&limit=12');
+    return mergeSongSearchResults([], spOnly.songs || [], 18, q);
+  }
   if (mode === 'qq') {
     var qqOnly = await apiJson('/api/qq/search?keywords=' + encodeURIComponent(q) + '&limit=12');
     return mergeSongSearchResults([], qqOnly.songs || [], 18, q);
@@ -18461,6 +18515,30 @@ async function playQueueAt(idx, opts) {
 
   try {
     markPlayPhase('source-url');
+    var isSpotifyPlayback = song.source === 'spotify' || song.type === 'spotify';
+    if (isSpotifyPlayback) {
+      if (!spotifyPlayer || !spotifyDeviceId) {
+        showToast('请先登录 Spotify 并等待加载完成');
+        return;
+      }
+      apiJson('/api/spotify/status').then(function(r) {
+        if (!r || !r.token) return;
+        fetch('https://api.spotify.com/v1/me/player/play?device_id=' + spotifyDeviceId, {
+          method: 'PUT',
+          body: JSON.stringify({ uris: ['spotify:track:' + song.id] }),
+          headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + r.token }
+        }).then(function(){
+          if (audio) { audio.pause(); audio.src = ''; }
+          playing = true;
+          setPlayIcon(true);
+          if (typeof forceLoadingSettled === 'function') forceLoadingSettled('spotify');
+          if (typeof tweenParticleAlpha === 'function') tweenParticleAlpha(uniforms.uAlpha.value || 0, 0.05, 300);
+          hideLoading();
+        });
+      });
+      return;
+    }
+
     var isQQPlayback = songProviderKey(song) === 'qq';
     var requestedQuality = normalizePlaybackQuality(opts.qualityOverride || playbackQuality);
     if (!isQQPlayback && requestedQuality === 'jymaster' && !hasProviderSvip('netease', loginStatus)) requestedQuality = 'hires';
@@ -18631,6 +18709,12 @@ async function playQueueAt(idx, opts) {
 async function attemptAudioPlay(opts) {
   opts = opts || {};
   try {
+      var isSpotify = playQueue[currentIdx] && (playQueue[currentIdx].source === 'spotify' || playQueue[currentIdx].type === 'spotify');
+      if (isSpotify && spotifyPlayer) {
+        spotifyPlayer.resume();
+        playing = true; setPlayIcon(true); hideLoading();
+        return true;
+      }
       if (!audio) return false;
       if (!audioReady) initAudio();
       if (opts.fade !== false) preparePlaybackFadeIn();
@@ -18669,6 +18753,14 @@ async function togglePlay() {
   playToggleBusy = true;
   try {
     forcePlaybackControlsInteractive();
+    var isSpotify = playQueue[currentIdx] && (playQueue[currentIdx].source === 'spotify' || playQueue[currentIdx].type === 'spotify');
+    if (isSpotify && spotifyPlayer) {
+      spotifyPlayer.togglePlay().then(() => {
+        playing = !isSpotifyPlaying; // Will be synced by state change event, this is optimistic
+        setPlayIcon(playing);
+      });
+      return;
+    }
     if ((!audio || !audio.src) && playQueue.length && currentIdx >= 0) {
       await playQueueAt(currentIdx, { manual: true });
       return;
@@ -23777,6 +23869,34 @@ function enableDualAccountView() {
 function requestDualLoginMode() {
   enableDualAccountView();
 }
+var spotifyPlayer = null;
+var spotifyDeviceId = null;
+var isSpotifyPlaying = false;
+window.onSpotifyWebPlaybackSDKReady = function() {
+  apiJson('/api/spotify/status').then(function(res) {
+    if(res && res.loggedIn && res.token) {
+      spotifyPlayer = new Spotify.Player({
+        name: 'Mineradio',
+        getOAuthToken: function(cb) { cb(res.token); },
+        volume: 0.8
+      });
+      spotifyPlayer.addListener('ready', function(obj) {
+        spotifyDeviceId = obj.device_id;
+        console.log('Spotify Ready with Device ID', obj.device_id);
+      });
+      spotifyPlayer.addListener('player_state_changed', function(state) {
+        if (!state) return;
+        isSpotifyPlaying = !state.paused;
+      });
+      spotifyPlayer.connect();
+    }
+  });
+};
+
+function openSpotifyLogin() {
+  window.open('/api/spotify/login', '_blank', 'width=500,height=600');
+}
+
 function openProviderLogin(provider) {
   provider = provider === 'qq' ? 'qq' : 'netease';
   closeUserModal();

--- a/public/index.html
+++ b/public/index.html
@@ -17558,12 +17558,13 @@ document.addEventListener('click', function(e){
 updateSearchModeTabs();
 
 function songProviderKey(song) {
+  if (song && (song.provider === 'spotify' || song.source === 'spotify' || song.type === 'spotify')) return 'spotify';
   if (song && (song.provider === 'qq' || song.source === 'qq' || song.type === 'qq')) return 'qq';
   return 'netease';
 }
 function songSourceTagHtml(song) {
   var key = songProviderKey(song);
-  var label = key === 'qq' ? 'QQ' : 'NE';
+  var label = key === 'spotify' ? 'SP' : (key === 'qq' ? 'QQ' : 'NE');
   return '<span class="tag-source ' + key + '">' + label + '</span>';
 }
 function searchResultMetaText(song) {
@@ -18189,10 +18190,16 @@ function playSearchResult(i) {
 var firstPlayDone = false;
 
 function playbackProviderLabel(song) {
-  return songProviderKey(song) === 'qq' ? 'QQ 音乐' : '网易云';
+  var key = songProviderKey(song);
+  if (key === 'spotify') return 'Spotify';
+  if (key === 'qq') return 'QQ 音乐';
+  return '网易云';
 }
 function playbackLoginProvider(song) {
-  return songProviderKey(song) === 'qq' ? 'qq' : 'netease';
+  var key = songProviderKey(song);
+  if (key === 'spotify') return 'spotify';
+  if (key === 'qq') return 'qq';
+  return 'netease';
 }
 function playbackRestrictionMessage(song, data) {
   data = data || {};

--- a/public/index.html
+++ b/public/index.html
@@ -2516,6 +2516,7 @@ html.control-glass-svg-ok #visual-guide-btn:hover{
     <div class="account-modal-actions">
       <button id="account-add-netease" class="modal-btn" onclick="openProviderLogin('netease')">补登网易云</button>
       <button id="account-add-qq" class="modal-btn" onclick="openProviderLogin('qq')">补登 QQ 音乐</button>
+      <button id="account-add-spotify" class="modal-btn" style="border-color: #1DB954; color: #1DB954;" onclick="openSpotifyLogin()">登录 Spotify</button>
     </div>
     <div id="account-hint" class="account-hint">QQ 音乐真实登录暂未接入，当前先预览双平台账号交互。</div>
     <div class="btn-row">

--- a/server.js
+++ b/server.js
@@ -3447,7 +3447,7 @@ const server = http.createServer(async (req, res) => {
       if (!pid) { sendJSON(res, { tracks: [] }); return; }
       const tokenInfo = await getValidSpotifyToken();
       if (!tokenInfo || !tokenInfo.access_token) throw new Error('Not logged into Spotify');
-      const resp = await fetch(`https://api.spotify.com/v1/playlists/${encodeURIComponent(pid)}/tracks?limit=100`, {
+      const resp = await fetch(`https://api.spotify.com/v1/playlists/${encodeURIComponent(pid)}/items?limit=100`, {
         headers: { 'Authorization': 'Bearer ' + tokenInfo.access_token }
       });
       if (!resp.ok) throw new Error('Spotify API Error ' + resp.status);

--- a/server.js
+++ b/server.js
@@ -3393,6 +3393,12 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  if (pn === '/api/spotify/logout') {
+    try { fs.unlinkSync(SPOTIFY_TOKEN_FILE); } catch(e){}
+    sendJSON(res, { ok: true });
+    return;
+  }
+
   if (pn === '/api/spotify/search') {
     try {
       const kw = url.searchParams.get('keywords') || '';
@@ -3413,7 +3419,10 @@ const server = http.createServer(async (req, res) => {
       const resp = await fetch('https://api.spotify.com/v1/me/playlists?limit=50', {
         headers: { 'Authorization': 'Bearer ' + tokenInfo.access_token }
       });
-      if (!resp.ok) throw new Error('Spotify API Error ' + resp.status);
+      if (!resp.ok) {
+        if (resp.status === 403) { try { fs.unlinkSync(SPOTIFY_TOKEN_FILE); } catch(e){} }
+        throw new Error('Spotify API Error ' + resp.status);
+      }
       const data = await resp.json();
       const playlists = (data.items || []).map(pl => ({
         id: pl.id,

--- a/server.js
+++ b/server.js
@@ -63,7 +63,7 @@ try {
       if (match) {
         const key = match[1];
         let val = match[2] || '';
-        val = val.replace(/^['"]|['"]$/g, '').trim();
+        val = val.trim().replace(/^['"]|['"]$/g, '');
         process.env[key] = val;
       }
     });

--- a/server.js
+++ b/server.js
@@ -3349,7 +3349,7 @@ const server = http.createServer(async (req, res) => {
 
   if (pn === '/api/spotify/login') {
     const scope = 'streaming user-read-email user-read-private user-library-read user-library-modify user-read-playback-state user-modify-playback-state';
-    const redirect_uri = `http://localhost:${PORT}/api/spotify/callback`;
+    const redirect_uri = `http://127.0.0.1:${PORT}/api/spotify/callback`;
     const urlStr = 'https://accounts.spotify.com/authorize?' + new URLSearchParams({
       response_type: 'code',
       client_id: SPOTIFY_CLIENT_ID,
@@ -3365,7 +3365,7 @@ const server = http.createServer(async (req, res) => {
     const code = url.searchParams.get('code') || '';
     if (!code) { res.end('Missing code'); return; }
     try {
-      const redirect_uri = `http://localhost:${PORT}/api/spotify/callback`;
+      const redirect_uri = `http://127.0.0.1:${PORT}/api/spotify/callback`;
       const params = new URLSearchParams({ code: code, redirect_uri: redirect_uri, grant_type: 'authorization_code' });
       const authHeader = 'Basic ' + Buffer.from(`${SPOTIFY_CLIENT_ID}:${SPOTIFY_CLIENT_SECRET}`).toString('base64');
       const resp = await fetch('https://accounts.spotify.com/api/token', {

--- a/server.js
+++ b/server.js
@@ -3447,15 +3447,21 @@ const server = http.createServer(async (req, res) => {
       if (!pid) { sendJSON(res, { tracks: [] }); return; }
       const tokenInfo = await getValidSpotifyToken();
       if (!tokenInfo || !tokenInfo.access_token) throw new Error('Not logged into Spotify');
-      const resp = await fetch(`https://api.spotify.com/v1/playlists/${encodeURIComponent(pid)}/items?limit=100&additional_types=track`, {
-        headers: { 'Authorization': 'Bearer ' + tokenInfo.access_token }
-      });
-      if (!resp.ok) {
-        const errText = await resp.text();
-        throw new Error(`Spotify API Error ${resp.status}: ${errText}`);
+      let allItems = [];
+      let nextUrl = `https://api.spotify.com/v1/playlists/${encodeURIComponent(pid)}/items?limit=100&additional_types=track`;
+      while (nextUrl && allItems.length < 3000) {
+        const resp = await fetch(nextUrl, {
+          headers: { 'Authorization': 'Bearer ' + tokenInfo.access_token }
+        });
+        if (!resp.ok) {
+          const errText = await resp.text();
+          throw new Error(`Spotify API Error ${resp.status}: ${errText}`);
+        }
+        const data = await resp.json();
+        if (data.items && data.items.length) allItems = allItems.concat(data.items);
+        nextUrl = data.next || null;
       }
-      const data = await resp.json();
-      const tracks = (data.items || []).filter(entry => entry && (entry.item || entry.track) && (entry.item || entry.track).id).map(entry => {
+      const tracks = allItems.filter(entry => entry && (entry.item || entry.track) && (entry.item || entry.track).id).map(entry => {
         const t = entry.item || entry.track;
         return {
           id: t.id,

--- a/server.js
+++ b/server.js
@@ -3447,13 +3447,16 @@ const server = http.createServer(async (req, res) => {
       if (!pid) { sendJSON(res, { tracks: [] }); return; }
       const tokenInfo = await getValidSpotifyToken();
       if (!tokenInfo || !tokenInfo.access_token) throw new Error('Not logged into Spotify');
-      const resp = await fetch(`https://api.spotify.com/v1/playlists/${encodeURIComponent(pid)}/items?limit=100`, {
+      const resp = await fetch(`https://api.spotify.com/v1/playlists/${encodeURIComponent(pid)}/items?limit=100&additional_types=track`, {
         headers: { 'Authorization': 'Bearer ' + tokenInfo.access_token }
       });
-      if (!resp.ok) throw new Error('Spotify API Error ' + resp.status);
+      if (!resp.ok) {
+        const errText = await resp.text();
+        throw new Error(`Spotify API Error ${resp.status}: ${errText}`);
+      }
       const data = await resp.json();
-      const tracks = (data.items || []).filter(item => item && item.track && item.track.id).map(item => {
-        const t = item.track;
+      const tracks = (data.items || []).filter(entry => entry && (entry.item || entry.track) && (entry.item || entry.track).id).map(entry => {
+        const t = entry.item || entry.track;
         return {
           id: t.id,
           name: t.name,

--- a/server.js
+++ b/server.js
@@ -3348,7 +3348,7 @@ const server = http.createServer(async (req, res) => {
   }
 
   if (pn === '/api/spotify/login') {
-    const scope = 'streaming user-read-email user-read-private user-library-read user-library-modify user-read-playback-state user-modify-playback-state';
+    const scope = 'streaming user-read-email user-read-private user-library-read user-library-modify user-read-playback-state user-modify-playback-state playlist-read-private playlist-read-collaborative';
     const redirect_uri = `http://127.0.0.1:${PORT}/api/spotify/callback`;
     const urlStr = 'https://accounts.spotify.com/authorize?' + new URLSearchParams({
       response_type: 'code',

--- a/server.js
+++ b/server.js
@@ -3294,10 +3294,15 @@ async function getValidSpotifyToken() {
 async function handleSpotifySearch(kw, limit) {
   const tokenInfo = await getValidSpotifyToken();
   if (!tokenInfo || !tokenInfo.access_token) throw new Error('Not logged into Spotify');
+  limit = Math.min(parseInt(limit) || 10, 10);
   const resp = await fetch(`https://api.spotify.com/v1/search?q=${encodeURIComponent(kw)}&type=track&limit=${limit}`, {
     headers: { 'Authorization': 'Bearer ' + tokenInfo.access_token }
   });
-  if (!resp.ok) throw new Error('Spotify API Error ' + resp.status);
+  if (!resp.ok) {
+    const errText = await resp.text();
+    console.error('[SpotifySearch Detail]', errText);
+    throw new Error(`Spotify API Error ${resp.status}: ${errText}`);
+  }
   const data = await resp.json();
   return (data.tracks && data.tracks.items ? data.tracks.items : []).map(t => ({
     id: t.id,

--- a/server.js
+++ b/server.js
@@ -54,11 +54,30 @@ const { once } = require('events');
 const { fileURLToPath } = require('url');
 const { analyzePodcastDjStream, analyzePodcastDjIntro } = require('./dj-analyzer');
 
+// Simple .env parser
+try {
+  const envPath = path.join(__dirname, '.env');
+  if (fs.existsSync(envPath)) {
+    fs.readFileSync(envPath, 'utf8').split('\n').forEach(line => {
+      const match = line.match(/^\s*([\w.-]+)\s*=\s*(.*)?\s*$/);
+      if (match) {
+        const key = match[1];
+        let val = match[2] || '';
+        val = val.replace(/^['"]|['"]$/g, '').trim();
+        process.env[key] = val;
+      }
+    });
+  }
+} catch (e) {}
+
 const PORT = process.env.PORT || 3000;
 const HOST = process.env.HOST || '0.0.0.0';
 const UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36';
 const COOKIE_FILE = process.env.COOKIE_FILE || path.join(__dirname, '.cookie');
 const QQ_COOKIE_FILE = process.env.QQ_COOKIE_FILE || path.join(__dirname, '.qq-cookie');
+const SPOTIFY_CLIENT_ID = process.env.SPOTIFY_CLIENT_ID || '';
+const SPOTIFY_CLIENT_SECRET = process.env.SPOTIFY_CLIENT_SECRET || '';
+const SPOTIFY_TOKEN_FILE = process.env.SPOTIFY_TOKEN_FILE || path.join(__dirname, '.spotify-token');
 const UPDATE_WORK_DIR = process.env.MINERADIO_UPDATE_DIR || path.join(__dirname, 'updates');
 const UPDATE_DOWNLOAD_DIR = process.env.MINERADIO_UPDATE_DOWNLOAD_DIR || path.join(UPDATE_WORK_DIR, 'downloads');
 const UPDATE_PATCH_BACKUP_DIR = process.env.MINERADIO_PATCH_BACKUP_DIR || path.join(UPDATE_WORK_DIR, 'backups', 'patches');
@@ -3238,6 +3257,61 @@ async function getLoginInfo() {
 }
 
 // ====================================================================
+//  Spotify Token & API Helpers
+// ====================================================================
+function readSpotifyToken() {
+  try { return JSON.parse(fs.readFileSync(SPOTIFY_TOKEN_FILE, 'utf8')); }
+  catch (e) { return null; }
+}
+function writeSpotifyToken(data) {
+  try { fs.writeFileSync(SPOTIFY_TOKEN_FILE, JSON.stringify(data)); } catch (e) {}
+}
+async function refreshSpotifyToken(refreshToken) {
+  if (!SPOTIFY_CLIENT_ID || !SPOTIFY_CLIENT_SECRET) throw new Error('Missing Spotify Client credentials');
+  const params = new URLSearchParams({ grant_type: 'refresh_token', refresh_token: refreshToken });
+  const authHeader = 'Basic ' + Buffer.from(`${SPOTIFY_CLIENT_ID}:${SPOTIFY_CLIENT_SECRET}`).toString('base64');
+  const resp = await fetch('https://accounts.spotify.com/api/token', {
+    method: 'POST',
+    headers: { 'Authorization': authHeader, 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: params
+  });
+  if (!resp.ok) throw new Error('Spotify refresh failed');
+  const data = await resp.json();
+  const tokenInfo = readSpotifyToken() || {};
+  const newInfo = { ...tokenInfo, access_token: data.access_token, expires_at: Date.now() + (data.expires_in * 1000) };
+  if (data.refresh_token) newInfo.refresh_token = data.refresh_token;
+  writeSpotifyToken(newInfo);
+  return newInfo;
+}
+async function getValidSpotifyToken() {
+  const info = readSpotifyToken();
+  if (!info || !info.refresh_token) return null;
+  if (Date.now() + 60000 > (info.expires_at || 0)) {
+    try { return await refreshSpotifyToken(info.refresh_token); } catch(e) { return null; }
+  }
+  return info;
+}
+async function handleSpotifySearch(kw, limit) {
+  const tokenInfo = await getValidSpotifyToken();
+  if (!tokenInfo || !tokenInfo.access_token) throw new Error('Not logged into Spotify');
+  const resp = await fetch(`https://api.spotify.com/v1/search?q=${encodeURIComponent(kw)}&type=track&limit=${limit}`, {
+    headers: { 'Authorization': 'Bearer ' + tokenInfo.access_token }
+  });
+  if (!resp.ok) throw new Error('Spotify API Error ' + resp.status);
+  const data = await resp.json();
+  return (data.tracks && data.tracks.items ? data.tracks.items : []).map(t => ({
+    id: t.id,
+    name: t.name,
+    artist: t.artists.map(a => a.name).join(', '),
+    album: t.album.name,
+    cover: t.album.images[0] ? t.album.images[0].url : '',
+    source: 'spotify',
+    type: 'spotify',
+    playable: true
+  }));
+}
+
+// ====================================================================
 //  HTTP Server
 // ====================================================================
 const server = http.createServer(async (req, res) => {
@@ -3269,6 +3343,65 @@ const server = http.createServer(async (req, res) => {
         ...localUpdateFallback(err.message || 'Update check failed', { configured: UPDATE_CONFIG.configured }),
         error: err.message || 'Update check failed',
       });
+    }
+    return;
+  }
+
+  if (pn === '/api/spotify/login') {
+    const scope = 'streaming user-read-email user-read-private user-library-read user-library-modify user-read-playback-state user-modify-playback-state';
+    const redirect_uri = `http://localhost:${PORT}/api/spotify/callback`;
+    const urlStr = 'https://accounts.spotify.com/authorize?' + new URLSearchParams({
+      response_type: 'code',
+      client_id: SPOTIFY_CLIENT_ID,
+      scope: scope,
+      redirect_uri: redirect_uri
+    }).toString();
+    res.writeHead(302, { 'Location': urlStr });
+    res.end();
+    return;
+  }
+
+  if (pn === '/api/spotify/callback') {
+    const code = url.searchParams.get('code') || '';
+    if (!code) { res.end('Missing code'); return; }
+    try {
+      const redirect_uri = `http://localhost:${PORT}/api/spotify/callback`;
+      const params = new URLSearchParams({ code: code, redirect_uri: redirect_uri, grant_type: 'authorization_code' });
+      const authHeader = 'Basic ' + Buffer.from(`${SPOTIFY_CLIENT_ID}:${SPOTIFY_CLIENT_SECRET}`).toString('base64');
+      const resp = await fetch('https://accounts.spotify.com/api/token', {
+        method: 'POST',
+        headers: { 'Authorization': authHeader, 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: params
+      });
+      if (!resp.ok) { res.end('Spotify Auth Error: ' + await resp.text()); return; }
+      const data = await resp.json();
+      writeSpotifyToken({ access_token: data.access_token, refresh_token: data.refresh_token, expires_at: Date.now() + (data.expires_in * 1000) });
+      res.writeHead(200, { 'Content-Type': 'text/html; charset=utf-8' });
+      res.end('<script>window.close();</script>Spotify Logged In! You can close this window and refresh Mineradio.');
+    } catch (e) {
+      res.end('Error: ' + e.message);
+    }
+    return;
+  }
+
+  if (pn === '/api/spotify/status') {
+    try {
+      const token = await getValidSpotifyToken();
+      if (token && token.access_token) sendJSON(res, { loggedIn: true, token: token.access_token });
+      else sendJSON(res, { loggedIn: false });
+    } catch(e) { sendJSON(res, { loggedIn: false }); }
+    return;
+  }
+
+  if (pn === '/api/spotify/search') {
+    try {
+      const kw = url.searchParams.get('keywords') || '';
+      const limit = parseInt(url.searchParams.get('limit') || '20');
+      const songs = await handleSpotifySearch(kw, limit);
+      sendJSON(res, { songs, provider: 'spotify' });
+    } catch (err) {
+      console.error('[SpotifySearch]', err);
+      sendJSON(res, { provider: 'spotify', error: err.message, songs: [] }, 500);
     }
     return;
   }

--- a/server.js
+++ b/server.js
@@ -3406,6 +3406,66 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  if (pn === '/api/spotify/playlists') {
+    try {
+      const tokenInfo = await getValidSpotifyToken();
+      if (!tokenInfo || !tokenInfo.access_token) { sendJSON(res, { playlists: [] }); return; }
+      const resp = await fetch('https://api.spotify.com/v1/me/playlists?limit=50', {
+        headers: { 'Authorization': 'Bearer ' + tokenInfo.access_token }
+      });
+      if (!resp.ok) throw new Error('Spotify API Error ' + resp.status);
+      const data = await resp.json();
+      const playlists = (data.items || []).map(pl => ({
+        id: pl.id,
+        name: pl.name,
+        cover: pl.images && pl.images[0] ? pl.images[0].url : '',
+        trackCount: pl.tracks ? pl.tracks.total : 0,
+        creator: pl.owner ? pl.owner.display_name : '',
+        provider: 'spotify',
+        source: 'spotify'
+      }));
+      sendJSON(res, { playlists, provider: 'spotify' });
+    } catch (err) {
+      console.error('[SpotifyPlaylists]', err);
+      sendJSON(res, { playlists: [], error: err.message }, 500);
+    }
+    return;
+  }
+
+  if (pn === '/api/spotify/playlist/tracks') {
+    try {
+      const pid = url.searchParams.get('id') || '';
+      if (!pid) { sendJSON(res, { tracks: [] }); return; }
+      const tokenInfo = await getValidSpotifyToken();
+      if (!tokenInfo || !tokenInfo.access_token) throw new Error('Not logged into Spotify');
+      const resp = await fetch(`https://api.spotify.com/v1/playlists/${encodeURIComponent(pid)}/tracks?limit=100`, {
+        headers: { 'Authorization': 'Bearer ' + tokenInfo.access_token }
+      });
+      if (!resp.ok) throw new Error('Spotify API Error ' + resp.status);
+      const data = await resp.json();
+      const tracks = (data.items || []).filter(item => item && item.track && item.track.id).map(item => {
+        const t = item.track;
+        return {
+          id: t.id,
+          name: t.name,
+          artist: t.artists ? t.artists.map(a => a.name).join(', ') : '',
+          album: t.album ? t.album.name : '',
+          cover: t.album && t.album.images && t.album.images[0] ? t.album.images[0].url : '',
+          source: 'spotify',
+          type: 'spotify',
+          duration: t.duration_ms ? Math.floor(t.duration_ms / 1000) : 0,
+          durationMs: t.duration_ms || 0,
+          playable: true
+        };
+      });
+      sendJSON(res, { tracks, provider: 'spotify' });
+    } catch (err) {
+      console.error('[SpotifyPlaylistTracks]', err);
+      sendJSON(res, { tracks: [], error: err.message }, 500);
+    }
+    return;
+  }
+
   if (pn === '/api/update/download') {
     try {
       const info = await fetchLatestUpdateInfo();


### PR DESCRIPTION
## 背景
当前播放器仅支持网易云和 QQ 音乐。为了满足海外及拥有 Spotify Premium 账号用户的需求，本次提交引入了官方 Spotify Web Playback SDK。

## 修改内容
- **后端 (`server.js`)**: 
  - 新增 Spotify OAuth2.0 的授权流程 (`/api/spotify/login`, `/api/spotify/callback`, `/api/spotify/status`)。
  - 增加了对读取本地根目录 `.env` 文件的原生支持，方便用户配置 Spotify API 密钥。
  - 新增了 `/api/spotify/search` 搜索接口代理。
- **前端 (`public/index.html`)**: 
  - 引入 `spotify-player.js`，为拥有 Premium 权限的账号提供原生音频串流解析。
  - 在用户中心增加了 "登录 Spotify" 按钮。
  - 搜索栏右侧加入了 "Spotify" 的资源切换 Tab。
  - **优雅降级 (DRM 保护处理)**: 由于 Spotify 的音频流受到 DRM 保护，常规的 `AudioContext` 无法获取其音频频率用于 3D 粒子解析。播放 Spotify 歌曲时，系统会自动暂停原生 `<audio>` 并通过 Tween 渐隐掉 3D 粒子（进入暗色纯净模式），防止因为没有音频数据导致动画卡死或视觉崩坏。
- **安全 & 杂项**: 
  - `.gitignore` 增加了 `.env` 和 `.spotify-token` 以防密钥和会话信息泄露。
  - 更新了 `CHANGELOG.md` 及 `package.json` 的版本号 (v1.2.0)。

## 测试指南
1. 去 Spotify Developer Dashboard 申请应用，获得 `Client ID` 和 `Client Secret`。
2. 将回调地址 (Redirect URIs) 设置为：`http://localhost:3000/api/spotify/callback`。
3. 在项目根目录创建 `.env` 文件并填入：
   ```env
   SPOTIFY_CLIENT_ID="你的_Client_ID"
   SPOTIFY_CLIENT_SECRET="你的_Client_Secret"