### PR TITLE
我看项目没有push后的自动测试，所以我写了一些github actions来帮助项目更方便快捷的管理

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  # Node.js 纯 JS 回归测试（不依赖 Electron 运行时和本地二进制文件）
+  test-node:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.x]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Node-level regression tests
+        run: |
+          set -e
+          FAILURES=0
+          SKIP_TESTS="qishui-passport-qr-login.test.js"
+          for f in tests/*.test.js; do
+            base="$(basename "$f")"
+            for skip in $SKIP_TESTS; do
+              if [ "$base" = "$skip" ]; then
+                echo "=== $base (skipped: requires Electron runtime) ==="
+                continue 2
+              fi
+            done
+            echo "=== $base ==="
+            node "$f" || FAILURES=$((FAILURES + 1))
+          done
+          if [ "$FAILURES" -gt 0 ]; then
+            echo "::error::$FAILURES test file(s) failed"
+            exit 1
+          fi
+
+      - name: Quick check (static analysis)
+        run: node scripts/quick-check.js


### PR DESCRIPTION
## Summary

Mineradio 此前没有任何 CI 检查。本次为仓库接入 GitHub Actions，在每次 push 到 main 和 PR 时自动运行全部 29 个 Node.js 级 `*.test.js` 回归测试和 `quick-check.js` 静态分析。

## Changes

- 新增 `.github/workflows/ci.yml`
  - `ubuntu-latest` / Node 22
  - `npm ci` 安装依赖
  - 按文件名排除 `qishui-passport-qr-login.test.js`（需要 Electron 运行时）
  - 其余 29 个 `*.test.js` 逐一运行，any failure = CI 红灯
  - 追加 `node scripts/quick-check.js` 静态分析

## Design decisions

- 使用 `ubuntu-latest` 而非 `windows-latest`，因为 Electron 不在 CI 安装，测试文件均为纯 Node.js
- 跳过 `qishui-passport-qr-login.test.js` 而非 mock electron，保持测试代码零侵入
- 单 job 简单结构，避免不必要的工作流复杂度

## Test plan

- [x] 本地模拟 CI 循环：`for f in tests/*.test.js; do node "$f" || exit 1; done` — 29/30 通过，1 跳过
- [x] `node scripts/quick-check.js` 本地通过
- [ ] CI 在 GitHub Actions 首次 push 后观察运行结果

## CI mapping

| Workflow/job | Trigger | Status |
|---|---|---|
| CI / test-node | push/PR to main | FORK_CI_PENDING |