### PR TITLE
Linux 适配：GPU 渲染修复、鼠标侧键拦截、deb 打包配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,34 @@ Mineradio 是一款 Windows 桌面沉浸式音乐播放器，把搜索播放、�
 
 安装时只需要下载并运行 `Mineradio-2.0.2-Setup.exe`。不要把 `.blockmap`、`latest.yml` 或 `win-unpacked` 当成正式安装包。
 
+## Linux 适配（Fork 分支 `linux-adapt`）
+
+本 fork 在原版基础上增加了 Linux 平台适配，分支 `linux-adapt` 包含以下改动：
+
+### 改动说明
+
+| 文件 | 改动 |
+| --- | --- |
+| `desktop/main.js` | `use-angle` 从 `d3d11` 改为 `gl`，修复 Linux 下 Three.js 粒子渲染异常 |
+| `public/js/index-loader.js` | 新增鼠标侧键拦截（button 3/4），防止 Electron 页面意外导航 |
+| `package.json` | 新增 `linux` 打包配置，支持 `.deb` 安装包生成；`executableArgs` 自动注入 `--no-sandbox --ozone-platform=x11` |
+
+### Linux 安装
+
+```bash
+npm install
+npm run build:linux
+sudo dpkg -i dist/mineradio_2.0.2_amd64.deb
+```
+
+### 适用平台
+
+- Ubuntu 24.04+ / Debian 12+ / 其他基于 Debian 的发行版
+- Wayland 会话（XWayland 兼容）
+- GNOME / KDE / XFCE 桌面环境
+
+
+
 ## 下载或安装被拦截怎么办
 
 小众 Electron 桌面软件、未签名安装包有时会被浏览器、Windows Defender 或 SmartScreen 提示风险。请先确认安装包来自上面的蓝奏云或 GitHub Release 官方入口，文件名是 `Mineradio-2.0.2-Setup.exe`。
@@ -35,7 +63,7 @@ Mineradio 2.0 重新整理了视觉层次、桌面模式、主页与搜索体验
 
 ## 当前版本
 
-当前版本：`2.0.2`
+当前版本：`2.0.2`（Linux 适配版基于此版本）
 
 状态：Mineradio 2.0.2 正式版。
 
@@ -71,6 +99,7 @@ Windows 用户可以在 GitHub Releases 中下载安装包。
 npm install
 npm start
 npm run build:win
+npm run build:linux    # 构建 .deb 安装包
 ```
 
 桌面版入口由 Electron 主进程加载本地服务。`npm run build:win` 会生成 Windows NSIS 安装包，产物位于 `dist/`。
@@ -102,6 +131,8 @@ Mineradio 由 XxHuberrr 主要设计与打造。emily 作为早期视觉底层�
 ## 版权与授权
 
 Copyright (C) 2026 XxHuberrr.
+
+Linux 适配分支维护：YannZhou · 2026
 
 本项目采用 GPL-3.0 授权。详见 [LICENSE](./LICENSE)。
 

--- a/desktop/main.js
+++ b/desktop/main.js
@@ -480,7 +480,7 @@ const CHROMIUM_SAFE_PERFORMANCE_SWITCHES = [
   ['enable-oop-rasterization'],
   ['enable-zero-copy'],
   ['enable-accelerated-2d-canvas'],
-  ['use-angle', 'd3d11'],
+  ['use-angle', 'gl'],
 ];
 const CHROMIUM_OPT_IN_PERFORMANCE_SWITCHES = [
   ['ignore-gpu-blocklist', null, 'MINERADIO_IGNORE_GPU_BLOCKLIST'],

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "productName": "Mineradio",
   "version": "2.0.2",
   "description": "Windows 沉浸式音乐播放器，融合桌面模式、歌词舞台、粒子视觉和 3D 歌单架。",
-  "author": "Mineradio",
+  "author": "Mineradio <3609286195@qq.com>",
+  "homepage": "https://github.com/XxHuberrr/Mineradio",
   "license": "GPL-3.0-only",
   "main": "desktop/main.js",
   "private": true,
@@ -43,6 +44,18 @@
       "public/index.html"
     ],
     "asar": false,
+    "linux": {
+      "icon": "build/icon.png",
+      "category": "Audio",
+      "maintainer": "yan <3609286195@qq.com>",
+      "executableArgs": ["--no-sandbox", "--ozone-platform=x11"],
+      "target": [
+        {
+          "target": "deb",
+          "arch": ["x64"]
+        }
+      ]
+    },
     "win": {
       "executableName": "Mineradio",
       "icon": "build/icon.ico",

--- a/public/js/index-loader.js
+++ b/public/js/index-loader.js
@@ -1,6 +1,10 @@
 'use strict';
 
 (function loadMineradioIndexModules() {
+  // 禁用鼠标侧键（后退/前进），防止误触导致页面重载
+  window.addEventListener('mouseup', function (e) {
+    if (e.button === 3 || e.button === 4) { e.preventDefault(); }
+  }, true);
   const moduleCacheBust = String(Date.now());
   const modulePaths = [
     'js/modules/00-state/00-core-stores.js',


### PR DESCRIPTION
## 改动说明

对 Mineradio 进行 Linux 平台适配，共修改 3 个文件：

### 1. desktop/main.js - use-angle: d3d11 改为 gl
Linux 不支持 Direct3D，必须用 OpenGL 后端才能正常渲染 Three.js 粒子效果

### 2. public/js/index-loader.js - 鼠标侧键拦截
Chromium 默认侧键触发前进/后退导航，在 Electron 中会导致页面重载

### 3. package.json - Linux .deb 打包配置
- 新增 linux 打包目标，支持生成 .deb 安装包
- executableArgs 自动注入 --no-sandbox --ozone-platform=x11
- 补充 author 邮箱和 homepage

已在 Ubuntu 24.04 + GNOME + Wayland 上测试通过。