### PR TITLE
docs: clarify manual GitHub installer download

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@ Mineradio 是一款 Windows 桌面沉浸式音乐播放器，把搜索播放、�
 
 ## 立即下载 Windows 安装包
 
-> 安装包通过夸克盘、百度云和蓝奏云分发；GitHub Release 用于版本说明与公开源码。
+> 安装包可从夸克盘、百度云、蓝奏云或 GitHub Release 手动下载；软件内更新入口仍只打开网盘线路，不读取 Release 附件。
 
 | 下载入口 | 推荐人群 | 链接 |
 | --- | --- | --- |
 | 夸克盘 | 夸克用户 | [下载 Mineradio 2.0.3](https://pan.quark.cn/s/f40289e1c5d3) |
 | 百度云 | 百度网盘用户（提取码 `sjhp`） | [下载 Mineradio 2.0.3](https://pan.baidu.com/s/14fgTABgbfseOg9QuX0Um7Q?pwd=sjhp) |
 | 蓝奏云 | 直接下载 | [下载 Mineradio 2.0.3](https://xxhuber.lanzout.com/mineradio2) |
-| GitHub Release | 版本说明与源码 | [Mineradio 2.0.3 Release](https://github.com/XxHuberrr/Mineradio/releases/tag/v2.0.3) |
+| GitHub Release | GitHub 用户、版本说明与源码 | [下载 Mineradio 2.0.3](https://github.com/XxHuberrr/Mineradio/releases/tag/v2.0.3) |
 
 安装时只需要下载并运行 `Mineradio-2.0.3-Setup.exe`。不要把 `.blockmap`、`latest.yml` 或 `win-unpacked` 当成正式安装包。
 
 ## 下载或安装被拦截怎么办
 
-小众 Electron 桌面软件、未签名安装包有时会被浏览器、Windows Defender 或 SmartScreen 提示风险。请先确认安装包来自上面的三个网盘官方入口，文件名是 `Mineradio-2.0.3-Setup.exe`。
+小众 Electron 桌面软件、未签名安装包有时会被浏览器、Windows Defender 或 SmartScreen 提示风险。请先确认安装包来自上面的网盘入口或官方 GitHub Release，文件名是 `Mineradio-2.0.3-Setup.exe`。
 
 1. 浏览器下载栏提示风险时，打开下载列表，点这条下载右侧的 `...` 三个点，选择 `保留` / `仍要保留` / `显示更多` 后继续保留。
 2. Windows SmartScreen 弹出蓝色拦截窗口时，点 `更多信息`，再点 `仍要运行`。
@@ -61,7 +61,7 @@ Mineradio 2.0 重新整理了视觉层次、桌面模式、主页与搜索体验
 
 ## 使用说明
 
-Windows 用户可以从本页列出的夸克盘、百度云或蓝奏云下载安装包。
+Windows 用户可以从本页列出的夸克盘、百度云、蓝奏云或 GitHub Release 下载安装包。
 
 正式分发以 `Mineradio-2.0.3-Setup.exe` 为准，不建议直接使用 `win-unpacked` 目录。安装包会创建桌面快捷方式。
 
@@ -79,7 +79,7 @@ npm run build:win
 
 ## 更新机制
 
-Mineradio 会请求 GitHub Releases latest 检测新版本。远端版本高于本地版本时，应用内更新入口会展示 Release 内容，并通过系统浏览器打开可选网盘线路；客户端不会在本地下载、缓存或应用安装包与补丁。
+Mineradio 会请求 GitHub Releases latest 检测新版本。远端版本高于本地版本时，应用内更新入口会展示 Release 内容，并通过系统浏览器打开可选网盘线路；即使 Release 附带完整安装包，`2.0.3+` 客户端也不会读取、下载、缓存或应用该附件与补丁。
 
 本地验证更新链路时，可以通过 `MINERADIO_UPDATE_MANIFEST` 指向一个本地 manifest JSON 或 HTTP 地址来模拟线上 Release。
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,8 @@
 - 安装包：`Mineradio-2.0.3-Setup.exe`
 - 仅从当前可信源码完整构建，不复用旧安装包或旧 `dist/`。
 - 正式 Release 不混入 Mineradio_Beat 产物。
-- GitHub Release 保持零二进制资产；安装包由网盘分发。
+- GitHub Release 仅附带完整安装包 `Mineradio-2.0.3-Setup.exe`，供用户手动下载；不上传 `latest.yml`、blockmap 或补丁。
+- `2.0.3+` 客户端不得从 Release assets 识别或下载安装包，软件内更新仍只读取正文中的网盘线路。
 - Release 正文使用 `<!-- mineradio-download-page: 线路名称|https://... -->` 写入 HTTPS 网盘地址，可配置多条线路。
 
 ## 网盘分发
@@ -29,7 +30,7 @@
 - `dist/latest.yml`
 - `dist/Mineradio-2.0.3-SHA256SUMS.txt`
 
-以上产物只用于本地验收和网盘上传，不作为 GitHub Release 资产发布。
+GitHub Release 只上传 `dist/Mineradio-2.0.3-Setup.exe`；其余产物只用于本地验收和校验，不作为 Release 资产发布。
 
 ## 发布前检查
 


### PR DESCRIPTION
## 变更

- 说明 GitHub Release 提供完整安装包供手动下载。
- 明确 2.0.3+ 软件内更新只读取网盘线路，不识别 Release 附件。
- 保持 `latest.yml`、blockmap 和补丁不进入 Release。

## 验证

- Release 仅有一份完整 EXE。
- `/api/update/latest` 在附件存在时仍返回 `asset: null` 和三条网盘线路。